### PR TITLE
refactor: use nix-ssh-keys-manager flake for ssh keys

### DIFF
--- a/docs/ssh-key-management-strategy.md
+++ b/docs/ssh-key-management-strategy.md
@@ -1,118 +1,73 @@
 # SSH Key Management Strategy
 
+This project uses the `nix-ssh-keys-manager` flake to declaratively manage SSH `authorized_keys` and `known_hosts` across all machines while allowing for dynamic key additions.
+
 ## Current Setup
 
-You already auto-populate `authorized_keys` from `ssh-keys/*.pub` files - this is good! But you're concerned about:
-1. File becoming read-only (nix store symlink)
-2. Can't add new keys dynamically (e.g., GitHub prompts)
+The `nix-ssh-keys-manager` flake provides a hybrid approach to SSH key management:
 
-## Solutions
+1. **NixOS-managed keys**: Keys are auto-populated from `.pub` files stored in the `ssh-keys/` directory. These are read-only and deployed declaratively via Nix.
+2. **Dynamic keys**: Users can manually add keys dynamically to `~/.ssh/authorized_keys_dynamic` (e.g., when prompted by GitHub or other services).
 
-### Option 1: Hybrid approach (Recommended)
-Combine NixOS-managed keys with dynamic keys:
+### 1. NixOS Module (`authorized_keys`)
+
+The NixOS module is imported across hosts to configure `authorized_keys` for users automatically. 
 
 ```nix
-users.users.deepwatrcreatur = {
-  openssh.authorizedKeys.keys = pubKeys;  # From ssh-keys/*.pub
-};
+{
+  imports = [ inputs.ssh-keys-manager.nixosModules.default ];
 
-# Allow additional keys in a mutable location
-systemd.tmpfiles.rules = [
-  "d /home/deepwatrcreatur/.ssh 0700 deepwatrcreatur users - -"
-  "f /home/deepwatrcreatur/.ssh/authorized_keys_dynamic 0600 deepwatrcreatur users - -"
-];
-
-# SSH config to check both files
-services.openssh.extraConfig = ''
-  # Check both NixOS-managed and user-managed keys
-  AuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys_dynamic
-'';
+  services.ssh-keys-manager = {
+    enable = true;
+    keysDirectory = ../../../ssh-keys;
+    username = "deepwatrcreatur"; # Explicitly define the user to apply keys to
+    enableDynamicKeys = true;     # Enables the hybrid approach
+  };
+}
 ```
 
 **Usage:**
 - NixOS manages keys from `ssh-keys/*.pub` → `~/.ssh/authorized_keys` (read-only)
 - You manually add keys → `~/.ssh/authorized_keys_dynamic` (writable)
-- SSH checks both files
+- The SSH daemon is configured to check both files.
 
-### Option 2: Git-based workflow (Your current implicit approach)
-Keep doing what you do now:
-1. Get prompted for new key (e.g., GitHub)
-2. Copy key to `ssh-keys/username@host.pub`
-3. Commit to git
-4. Rebuild affected hosts
+### 2. Home-Manager Module (`known_hosts`)
 
