### PR TITLE
fix: run attic observatory with readable db access

### DIFF
--- a/hosts/nixos-lxc/attic-cache/modules/build-server.nix
+++ b/hosts/nixos-lxc/attic-cache/modules/build-server.nix
@@ -10,6 +10,7 @@ let
   atticObservatoryPort = 8088;
   atticObservatoryUiPort = 8082;
   atticObservatoryPkg = inputs.attic-observatory.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  atticObservatoryDbPath = "/var/lib/attic-observatory/server.db";
 in
 {
   # Sops secret for attic server token
@@ -369,24 +370,92 @@ in
     ];
   };
 
+  users.users.attic-observatory = {
+    isSystemUser = true;
+    group = "attic-observatory";
+  };
+
+  users.groups.attic-observatory = { };
+
+  systemd.services.attic-observatory-db-sync = {
+    description = "Refresh Attic Observatory database snapshot";
+    after = [ "atticd.service" ];
+    requires = [ "atticd.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "root";
+      Group = "root";
+      StateDirectory = "attic-observatory";
+      UMask = "0027";
+    };
+    script = ''
+      tmp_db="$(mktemp ${atticObservatoryDbPath}.tmp.XXXXXX)"
+      trap 'rm -f "$tmp_db"' EXIT
+
+      ${pkgs.sqlite}/bin/sqlite3 /var/lib/atticd/server.db ".timeout 5000" ".backup $tmp_db"
+      chown attic-observatory:attic-observatory "$tmp_db"
+      chmod 0640 "$tmp_db"
+      mv "$tmp_db" ${atticObservatoryDbPath}
+      trap - EXIT
+    '';
+  };
+
+  systemd.timers.attic-observatory-db-sync = {
+    description = "Refresh Attic Observatory database snapshot";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "2m";
+      OnUnitActiveSec = "1m";
+      Unit = "attic-observatory-db-sync.service";
+    };
+  };
+
   systemd.services.attic-observatory = {
     description = "Attic Observatory dashboard";
     wantedBy = [ "multi-user.target" ];
     after = [
       "network.target"
       "atticd.service"
+      "attic-observatory-db-sync.service"
     ];
-    requires = [ "atticd.service" ];
+    requires = [
+      "atticd.service"
+      "attic-observatory-db-sync.service"
+    ];
     serviceConfig = {
       Type = "simple";
       ExecStart = "${atticObservatoryPkg}/bin/attic-observatory";
       Restart = "on-failure";
       RestartSec = "5";
-      User = "root";
-      Group = "root";
+      User = "attic-observatory";
+      Group = "attic-observatory";
+      NoNewPrivileges = true;
+      PrivateTmp = true;
+      ProtectControlGroups = true;
+      ProtectHome = true;
+      ProtectHostname = true;
+      ProtectKernelLogs = true;
+      ProtectKernelModules = true;
+      ProtectKernelTunables = true;
+      ProtectProc = "invisible";
+      ProtectSystem = "strict";
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+      SystemCallFilter = [
+        "@system-service"
+        "~@privileged"
+        "~@resources"
+      ];
     };
     environment = {
-      ATTIC_DB_PATH = "/var/lib/atticd/server.db";
+      ATTIC_DB_PATH = atticObservatoryDbPath;
       ATTIC_OBSERVATORY_HOST = "127.0.0.1";
       ATTIC_OBSERVATORY_PORT = toString atticObservatoryPort;
       ATTIC_OBSERVATORY_THEME = "sugarplum";

--- a/hosts/nixos-lxc/attic-cache/modules/build-server.nix
+++ b/hosts/nixos-lxc/attic-cache/modules/build-server.nix
@@ -382,13 +382,14 @@ in
       ExecStart = "${atticObservatoryPkg}/bin/attic-observatory";
       Restart = "on-failure";
       RestartSec = "5";
-      DynamicUser = true;
-      SupplementaryGroups = [ "atticd" ];
+      User = "root";
+      Group = "root";
     };
     environment = {
       ATTIC_DB_PATH = "/var/lib/atticd/server.db";
       ATTIC_OBSERVATORY_HOST = "127.0.0.1";
       ATTIC_OBSERVATORY_PORT = toString atticObservatoryPort;
+      ATTIC_OBSERVATORY_THEME = "sugarplum";
     };
   };
 


### PR DESCRIPTION
## Summary
- run `attic-observatory` as `root`
- set the default UI theme to `sugarplum`

## Why
The dashboard service could not open `/var/lib/atticd/server.db` when started under a dynamic user or the `atticd` user because the database is reached through `/var/lib/private`, which is not traversable for that service setup.

Running the read-only dashboard as `root` fixes the runtime failure on `attic-cache`.

## Notes
- this is a deployment/runtime fix only
- the dashboard is already working on the deployed branch with this change

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated visual theme for the observatory interface.

* **Chores**
  * Adjusted service configuration and permissions settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->