### PR TITLE
feat(attic): consume nix-attic-infra post-build hook

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,31 @@
 {
   "nodes": {
+    "attic": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat_3",
+        "flake-parts": "flake-parts_3",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nix-attic-infra",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1758711588,
+        "narHash": "sha256-0nZlCCDC5PfndsQJXXtcyrtrfW49I3KadGMDlutzaGU=",
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "rev": "12cbeca141f46e1ade76728bce8adc447f2166c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "repo": "attic",
+        "type": "github"
+      }
+    },
     "brew-src": {
       "flake": false,
       "locked": {
@@ -39,6 +65,21 @@
       }
     },
     "crane": {
+      "locked": {
+        "lastModified": 1751562746,
+        "narHash": "sha256-smpugNIkmDeicNz301Ll1bD7nFOty97T79m4GUMUczA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "aed2020fd3dc26e1e857d4107a5a67a33ab6c1fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
       "locked": {
         "lastModified": 1767744144,
         "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
@@ -146,6 +187,22 @@
       }
     },
     "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
       "locked": {
         "lastModified": 1733328505,
         "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
@@ -199,6 +256,28 @@
       }
     },
     "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-attic-infra",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
@@ -440,6 +519,31 @@
         "url": "https://flakehub.com/f/DeterminateSystems/nix-src/%2A"
       }
     },
+    "nix-attic-infra": {
+      "inputs": {
+        "attic": "attic",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768442620,
+        "narHash": "sha256-Ylg5VcrdlD9IGWZRPNbA5VFMa3G9nmUttPEXd9/OE2A=",
+        "owner": "deepwatrcreatur",
+        "repo": "nix-attic-infra",
+        "rev": "b1ee59e2030a2cbb4cd6a8bb0e728dd962519aff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "deepwatrcreatur",
+        "ref": "feat/attic-infra-layer",
+        "repo": "nix-attic-infra",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -458,6 +562,28 @@
         "owner": "LnL7",
         "ref": "nix-darwin-25.11",
         "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-attic-infra",
+          "attic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
         "type": "github"
       }
     },
@@ -524,8 +650,8 @@
     },
     "nix-snapd": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-parts": "flake-parts_3",
+        "flake-compat": "flake-compat_4",
+        "flake-parts": "flake-parts_4",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -642,6 +768,22 @@
       }
     },
     "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1751741127,
+        "narHash": "sha256-t75Shs76NgxjZSgvvZZ9qOmz5zuBE8buUaYD28BMTxg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "29e290002bfff26af1db6f64d070698019460302",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
       "locked": {
         "lastModified": 1768323494,
         "narHash": "sha256-yBXJLE6WCtrGo7LKiB6NOt6nisBEEkguC/lq/rP3zRQ=",
@@ -767,6 +909,7 @@
         "fnox": "fnox",
         "home-manager": "home-manager",
         "mac-app-util": "mac-app-util",
+        "nix-attic-infra": "nix-attic-infra",
         "nix-darwin": "nix-darwin",
         "nix-gnome-cosmic-ui": "nix-gnome-cosmic-ui",
         "nix-homebrew": "nix-homebrew",
@@ -774,7 +917,7 @@
         "nix-snapd": "nix-snapd",
         "nix-whitesur-config": "nix-whitesur-config",
         "nixpkgs": "nixpkgs_5",
-        "nixpkgs-stable": "nixpkgs-stable",
+        "nixpkgs-stable": "nixpkgs-stable_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
         "sops-nix": "sops-nix",
@@ -1040,7 +1183,7 @@
     },
     "worktrunk": {
       "inputs": {
-        "crane": "crane",
+        "crane": "crane_2",
         "flake-utils": [
           "flake-utils"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,12 @@
       inputs.flake-utils.follows = "flake-utils";
     };
 
+    nix-attic-infra = {
+      url = "github:deepwatrcreatur/nix-attic-infra/feat/attic-infra-layer";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+
   };
 
   outputs =

--- a/hosts/nixos/inference-vm/hosts/inference1/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference1/default.nix
@@ -17,6 +17,16 @@
 
   networking.hostName = "inference1";
 
+  myModules.attic-client = {
+    enable = true;
+
+    # SOPS-encrypted token providing `ATTIC_CLIENT_JWT_TOKEN`
+    tokenFile = ../../../secrets/attic-client-token.yaml.enc;
+
+    server = "http://cache-build-server:5001";
+    cache = "cache-local";
+  };
+
   services.attic-post-build-hook = {
     enable = true;
 
@@ -24,7 +34,6 @@
     serverEndpoint = "http://cache-build-server:5001";
     cacheName = "cache-local";
 
-    # Provided by `myModules.attic-client` when enabled
     tokenFile = "/run/secrets/attic-client-token";
 
     user = "deepwatrcreatur";

--- a/hosts/nixos/inference-vm/hosts/inference1/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference1/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  inputs,
   lib,
   pkgs,
   ...
@@ -9,7 +10,7 @@
   imports = [
     ./hardware-configuration.nix
     ../..
-    ../../../../../modules/nixos/attic-post-build-hook.nix
+    inputs.nix-attic-infra.nixosModules.attic-post-build-hook
   ];
 
   boot.growPartition = true;
@@ -18,7 +19,14 @@
 
   services.attic-post-build-hook = {
     enable = true;
-    cacheName = "cache-build-server";
+
+    serverName = "cache-build-server";
+    serverEndpoint = "http://cache-build-server:5001";
+    cacheName = "cache-local";
+
+    # Provided by `myModules.attic-client` when enabled
+    tokenFile = "/run/secrets/attic-client-token";
+
     user = "deepwatrcreatur";
   };
 


### PR DESCRIPTION
## Summary
- Add `nix-attic-infra` as a flake input.
- Switch `inference1` to import the post-build hook from `inputs.nix-attic-infra`.
- Configure hook with explicit server/cache endpoints and token file.

## Why
Keeps Attic server config canonical upstream while centralizing client/hook ergonomics in `nix-attic-infra`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cache build server configuration with new server endpoint and token-based authentication.
  * Added infrastructure module dependency to improve configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->