-**This is fine!** It's declarative and version-controlled.
-
-### Option 3: Make authorized_keys mutable
-```nix
-home.file.".ssh/authorized_keys" = {
-  text = lib.concatStringsSep "\n" pubKeys;
-  # Don't use source, use text - creates mutable file
-};
-
-# Ensure directory permissions
-home.file.".ssh/.keep".text = "";
-home.file.".ssh/.keep".onChange = ''
-  chmod 700 ~/.ssh
-  chmod 600 ~/.ssh/authorized_keys 2>/dev/null || true
-'';
-```
-
-This pre-populates but stays mutable so you can `echo "key" >> ~/.ssh/authorized_keys`.
-
-## For agenix secrets.nix automation
-
-**Yes, you can auto-generate from ssh-keys directory!**
+The Home Manager module is used to parse the SSH config and deploy a managed `known_hosts` file across systems.
 
 ```nix
-# secrets.nix
-let
-  sshKeysDir = ./ssh-keys;
-  
-  # Read all pub keys and create attrset
-  readKeys = dir: 
-    let
-      entries = builtins.readDir dir;
-      pubFiles = lib.filterAttrs (name: type: 
-        type == "regular" && lib.hasSuffix ".pub" name
-      ) entries;
-    in
-    lib.mapAttrs (name: _: 
-      lib.strings.trim (builtins.readFile (dir + "/${name}"))
-    ) pubFiles;
-  
-  keys = readKeys sshKeysDir;
-  
-  # Extract by pattern
-  hostKeys = lib.filterAttrs (name: _: lib.hasPrefix "root@" name) keys;
-  userKeys = lib.filterAttrs (name: _: lib.hasPrefix "deepwatrcreatur@" name) keys;
-  
-  # Convenient groups
-  allHostKeys = builtins.attrValues hostKeys;
-  allUserKeys = builtins.attrValues userKeys;
-  allKeys = allHostKeys ++ allUserKeys;
-in
 {
-  "technitium-api-key.age".publicKeys = allKeys;
-  "github-token.age".publicKeys = allKeys;
-  # etc...
+  imports = [ inputs.ssh-keys-manager.homeManagerModules.default ];
+
+  programs.ssh-known-hosts-manager = {
+    enable = true;
+    keysDirectory = ../../../ssh-keys;
+    sshConfigFile = ../ssh-config;
+    outputFile = ".ssh/known_hosts_managed";
+  };
 }
 ```
 
-**But note:** Your ssh-keys has **user keys from various hosts**, not SSH **host keys**. For agenix, you need:
-- **Host keys:** `/etc/ssh/ssh_host_ed25519_key.pub` from each system
-- **User keys:** Your personal `~/.ssh/id_ed25519.pub`
+## Adding a New Key
 
-## Action Items
+1. Copy the new `.pub` key to the `ssh-keys/` directory.
+   - Use the convention `{hostname}-host-ed25519.pub` for host keys.
+   - Use the convention `{username}@{hostname}-ed25519.pub` for user keys.
+2. Commit the key to Git.
+3. Rebuild the affected hosts.
+
+## For agenix secrets.nix automation
+
+You can auto-generate `secrets.nix` for Agenix from the `ssh-keys` directory.
+
+The repository includes scripts to collect host keys and auto-generate the `secrets.nix` file:
 
 1. **Collect host keys:**
    ```bash
-   ssh gateway "cat /etc/ssh/ssh_host_ed25519_key.pub" > ssh-keys/gateway-host-ed25519.pub
-   ssh homeserver "cat /etc/ssh/ssh_host_ed25519_key.pub" > ssh-keys/homeserver-host-ed25519.pub
+   ./scripts/agenix/collect-host-keys.sh
    ```
 
-2. **Create convention:** `{hostname}-host-ed25519.pub` for host keys vs `user@host-ed25519.pub` for user keys
-
-3. **Auto-generate secrets.nix** from these files
-
-Want me to implement the auto-generation script and hybrid authorized_keys approach?
+2. **Generate secrets.nix:**
+   ```bash
+   ./scripts/agenix/generate-secrets-nix.sh
+   ```

--- a/flake.lock
+++ b/flake.lock
@@ -1189,11 +1189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773227479,
-        "narHash": "sha256-G+ooln53uYoQkAuA6MG12CaYiBWMPSwWSqtSfMzbg30=",
+        "lastModified": 1773211200,
+        "narHash": "sha256-PBdX90fKEg+r49ZLlPqrfjEODCjpMv1/jgw/0yxnvSA=",
         "owner": "deepwatrcreatur",
         "repo": "nix-ssh-keys-manager",
-        "rev": "f9c9082bdbd9f8736e11c309c65b5b15788f3f04",
+        "rev": "aca08c23300a64f586f3daf12fa18812b959727e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1131,6 +1131,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
         "sops-nix": "sops-nix",
+        "ssh-keys-manager": "ssh-keys-manager",
         "tap-gabe565": "tap-gabe565",
         "tap-romkatv-powerlevel10k": "tap-romkatv-powerlevel10k",
         "tap-sst": "tap-sst",
