### PR TITLE
fix: consume observatory runtime follow-up

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773492668,
-        "narHash": "sha256-fiwt494iXWT7x4l8zFUSwJ8D7gzozFhvp7itcgk2IG8=",
+        "lastModified": 1773503295,
+        "narHash": "sha256-lArHSe0DuXEriP79Gxcpdkn/+c9iAqMD/FaStix499E=",
         "owner": "deepwatrcreatur",
         "repo": "attic-observatory",
-        "rev": "4beb35edd4f8d22d1165487df4ce2a1e632b3835",
+        "rev": "2211935082bf462f6b1785dc65517891bf4ffd71",
         "type": "github"
       },
       "original": {
@@ -851,15 +851,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1773499277,
-        "narHash": "sha256-C9pZfcbN7ZSZztRger2/ePp7vyaJIxU9sGHelRBuROU=",
-        "ref": "refs/heads/main",
-        "rev": "5e9e59d7fc7d9b94a7b8a5dcc15eaa34d8e1c478",
-        "revCount": 23,
+        "lastModified": 1773503354,
+        "narHash": "sha256-EIKtC5JTeaBItNRYnB8U/06A/CNGhbXzF+w7ptqI6CQ=",
+        "ref": "fix/attic-observatory-immutable",
+        "rev": "ce6a4ddb0e313ba0b7d6cdf684ec447f69787a85",
+        "revCount": 24,
         "type": "git",
         "url": "ssh://git@github.com/deepwatrcreatur/nix-attic-infra"
       },
       "original": {
+        "ref": "fix/attic-observatory-immutable",
         "type": "git",
         "url": "ssh://git@github.com/deepwatrcreatur/nix-attic-infra"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
     };
 
     nix-attic-infra = {
-      url = "git+ssh://git@github.com/deepwatrcreatur/nix-attic-infra";
+      url = "git+ssh://git@github.com/deepwatrcreatur/nix-attic-infra?ref=fix/attic-observatory-immutable";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };

--- a/hosts/nixos-lxc/attic-cache/modules/build-server.nix
+++ b/hosts/nixos-lxc/attic-cache/modules/build-server.nix
@@ -346,7 +346,7 @@ in
 
   services.attic-observatory = {
     enable = true;
-    theme = "sugarplum";
+    theme = "x-dark";
     openFirewall = true;
 
     nginx = {


### PR DESCRIPTION
Summary:
- point nix-attic-infra at the immutable-snapshot follow-up branch for review
- switch attic-cache observatory theme to x-dark
- carry the merged attic-observatory app fix through the lockfile

Verification:
- nix eval .#nixosConfigurations.attic-cache.config.services.attic-observatory.theme
- nix eval .#nixosConfigurations.attic-cache.config.systemd.services.attic-observatory.environment.ATTIC_DB_IMMUTABLE

Note:
- full flake check is currently blocked by an unrelated pre-existing gateway config error on main: hosts/nixos/gateway/default.nix uses RestartSec = 30 s;

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
