### PR TITLE
feat: add static and dynamic MOTD

### DIFF
--- a/modules/home-manager/common/motd.nix
+++ b/modules/home-manager/common/motd.nix
@@ -1,0 +1,137 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.custom.motd;
+
+  motdScript = pkgs.writeShellScriptBin "motd" ''
+    set -u
+
+    hr() {
+      width="''${MOTD_WIDTH:-72}"
+      printf '%*s\n' "$width" "" | tr ' ' '-'
+    }
+
+    host="$(hostname 2>/dev/null || echo unknown)"
+    now="$(date -Is 2>/dev/null || true)"
+
+    # Default to the standard location our shortcuts expect.
+    repo="''${MOTD_FLAKE_REPO:-$HOME/flakes/unified-nix-configuration}"
+
+    echo
+    hr
+    echo "Host: $host"
+    [ -n "$now" ] && echo "Time: $now"
+    echo "Repo: $repo"
+    echo
+
+    echo "Common commands:"
+    echo "  - NixOS:   nh os switch -H $host -f $repo"
+    echo "  - Proxmox: cd $repo && home-manager switch --flake .#proxmox-root"
+    echo
+
+    if command -v git >/dev/null 2>&1 && [ -d "$repo/.git" ]; then
+      rev="$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || true)"
+      branch="$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+      if [ -n "$rev" ]; then
+        echo "Config: $branch@$rev"
+        echo
+      fi
+    fi
+
+    if command -v nix >/dev/null 2>&1; then
+      nixver="$(nix --version 2>/dev/null || true)"
+      [ -n "$nixver" ] && echo "Nix: $nixver"
+    fi
+
+    if command -v determinate-nixd >/dev/null 2>&1; then
+      det="$(determinate-nixd status 2>/dev/null | head -n 3 | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g' || true)"
+      [ -n "$det" ] && echo "Determinate: $det"
+    fi
+
+    if command -v uptime >/dev/null 2>&1; then
+      up="$(uptime 2>/dev/null || true)"
+      [ -n "$up" ] && echo "Uptime: $up"
+    fi
+
+    if command -v df >/dev/null 2>&1; then
+      rootdf="$(df -h / 2>/dev/null | awk 'NR==2 {print $4" free of "$2" ("$5" used)"}' || true)"
+      [ -n "$rootdf" ] && echo "Disk(/): $rootdf"
+    fi
+
+    if command -v free >/dev/null 2>&1; then
+      mem="$(free -h 2>/dev/null | awk '/Mem:/ {print $7" free of "$2""}' || true)"
+      [ -n "$mem" ] && echo "Mem: $mem"
+    fi
+
+    if command -v hostname >/dev/null 2>&1; then
+      ips="$(hostname -I 2>/dev/null | tr -s ' ' | sed 's/[[:space:]]*$//' || true)"
+      [ -n "$ips" ] && echo "IPs: $ips"
+    fi
+
+    hr
+  '';
+
+  bashHook = ''
+    # MOTD (once per SSH session)
+    if [ -z "''${__MOTD_SHOWN-}" ] && [ -n "''${SSH_CONNECTION-}" ]; then
+      export __MOTD_SHOWN=1
+      if command -v motd >/dev/null 2>&1; then motd || true; fi
+    fi
+  '';
+
+  zshHook = ''
+    # MOTD (once per SSH session)
+    if [[ -z "''${__MOTD_SHOWN-}" && -n "''${SSH_CONNECTION-}" ]]; then
+      export __MOTD_SHOWN=1
+      if command -v motd >/dev/null 2>&1; then motd || true; fi
+    fi
+  '';
+
+  fishHook = ''
+    # MOTD (once per SSH session)
+    if status is-interactive
+      if set -q SSH_CONNECTION
+        if not set -q __MOTD_SHOWN
+          set -gx __MOTD_SHOWN 1
+          if type -q motd
+            motd
+          end
+        end
+      end
+    end
+  '';
+
+in
+{
+  options.custom.motd = {
+    enable = lib.mkEnableOption "login motd banner";
+  };
+
+  config = lib.mkIf cfg.enable {
+    custom.motd.enable = lib.mkDefault true;
+
+    home.packages = [ motdScript ];
+
+    # Dynamic banner on SSH logins
+    programs.bash.initExtra = lib.mkAfter bashHook;
+    programs.zsh.initContent = lib.mkAfter zshHook;
+    programs.fish.interactiveShellInit = lib.mkAfter fishHook;
+
+    # Static /etc/motd for non-NixOS (e.g. Proxmox) when using root HM
+    home.activation.writeEtcMotd = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ "$(id -u)" -eq 0 ] && [ ! -e /etc/NIXOS ]; then
+        install -m 644 /dev/null /etc/motd
+        {
+          echo "Host: $(hostname 2>/dev/null || echo unknown)"
+          echo "Repo: $HOME/flakes/unified-nix-configuration"
+          echo "Hint: use 'motd' for live status"
+        } > /etc/motd
+      fi
+    '';
+  };
+}

--- a/modules/home-manager/common/motd.nix
+++ b/modules/home-manager/common/motd.nix
@@ -109,11 +109,12 @@ let
 in
 {
   options.custom.motd = {
-    enable = lib.mkEnableOption "login motd banner";
+    enable = lib.mkEnableOption "login motd banner" // {
+      default = true;
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    custom.motd.enable = lib.mkDefault true;
 
     home.packages = [ motdScript ];
 

--- a/modules/home-manager/common/tool-aliases.nix
+++ b/modules/home-manager/common/tool-aliases.nix
@@ -42,7 +42,6 @@ let
   # Prefer explicit wrappers via aliases (raw remains available)
   wrappedToolAliases =
     (lib.optionalAttrs (pkgs ? gh-fnox) { gh = "gh-fnox"; })
-    // (lib.optionalAttrs (pkgs ? opencode-zai) { opencode = "opencode-zai"; })
     // (lib.optionalAttrs (pkgs ? bw-fnox) { bw = "bw-fnox"; });
 in
 {

--- a/modules/nixos/motd.nix
+++ b/modules/nixos/motd.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  host = config.networking.hostName;
+
+  text = ''
+    Host: ${host}
+
+    Repo: ~/flakes/unified-nix-configuration
+    Proxmox repo: /root/flakes/unified-nix-configuration
+
+    Useful:
+      - motd            (live status)
+      - nh os switch -H ${host} -f ~/flakes/unified-nix-configuration
+  '';
+
+in
+{
+  environment.etc."motd".text = lib.mkForce text;
+}


### PR DESCRIPTION
## Summary
- Add a `motd` command and SSH-login banner (bash/zsh/fish) via Home Manager.
- Add a basic `/etc/motd` for NixOS, and write `/etc/motd` for Proxmox root HM.
- Fix Proxmox `opencode` alias by not forcing `opencode -> opencode-zai` when wrapper isn’t installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dynamic login banner that displays system information (host, time, repository metadata, git status, Nix version, uptime, disk usage, memory, IP addresses) upon SSH login across Bash, Zsh, and Fish shells. Includes a static fallback for non-NixOS environments.

* **Chores**
  * Removed opencode alias.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->