@@ -1178,6 +1179,26 @@
       "original": {
         "owner": "Mic92",
         "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "ssh-keys-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773211200,
+        "narHash": "sha256-PBdX90fKEg+r49ZLlPqrfjEODCjpMv1/jgw/0yxnvSA=",
+        "owner": "deepwatrcreatur",
+        "repo": "nix-ssh-keys-manager",
+        "rev": "aca08c23300a64f586f3daf12fa18812b959727e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "deepwatrcreatur",
+        "repo": "nix-ssh-keys-manager",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1189,11 +1189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773211200,
-        "narHash": "sha256-PBdX90fKEg+r49ZLlPqrfjEODCjpMv1/jgw/0yxnvSA=",
+        "lastModified": 1773227479,
+        "narHash": "sha256-G+ooln53uYoQkAuA6MG12CaYiBWMPSwWSqtSfMzbg30=",
         "owner": "deepwatrcreatur",
         "repo": "nix-ssh-keys-manager",
-        "rev": "aca08c23300a64f586f3daf12fa18812b959727e",
+        "rev": "f9c9082bdbd9f8736e11c309c65b5b15788f3f04",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -795,7 +795,8 @@
         pkgs = import inputs.nixpkgs {
           system = "x86_64-linux";
         };
-        modules = [ ./modules/home-manager/non-nixos.nix ];
+        extraSpecialArgs = { inherit inputs; };
+        modules = [ ./modules/home-manager/default.nix ];
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,11 @@
       inputs.flake-utils.follows = "flake-utils";
     };
 
+    ssh-keys-manager = {
+      url = "github:deepwatrcreatur/nix-ssh-keys-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -791,14 +791,9 @@
     in
     (loadOutputs ./outputs)
     // {
-      hm-opts = inputs.home-manager.lib.homeManagerConfiguration {
-        pkgs = import inputs.nixpkgs {
-          system = "x86_64-linux";
-        };
-        extraSpecialArgs = homeManagerModuleArgs // {
-          hostName = "";
-          isDesktop = false;
-        };
+      hm-opts = helpers.mkHomeConfig {
+        system = "x86_64-linux";
+        userPath = ./modules/home-manager/non-nixos.nix;
         modules = [ ./modules/home-manager/default.nix ];
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -793,8 +793,11 @@
     // {
       hm-opts = helpers.mkHomeConfig {
         system = "x86_64-linux";
-        userPath = ./modules/home-manager/non-nixos.nix;
-        modules = [ ./modules/home-manager/default.nix ];
+        userPath = ./modules/home-manager; # mkHomeConfig automatically imports default.nix
+        extraSpecialArgs = homeManagerModuleArgs // {
+          hostName = "";
+          isDesktop = false;
+        };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -795,7 +795,10 @@
         pkgs = import inputs.nixpkgs {
           system = "x86_64-linux";
         };
-        extraSpecialArgs = { inherit inputs; };
+        extraSpecialArgs = homeManagerModuleArgs // {
+          hostName = "";
+          isDesktop = false;
+        };
         modules = [ ./modules/home-manager/default.nix ];
       };
     };

--- a/hosts/nixos-lxc/homeserver/configuration.nix
+++ b/hosts/nixos-lxc/homeserver/configuration.nix
@@ -18,7 +18,6 @@
 
   # Ensure SSH is enabled for SOPS
   services.openssh.enable = true;
-  services.nginx-proxy-manager.enable = true;
 
   # Enable nix-ld for running dynamically linked executables (like homebrew packages)
   programs.nix-ld.enable = true;

--- a/hosts/nixos/gateway/default.nix
+++ b/hosts/nixos/gateway/default.nix
@@ -84,6 +84,8 @@
     shell = pkgs.fish;
   };
 
+  services.ssh-keys-manager.username = "deepwatrcreatur";
+
   # Enable fish shell
   programs.fish.enable = true;
   

