### PR TITLE
chore: pin observatory infra to main

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -853,13 +853,14 @@
       "locked": {
         "lastModified": 1773503892,
         "narHash": "sha256-EIKtC5JTeaBItNRYnB8U/06A/CNGhbXzF+w7ptqI6CQ=",
-        "ref": "refs/heads/main",
+        "ref": "main",
         "rev": "bda2eaf904f1dd4555d839cb263e17157a5cccb2",
         "revCount": 25,
         "type": "git",
         "url": "ssh://git@github.com/deepwatrcreatur/nix-attic-infra"
       },
       "original": {
+        "ref": "main",
         "type": "git",
         "url": "ssh://git@github.com/deepwatrcreatur/nix-attic-infra"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -851,16 +851,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1773503354,
+        "lastModified": 1773503892,
         "narHash": "sha256-EIKtC5JTeaBItNRYnB8U/06A/CNGhbXzF+w7ptqI6CQ=",
-        "ref": "fix/attic-observatory-immutable",
-        "rev": "ce6a4ddb0e313ba0b7d6cdf684ec447f69787a85",
-        "revCount": 24,
+        "ref": "refs/heads/main",
+        "rev": "bda2eaf904f1dd4555d839cb263e17157a5cccb2",
+        "revCount": 25,
         "type": "git",
         "url": "ssh://git@github.com/deepwatrcreatur/nix-attic-infra"
       },
       "original": {
-        "ref": "fix/attic-observatory-immutable",
         "type": "git",
         "url": "ssh://git@github.com/deepwatrcreatur/nix-attic-infra"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
     };
 
     nix-attic-infra = {
-      url = "git+ssh://git@github.com/deepwatrcreatur/nix-attic-infra";
+      url = "git+ssh://git@github.com/deepwatrcreatur/nix-attic-infra?ref=main";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
     };
 
     nix-attic-infra = {
-      url = "git+ssh://git@github.com/deepwatrcreatur/nix-attic-infra?ref=fix/attic-observatory-immutable";
+      url = "git+ssh://git@github.com/deepwatrcreatur/nix-attic-infra";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };


### PR DESCRIPTION
## Summary
- stop pinning nix-attic-infra to the temporary fix/attic-observatory-immutable branch
- refresh flake.lock to the merged nix-attic-infra main commit

## Verification
- nix flake check --no-build

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to use the latest stable version of a core dependency, improving build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->