### PR TITLE
fix: ensure opencode overlay applies everywhere

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,23 @@
       commonNixpkgsConfig = {
         allowUnfree = true;
       };
+
+      # Extract the opencode override overlay so we can exclude it from the
+      # nested unstable import (prevents infinite recursion).
+      opencodeFromUnstableOverlay =
+        final: prev:
+        let
+          overlaysForUnstable = nixpkgsLib.filter (o: o != opencodeFromUnstableOverlay) commonOverlays;
+          unstable = import inputs.nixpkgs-unstable {
+            system = prev.stdenv.hostPlatform.system;
+            config = commonNixpkgsConfig;
+            overlays = overlaysForUnstable;
+          };
+        in
+        {
+          opencode = unstable.opencode or prev.opencode;
+        };
+
       commonOverlays = [
         # Overlay to selectively use stable packages when unstable ones cause issues
         (
@@ -133,20 +150,7 @@
         })
 
         # Prefer opencode from nixpkgs-unstable
-        (
-          final: prev:
-          let
-            unstable = import inputs.nixpkgs-unstable {
-              system = prev.stdenv.hostPlatform.system;
-              config = commonNixpkgsConfig;
-              # Ensure any of our overlays (wrappers, etc.) still apply.
-              overlays = commonOverlays;
-            };
-          in
-          {
-            opencode = unstable.opencode or prev.opencode;
-          }
-        )
+        opencodeFromUnstableOverlay
 
         # Worktrunk (git worktree management for parallel agents)
         (final: prev: {

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,8 @@
             unstable = import inputs.nixpkgs-unstable {
               system = prev.stdenv.hostPlatform.system;
               config = commonNixpkgsConfig;
+              # Ensure any of our overlays (wrappers, etc.) still apply.
+              overlays = commonOverlays;
             };
           in
           {


### PR DESCRIPTION
## Summary
- Ensure the `opencode` override from `nixpkgs-unstable` imports with the same overlays as the rest of the flake.

## Why
Proxmox (HM-only) hosts were still getting the older pinned `opencode` version because the overlay’s unstable import didn’t apply `commonOverlays`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved flake configuration to safely prefer a package set from the unstable channel while preserving the previous fallback.
  * Prevented recursion when sourcing the unstable package set and ensured overlays are applied consistently during imports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->