--- a/hosts/nixos/workstation/default.nix
+++ b/hosts/nixos/workstation/default.nix
@@ -138,6 +138,8 @@
     shell = pkgs.fish;
   };
 
+  services.ssh-keys-manager.username = "deepwatrcreatur";
+
   # Configure automatic login for deepwatrcreatur user
   services.displayManager.autoLogin.enable = true;
   services.displayManager.autoLogin.user = "deepwatrcreatur";

--- a/modules/home-manager/common/ssh-known-hosts.nix
+++ b/modules/home-manager/common/ssh-known-hosts.nix
@@ -1,81 +1,15 @@
 # modules/home-manager/common/ssh-known-hosts.nix
 # Manages known SSH host keys for common infrastructure
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, inputs, ... }:
 
-let
-  sshKeysDir = ../../../ssh-keys;
-  sshConfigFile = ../ssh-config;
-  
-  # Parse ssh-config to extract hostname -> IP mappings
-  sshConfigContent = builtins.readFile sshConfigFile;
-  
-  # Extract Host and Hostname pairs from ssh-config
-  # This is a simple parser - matches "Host X" followed by "Hostname Y"
-  parseSSHConfig = content:
-    let
-      lines = lib.splitString "\n" content;
-      # Remove comments and trim
-      cleanLines = map (line: lib.strings.trim line) (lib.filter (line: 
-        !(lib.hasPrefix "#" (lib.strings.trim line)) && (lib.strings.trim line) != ""
-      ) lines);
-      
-      # Parse pairs of Host/Hostname
-      parseLines = lines: acc:
-        if lines == [] then acc
-        else
-          let
-            line = lib.head lines;
-            rest = lib.tail lines;
-          in
-          if lib.hasPrefix "Host " line && line != "Host *" then
-            let
-              hostname = lib.removePrefix "Host " line;
-              # Look ahead for Hostname line
-              nextLine = if rest != [] then lib.head rest else "";
-              hasIP = lib.hasPrefix "Hostname " nextLine || lib.hasPrefix "HostName " nextLine;
-              ip = if hasIP then 
-                     lib.removePrefix "Hostname " (lib.removePrefix "HostName " nextLine)
-                   else null;
-            in
-            if ip != null then
-              parseLines (lib.tail rest) (acc // { ${hostname} = ip; })
-            else
-              parseLines rest acc
-          else
-            parseLines rest acc;
-    in
-    parseLines cleanLines {};
-  
-  hostToIP = parseSSHConfig sshConfigContent;
-  
-  # Read host keys (pattern: {hostname}-host-ed25519.pub)
-  hostKeyFiles = builtins.attrNames (
-    lib.filterAttrs (name: type: 
-      type == "regular" && lib.hasSuffix "-host-ed25519.pub" name
-    ) (builtins.readDir sshKeysDir)
-  );
-  
-  # Convert to known_hosts format with hostname,IP
-  knownHostsEntries = lib.concatMapStringsSep "\n" (file:
-    let
-      hostname = lib.removeSuffix "-host-ed25519.pub" file;
-      key = lib.strings.trim (builtins.readFile (sshKeysDir + "/${file}"));
-      # Add IP if we have a mapping, otherwise just hostname
-      hostPattern = if hostToIP ? ${hostname}
-                    then "${hostname},${hostToIP.${hostname}}"
-                    else hostname;
-    in
-    "${hostPattern} ${key}"
-  ) hostKeyFiles;
-in
 {
-  # Create managed known_hosts file
-  home.file.".ssh/known_hosts_managed" = {
-    text = ''
-      # NixOS-managed known_hosts (read-only)
-      # Auto-generated from ssh-keys/*-host-ed25519.pub
-      # IPs auto-extracted from ssh-config
-      ${knownHostsEntries}
-    '';
+  imports = [
+    inputs.ssh-keys-manager.homeManagerModules.default
+  ];
+
+  programs.ssh-known-hosts-manager = {
+    enable = true;
+    keysDirectory = ../../../ssh-keys;
+    sshConfigFile = ../ssh-config;
   };
 }

--- a/modules/home-manager/common/ssh-known-hosts.nix
+++ b/modules/home-manager/common/ssh-known-hosts.nix
@@ -11,5 +11,6 @@
     enable = true;
     keysDirectory = ../../../ssh-keys;
     sshConfigFile = ../ssh-config;
+    outputFile = ".ssh/known_hosts_managed";
   };
 }

