### PR TITLE
fix: package attic observatory as flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,7 +51,7 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-/UviibsJ2wTDt2nzRmhLV392qX0mUbDrdFAcAId0WFk=",
+        "narHash": "sha256-H6JkBJo0dPXmc8jlb5fyMFHxo06HVzJ6JPU4Zh3eYFA=",
         "type": "git",
         "url": "file:///home/deepwatrcreatur/flakes/agents-status-tray-home-manager"
       },
@@ -84,6 +84,26 @@
         "owner": "zhaofengli",
         "repo": "attic",
         "type": "github"
+      }
+    },
+    "attic-observatory": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773482888,
+        "narHash": "sha256-bWgiT/ieBwdlE0xZqAtDnphP1psG/d3bkPiRIC7cKBQ=",
+        "ref": "refs/heads/main",
+        "rev": "2685ab37167c8163e95132df76d1e5cb8ba2de99",
+        "revCount": 1,
+        "type": "git",
+        "url": "ssh://git@github.com/deepwatrcreatur/attic-observatory"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://git@github.com/deepwatrcreatur/attic-observatory"
       }
     },
     "brew-src": {
@@ -1242,6 +1262,7 @@
       "inputs": {
         "agenix": "agenix",
         "agents-status-tray-home-manager": "agents-status-tray-home-manager",
+        "attic-observatory": "attic-observatory",
         "claude-statusline-flake": "claude-statusline-flake",
         "codex-cli-nix": "codex-cli-nix",
         "determinate": "determinate",

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    attic-observatory = {
+      url = "git+ssh://git@github.com/deepwatrcreatur/attic-observatory";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     agents-status-tray-home-manager = {
       url = "git+file:///home/deepwatrcreatur/flakes/agents-status-tray-home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/nixos-lxc/attic-cache/modules/build-server.nix
+++ b/hosts/nixos-lxc/attic-cache/modules/build-server.nix
@@ -2,16 +2,14 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }:
 
 let
   atticObservatoryPort = 8088;
   atticObservatoryUiPort = 8082;
-  atticObservatoryPkg =
-    import ../../../../../attic-observatory/default.nix {
-      inherit pkgs;
-    };
+  atticObservatoryPkg = inputs.attic-observatory.packages.${pkgs.stdenv.hostPlatform.system}.default;
 in
 {
   # Sops secret for attic server token


### PR DESCRIPTION
## Summary
- add  as a flake input
- consume the packaged app from flake inputs instead of importing a sibling path
- update the lockfile for the new input

## Why
The attic-cache deployment failed during pure flake evaluation because  imported , which escapes the flake source tree on the remote host.

Using a proper flake input makes the deployment reproducible and allows remote evaluation/rebuilds to succeed.

## Notes
- deployment wiring itself is already on 
- this PR is only the packaging/evaluation fix needed for remote rebuilds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized attic-observatory package management through flake inputs.
  * Updated build server configuration to reference the external package source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->