### PR TITLE
fix(lxc): disable growPartition on cache-build-server

### DIFF
--- a/hosts/nixos-lxc/cache-build-server/modules/configuration.nix
+++ b/hosts/nixos-lxc/cache-build-server/modules/configuration.nix
@@ -37,7 +37,10 @@
   ];
 
   boot.initrd.systemd.fido2.enable = false;
-  boot.growPartition = true;
+
+  # LXC containers don't have a stable block device for `fileSystems."/".device`.
+  # NixOS grow-partition relies on that, so disable it here.
+  boot.growPartition = false;
 
   system.stateVersion = "25.05";
 }


### PR DESCRIPTION
### **User description**
## Summary
- Disable `boot.growPartition` on the `hosts/nixos-lxc/cache-build-server` LXC config.

## Why
NixOS grow-partition requires `fileSystems."/".device`, which is not present for LXC container roots; this breaks `nix build` / `just update` with:
`error: attribute '"/"' missing`.


___

### **PR Type**
Bug fix


___

### **Description**
- Disable `boot.growPartition` on cache-build-server LXC container

- Fixes build failures due to missing `fileSystems."/".device` in LXC

- Added explanatory comment documenting the LXC limitation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["boot.growPartition = true"] -- "LXC lacks stable block device" --> B["boot.growPartition = false"]
  B -- "Fixes nix build errors" --> C["Build succeeds"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Disable growPartition and add explanatory comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/nixos-lxc/cache-build-server/modules/configuration.nix

<ul><li>Changed <code>boot.growPartition</code> from <code>true</code> to <code>false</code><br> <li> Added comment explaining why grow-partition is disabled for LXC <br>containers<br> <li> Clarifies that LXC containers lack stable block device for <br><code>fileSystems."/".device</code></ul>


</details>


  </td>
  <td><a href="https://github.com/deepwatrcreatur/unified-nix-configuration/pull/5/files#diff-76e6f083f01aa0dd668117bd6049dd92b1975cca1722eae85c33d2a908869a5d">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed boot partition resizing behavior for NixOS LXC container configurations. Automatic partition expansion capability has been disabled to properly accommodate environment-specific constraints of containerized platforms. This configuration change prevents potential boot-related errors, significantly improves system stability and reliability, and ensures more predictable and robust deployments in LXC environments without encountering unexpected complications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->