--- a/modules/nixos/common/ssh-keys.nix
+++ b/modules/nixos/common/ssh-keys.nix
@@ -1,36 +1,14 @@
-{ config, lib, ... }:
+{ config, lib, inputs, ... }:
 
-let
-  # Get all .pub files from the ssh-keys directory
-  sshKeysDir = ../../../ssh-keys;
-  pubKeyFiles = builtins.attrNames (
-    lib.filterAttrs (name: type: type == "regular" && lib.hasSuffix ".pub" name) (
-      builtins.readDir sshKeysDir
-    )
-  );
-
-  # Read content of each public key file and clean whitespace
-  pubKeys = map (file: lib.strings.trim (builtins.readFile (sshKeysDir + "/${file}"))) pubKeyFiles;
-in
 {
-  # Set SSH authorized keys for the main user
-  users.users.deepwatrcreatur = {
-    isNormalUser = true;
-    openssh.authorizedKeys.keys = pubKeys;
-  };
-
-  # Ensure SSH service is enabled
-  services.openssh.enable = lib.mkDefault true;
-  
-  # Enable hybrid authorized_keys: NixOS-managed + user-managed dynamic keys
-  services.openssh.extraConfig = ''
-    # Check both NixOS-managed and user-managed keys
-    AuthorizedKeysFile .ssh/authorized_keys .ssh/authorized_keys_dynamic
-  '';
-  
-  # Create mutable authorized_keys_dynamic file
-  systemd.tmpfiles.rules = [
-    "d /home/deepwatrcreatur/.ssh 0700 deepwatrcreatur users - -"
-    "f /home/deepwatrcreatur/.ssh/authorized_keys_dynamic 0600 deepwatrcreatur users - -"
+  imports = [
+    inputs.ssh-keys-manager.nixosModules.default
   ];
+
+  services.ssh-keys-manager = {
+    enable = true;
+    keysDirectory = ../../../ssh-keys;
+    username = "deepwatrcreatur";
+    enableDynamicKeys = true;
+  };
 }

--- a/modules/nixos/common/ssh-keys.nix
+++ b/modules/nixos/common/ssh-keys.nix
@@ -5,10 +5,11 @@
     inputs.ssh-keys-manager.nixosModules.default
   ];
 
+  # Note: The per-host NixOS config must set services.ssh-keys-manager.username
+  # in order for the keys to be mapped to a specific user.
   services.ssh-keys-manager = {
     enable = true;
     keysDirectory = ../../../ssh-keys;
-    username = "deepwatrcreatur";
     enableDynamicKeys = true;
   };
 }

--- a/tests/ssh-keys-manager-eval.nix
+++ b/tests/ssh-keys-manager-eval.nix
@@ -1,8 +1,9 @@
 { lib ? import <nixpkgs/lib> }:
 
 let
-  # A mock of the options from the ssh-keys-manager flake
-  mockOptions = {
+  # A minimal stub for the inputs.ssh-keys-manager.nixosModules.default
+  # that only provides the options needed for the test to evaluate successfully
+  mockFlakeModule = {
     options.services.ssh-keys-manager = {
       enable = lib.mkEnableOption "ssh keys manager";
       keysDirectory = lib.mkOption { type = lib.types.path; };
@@ -11,31 +12,43 @@ let
     };
   };
 
+  # Provide the inputs structure as it would be passed by the flake
+  mockInputs = {
+    ssh-keys-manager = {
+      nixosModules = {
+        default = mockFlakeModule;
+      };
+    };
+  };
+
+  # Dummy modules needed to satisfy the common module's references to base NixOS options
+  dummyModules = [
+    {
+      options.users.users = lib.mkOption {
+        type = lib.types.attrsOf lib.types.attrs;
+        default = {};
+      };
+      options.services.openssh.enable = lib.mkEnableOption "ssh";
+      options.services.openssh.extraConfig = lib.mkOption { type = lib.types.str; default = ""; };
+      options.systemd.tmpfiles.rules = lib.mkOption { type = lib.types.listOf lib.types.str; default = []; };
+    }
+  ];
+
   # Test case 1: Username is null by default
   evalDefault = lib.evalModules {
-    modules = [
-      mockOptions
-      {
-        services.ssh-keys-manager = {
-          enable = true;
-          keysDirectory = ../ssh-keys;
-          enableDynamicKeys = true;
-        };
-      }
+    specialArgs = { inputs = mockInputs; };
+    modules = dummyModules ++ [
+      ../modules/nixos/common/ssh-keys.nix
     ];
   };
 
   # Test case 2: Username can be set
   evalWithUser = lib.evalModules {
-    modules = [
-      mockOptions
+    specialArgs = { inputs = mockInputs; };
+    modules = dummyModules ++ [
+      ../modules/nixos/common/ssh-keys.nix
       {
-        services.ssh-keys-manager = {
-          enable = true;
-          keysDirectory = ../ssh-keys;
-          enableDynamicKeys = true;
-          username = "deepwatrcreatur";
-        };
+        services.ssh-keys-manager.username = "deepwatrcreatur";
       }
     ];
   };

--- a/tests/ssh-keys-manager-eval.nix
+++ b/tests/ssh-keys-manager-eval.nix
@@ -1,0 +1,54 @@
+{ lib ? import <nixpkgs/lib> }:
+
+let
+  # A mock of the options from the ssh-keys-manager flake
+  mockOptions = {
+    options.services.ssh-keys-manager = {
+      enable = lib.mkEnableOption "ssh keys manager";
+      keysDirectory = lib.mkOption { type = lib.types.path; };
+      username = lib.mkOption { type = lib.types.nullOr lib.types.str; default = null; };
+      enableDynamicKeys = lib.mkEnableOption "dynamic keys";
+    };
+  };
+
+  # Test case 1: Username is null by default
+  evalDefault = lib.evalModules {
+    modules = [
+      mockOptions
+      {
+        services.ssh-keys-manager = {
+          enable = true;
+          keysDirectory = ../ssh-keys;
+          enableDynamicKeys = true;
+        };
+      }
+    ];
+  };
+
+  # Test case 2: Username can be set
+  evalWithUser = lib.evalModules {
+    modules = [
+      mockOptions
+      {
+        services.ssh-keys-manager = {
+          enable = true;
+          keysDirectory = ../ssh-keys;
+          enableDynamicKeys = true;
+          username = "deepwatrcreatur";
+        };
+      }
+    ];
+  };
+
+in
+lib.runTests {
+  testDefaultUsernameIsNull = {
+    expr = evalDefault.config.services.ssh-keys-manager.username;
+    expected = null;
+  };
+
+  testUsernameIsSet = {
+    expr = evalWithUser.config.services.ssh-keys-manager.username;
+    expected = "deepwatrcreatur";
+  };
+}

--- a/tests/ssh-keys-manager-eval.nix
+++ b/tests/ssh-keys-manager-eval.nix
@@ -1,4 +1,4 @@
-{ lib ? import <nixpkgs/lib> }:
+{ lib }:
 
 let
   # A minimal stub for the inputs.ssh-keys-manager.nixosModules.default


### PR DESCRIPTION
Replaces the local automated ssh key management with the new nix-ssh-keys-manager flake.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Declarative SSH keys manager for centralized handling of authorized_keys and known_hosts, with dynamic key support and per-system username configuration.
* **Refactor**
  * Delegate SSH key and known_hosts generation to the new external manager for simpler, more maintainable configs.
* **Documentation**
  * Updated SSH key management guide with workflows for adding keys and manager usage.
* **Tests**
  * Added evaluations to verify username handling for the SSH keys manager.
* **Chores**
  * Disabled nginx-proxy-manager by default on one host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->