### PR TITLE
Restore declarative remote builder key

### DIFF
--- a/hosts/nixos-lxc/homeserver/default.nix
+++ b/hosts/nixos-lxc/homeserver/default.nix
@@ -5,14 +5,15 @@
 {
   # Declarative host configuration
   host.type = "lxc";
-  host.networking.enableTailscale = false;  # LXC containers can't run Tailscale
+  host.networking.enableTailscale = false; # LXC containers can't run Tailscale
   host.services.iperf3.enable = true;
 
   imports = [
-    ../../../modules/nixos/common  # Common NixOS modules including ssh-keys-manager
+    ../../../modules/nixos/common # Common NixOS modules including ssh-keys-manager
     ../../../modules/nixos/services/iperf3.nix
-    ../../../modules/nixos/attic-client.nix  # Attic binary cache client
-    ../../../modules/nixos/nix-daemon-user-ssh.nix  # SSH socket for git+ssh flake inputs
+    ../../../modules/nixos/attic-client.nix # Attic binary cache client
+    ../../../modules/nixos/nix-daemon-user-ssh.nix # SSH socket for git+ssh flake inputs
+    ./modules/networking.nix
     ./modules/configuration.nix
     ./modules/homebridge.nix
     ./modules/home-manager-users.nix
@@ -25,7 +26,7 @@
   services.semaphore = {
     enable = true;
     openFirewall = true;
-    host = "http://homeserver:3000";  # Required for WebSocket connections
+    host = "http://homeserver:3000"; # Required for WebSocket connections
   };
 
   # SSH keys manager - deploy authorized_keys from ssh-keys/ directory

--- a/hosts/nixos-lxc/homeserver/modules/configuration.nix
+++ b/hosts/nixos-lxc/homeserver/modules/configuration.nix
@@ -9,32 +9,6 @@
 
   networking.hostName = "homeserver";
 
-  systemd.network = {
-    enable = true;
-    wait-online.enable = true;
-    networks."10-eth0" = {
-      matchConfig.Name = "eth0";
-      address = [ "10.10.11.69/16" ];
-      routes = [
-        { Gateway = "10.10.10.1"; }
-      ];
-      networkConfig = {
-        DNS = [ "10.10.10.1" ];
-        Domains = [ "deepwatercreature.com" ];
-        IPv6AcceptRA = true;
-      };
-      linkConfig.RequiredForOnline = "routable";
-    };
-  };
-
-  networking = {
-    useDHCP = false;
-    useHostResolvConf = false;
-    nameservers = [ "10.10.10.1" ];
-  };
-
-  services.resolved.enable = true;
-
   services.openssh.enable = true;
   services.openssh.settings = {
     PasswordAuthentication = true;

--- a/hosts/nixos-lxc/homeserver/modules/networking.nix
+++ b/hosts/nixos-lxc/homeserver/modules/networking.nix
@@ -6,10 +6,9 @@
 }:
 
 {
-  networking = {
-    useDHCP = true;
-    useHostResolvConf = false;
-  };
+  networking.useNetworkd = true;
+  networking.useDHCP = true;
+  networking.useHostResolvConf = false;
 
   systemd.network = {
     enable = true;

--- a/hosts/nixos-lxc/homeserver/modules/networking.nix
+++ b/hosts/nixos-lxc/homeserver/modules/networking.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  networking = {
+    useDHCP = true;
+    useHostResolvConf = false;
+  };
+
+  systemd.network = {
+    enable = true;
+    wait-online.enable = true;
+    networks."10-eth0" = {
+      matchConfig.Name = "eth0";
+      dhcpV4Config = {
+        UseDNS = true;
+        UseDomains = true;
+        ClientIdentifier = "mac";
+      };
+      ipv6AcceptRAConfig.UseDNS = false;
+      linkConfig.RequiredForOnline = "routable";
+    };
+  };
+
+  services.resolved.enable = true;
+}

--- a/hosts/nixos/gateway/default.nix
+++ b/hosts/nixos/gateway/default.nix
@@ -191,25 +191,6 @@
         "${dnsConfig.domain}" = mkZone dnsConfig;
       };
 
-  # Enable remote building on gateway using attic-cache
-  nix.distributedBuilds = lib.mkForce true;
-  nix.buildMachines = lib.mkForce [
-    {
-      hostName = "10.10.11.39"; # attic-cache
-      system = "x86_64-linux";
-      maxJobs = 8;
-      speedFactor = 2;
-      supportedFeatures = [
-        "nixos-test"
-        "benchmark"
-        "big-parallel"
-        "kvm"
-      ];
-      sshUser = "root";
-      sshKey = "/root/.ssh/id_ed25519"; # Use existing gateway root SSH key
-    }
-  ];
-
   # Home manager configuration for gateway
   home-manager.users.deepwatrcreatur = {
     imports = [

--- a/hosts/nixos/gateway/networking.nix
+++ b/hosts/nixos/gateway/networking.nix
@@ -22,23 +22,12 @@
   ];
 
   # Create static resolv.conf with our nameservers and search domain
-  # systemd-networkd may override this, so we use a systemd service to restore it
-  systemd.services.fix-resolv-conf = {
-    description = "Set correct resolv.conf with search domain";
-    wantedBy = [ "network.target" ];
-    after = [ "systemd-networkd.service" ];
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      ExecStart = pkgs.writeScript "fix-resolv-conf.sh" ''
-        #!/bin/sh
-        echo "search deepwatercreature.com" > /etc/resolv.conf
-        echo "nameserver 127.0.0.1" >> /etc/resolv.conf
-        echo "nameserver 1.1.1.1" >> /etc/resolv.conf
-        echo "nameserver 8.8.8.8" >> /etc/resolv.conf
-      '';
-    };
-  };
+  environment.etc."resolv.conf".text = ''
+    search deepwatercreature.com
+    nameserver 127.0.0.1
+    nameserver 1.1.1.1
+    nameserver 8.8.8.8
+  '';
 
   # If Technitium fails, you can still SSH via IP: ssh 192.168.100.100
 
@@ -51,7 +40,7 @@
   systemd.network.networks."10-wan" = {
     matchConfig.Name = "ens17";
     networkConfig = {
-      DHCP = "yes";
+      DHCP = true;
       IPv6AcceptRA = true;
     };
     # Request IPv6 prefix delegation
@@ -76,12 +65,12 @@
       }
     ];
     networkConfig = {
-      DHCPServer = "no";
+      DHCPServer = false;
       IPv6SendRA = true;
-      DHCPPrefixDelegation = true; # Enable receiving and using delegated prefixes
+      DHCPPrefixDelegation = true;
       DNS = [ "127.0.0.1" ];
       Domains = [ "deepwatercreature.com" ];
-      MakeResolvConf = false; # Don't let networkd overwrite resolv.conf
+      MakeResolvConf = false;
     };
     ipv6SendRAConfig = {
       Managed = false; # Use SLAAC, not DHCPv6

--- a/hosts/nixos/gateway/networking.nix
+++ b/hosts/nixos/gateway/networking.nix
@@ -70,7 +70,6 @@
       DHCPPrefixDelegation = true;
       DNS = [ "127.0.0.1" ];
       Domains = [ "deepwatercreature.com" ];
-      MakeResolvConf = false;
     };
     ipv6SendRAConfig = {
       Managed = false; # Use SLAAC, not DHCPv6

--- a/hosts/nixos/gateway/networking.nix
+++ b/hosts/nixos/gateway/networking.nix
@@ -72,6 +72,8 @@
       DHCPServer = "no";
       IPv6SendRA = true;
       DHCPPrefixDelegation = true; # Enable receiving and using delegated prefixes
+      DNS = [ "127.0.0.1" ];
+      Domains = [ "deepwatercreature.com" ];
     };
     ipv6SendRAConfig = {
       Managed = false; # Use SLAAC, not DHCPv6

--- a/hosts/nixos/gateway/networking.nix
+++ b/hosts/nixos/gateway/networking.nix
@@ -22,16 +22,23 @@
   ];
 
   # Create static resolv.conf with our nameservers and search domain
-  environment.etc."resolv.conf".text = ''
-    # Gateway DNS configuration
-    # Primary: Technitium DNS on localhost
-    # Fallback: Cloudflare and Google
-    search deepwatercreature.com
-    nameserver 127.0.0.1
-    nameserver 1.1.1.1
-    nameserver 8.8.8.8
-    options edns0
-  '';
+  # systemd-networkd may override this, so we use a systemd service to restore it
+  systemd.services.fix-resolv-conf = {
+    description = "Set correct resolv.conf with search domain";
+    wantedBy = [ "network.target" ];
+    after = [ "systemd-networkd.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = pkgs.writeScript "fix-resolv-conf.sh" ''
+        #!/bin/sh
+        echo "search deepwatercreature.com" > /etc/resolv.conf
+        echo "nameserver 127.0.0.1" >> /etc/resolv.conf
+        echo "nameserver 1.1.1.1" >> /etc/resolv.conf
+        echo "nameserver 8.8.8.8" >> /etc/resolv.conf
+      '';
+    };
+  };
 
   # If Technitium fails, you can still SSH via IP: ssh 192.168.100.100
 

--- a/hosts/nixos/gateway/networking.nix
+++ b/hosts/nixos/gateway/networking.nix
@@ -74,6 +74,7 @@
       DHCPPrefixDelegation = true; # Enable receiving and using delegated prefixes
       DNS = [ "127.0.0.1" ];
       Domains = [ "deepwatercreature.com" ];
+      MakeResolvConf = false; # Don't let networkd overwrite resolv.conf
     };
     ipv6SendRAConfig = {
       Managed = false; # Use SLAAC, not DHCPv6

--- a/hosts/nixos/gateway/networking.nix
+++ b/hosts/nixos/gateway/networking.nix
@@ -1,5 +1,10 @@
 # Gateway networking configuration
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   networking.hostName = "gateway";
@@ -7,22 +12,27 @@
 
   # Disable systemd-resolved, use Technitium DNS directly
   services.resolved.enable = false;
-  
+
   # DNS configuration - with fallback if Technitium is unavailable
   # Note: With systemd-networkd, this needs special handling
-  networking.nameservers = [ "127.0.0.1" "1.1.1.1" "8.8.8.8" ];
-  
-  # Create static resolv.conf with our nameservers
+  networking.nameservers = [
+    "127.0.0.1"
+    "1.1.1.1"
+    "8.8.8.8"
+  ];
+
+  # Create static resolv.conf with our nameservers and search domain
   environment.etc."resolv.conf".text = ''
     # Gateway DNS configuration
     # Primary: Technitium DNS on localhost
     # Fallback: Cloudflare and Google
+    search deepwatercreature.com
     nameserver 127.0.0.1
     nameserver 1.1.1.1
     nameserver 8.8.8.8
     options edns0
   '';
-  
+
   # If Technitium fails, you can still SSH via IP: ssh 192.168.100.100
 
   # Network interfaces using systemd-networkd
@@ -39,12 +49,12 @@
     };
     # Request IPv6 prefix delegation
     dhcpV6Config = {
-      PrefixDelegationHint = "::/56";  # Request /56 prefix from ISP (matches OPNsense)
-      UseAddress = true;  # Also get an address for the gateway itself
+      PrefixDelegationHint = "::/56"; # Request /56 prefix from ISP (matches OPNsense)
+      UseAddress = true; # Also get an address for the gateway itself
     };
     ipv6AcceptRAConfig = {
       DHCPv6Client = "always";
-      UseDNS = false;  # Use Technitium DNS instead
+      UseDNS = false; # Use Technitium DNS instead
     };
   };
 
@@ -61,15 +71,15 @@
     networkConfig = {
       DHCPServer = "no";
       IPv6SendRA = true;
-      DHCPPrefixDelegation = true;  # Enable receiving and using delegated prefixes
+      DHCPPrefixDelegation = true; # Enable receiving and using delegated prefixes
     };
     ipv6SendRAConfig = {
-      Managed = false;  # Use SLAAC, not DHCPv6
+      Managed = false; # Use SLAAC, not DHCPv6
       OtherInformation = false;
     };
     ipv6Prefixes = [
       {
-        Prefix = "::/64";  # Announce a /64 from the delegated prefix
+        Prefix = "::/64"; # Announce a /64 from the delegated prefix
         PreferredLifetimeSec = 1800;
         ValidLifetimeSec = 3600;
       }

--- a/hosts/nixos/workstation/default.nix
+++ b/hosts/nixos/workstation/default.nix
@@ -219,6 +219,7 @@
     satty # Screenshot annotation tool inspired by Swappy and Flameshot
     gthumb # Image browser and viewer with crop support
     yt-dlp # YouTube and video downloader
+    vivaldi # Chromium-based browser with advanced features
   ];
 
   # Enable nix-ld for running dynamically linked executables (like homebrew packages)

--- a/lib/remote-builder.nix
+++ b/lib/remote-builder.nix
@@ -1,0 +1,7 @@
+{
+  supportedHosts = [
+    "gateway"
+    "homeserver"
+    "workstation"
+  ];
+}

--- a/modules/common/nix-settings.nix
+++ b/modules/common/nix-settings.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  options,
   pkgs,
   inputs,
   ...
@@ -28,9 +29,27 @@ let
 
   # Detect if this is the attic-cache server itself (avoid circular dependency)
   isCacheServer = config.networking.hostName or "" == "attic-cache";
+
+  remoteBuilderSupportedHosts = [
+    "gateway"
+    "homeserver"
+    "podman"
+    "workstation"
+  ];
+  remoteBuilderKeyPath = if pkgs.stdenv.isDarwin then "/var/root/.ssh/nix-remote" else "/root/.ssh/nix-remote";
+  hasDeclarativeRemoteBuilderKey = builtins.elem (config.networking.hostName or "") remoteBuilderSupportedHosts;
+  canUseRemoteBuilder = !isCacheServer && hasDeclarativeRemoteBuilderKey;
 in
 {
   nixpkgs.config.allowUnfree = true;
+
+  age.secrets.nix-remote-builder-key = lib.mkIf (canUseRemoteBuilder && options ? age) {
+    file = ../../secrets-agenix/nix-remote-builder-key.age;
+    path = remoteBuilderKeyPath;
+    owner = "root";
+    group = "root";
+    mode = "0400";
+  };
 
   nix.settings = {
     experimental-features = [
@@ -119,8 +138,8 @@ in
   nix.settings.use-cgroups = lib.mkIf (!isContainer) true;
 
   # Remote building configuration
-  nix.distributedBuilds = lib.mkIf (!isCacheServer) true;
-  nix.buildMachines = lib.mkIf (!isCacheServer) [
+  nix.distributedBuilds = lib.mkIf canUseRemoteBuilder true;
+  nix.buildMachines = lib.mkIf canUseRemoteBuilder [
     {
       hostName = "10.10.11.39"; # attic-cache
       system = "x86_64-linux";
@@ -133,7 +152,7 @@ in
         "kvm"
       ];
       sshUser = "deepwatrcreatur";
-      sshKey = if pkgs.stdenv.isDarwin then "/var/root/.ssh/nix-remote" else "/root/.ssh/nix-remote";
+      sshKey = remoteBuilderKeyPath;
     }
   ];
 }

--- a/modules/common/nix-settings.nix
+++ b/modules/common/nix-settings.nix
@@ -7,6 +7,8 @@
 }:
 
 let
+  remoteBuilder = import ../../lib/remote-builder.nix;
+
   # Path to GitHub token (works for both user and root contexts)
   githubTokenPath =
     if
@@ -29,13 +31,8 @@ let
   # Detect if this is the attic-cache server itself (avoid circular dependency)
   isCacheServer = config.networking.hostName or "" == "attic-cache";
 
-  remoteBuilderSupportedHosts = [
-    "gateway"
-    "homeserver"
-    "workstation"
-  ];
   remoteBuilderKeyPath = if pkgs.stdenv.isDarwin then "/var/root/.ssh/nix-remote" else "/root/.ssh/nix-remote";
-  hasDeclarativeRemoteBuilderKey = builtins.elem (config.networking.hostName or "") remoteBuilderSupportedHosts;
+  hasDeclarativeRemoteBuilderKey = builtins.elem (config.networking.hostName or "") remoteBuilder.supportedHosts;
   canUseRemoteBuilder = !isCacheServer && hasDeclarativeRemoteBuilderKey;
 in
 {

--- a/modules/common/nix-settings.nix
+++ b/modules/common/nix-settings.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  options,
   pkgs,
   inputs,
   ...
@@ -33,7 +32,6 @@ let
   remoteBuilderSupportedHosts = [
     "gateway"
     "homeserver"
-    "podman"
     "workstation"
   ];
   remoteBuilderKeyPath = if pkgs.stdenv.isDarwin then "/var/root/.ssh/nix-remote" else "/root/.ssh/nix-remote";
@@ -42,14 +40,6 @@ let
 in
 {
   nixpkgs.config.allowUnfree = true;
-
-  age.secrets.nix-remote-builder-key = lib.mkIf (canUseRemoteBuilder && options ? age) {
-    file = ../../secrets-agenix/nix-remote-builder-key.age;
-    path = remoteBuilderKeyPath;
-    owner = "root";
-    group = "root";
-    mode = "0400";
-  };
 
   nix.settings = {
     experimental-features = [

--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -8,6 +8,7 @@
     ./locale.nix
     ./nh.nix
     ./ssh-keys.nix
+    ./remote-builder-key.nix
     ./agenix.nix
     ./fstrim.nix
     ./git-ssh.nix

--- a/modules/nixos/common/remote-builder-key.nix
+++ b/modules/nixos/common/remote-builder-key.nix
@@ -1,13 +1,9 @@
 { config, lib, pkgs, ... }:
 
 let
-  remoteBuilderSupportedHosts = [
-    "gateway"
-    "homeserver"
-    "workstation"
-  ];
+  remoteBuilder = import ../../../lib/remote-builder.nix;
   hostName = config.networking.hostName or "";
-  canUseRemoteBuilder = hostName != "attic-cache" && builtins.elem hostName remoteBuilderSupportedHosts;
+  canUseRemoteBuilder = hostName != "attic-cache" && builtins.elem hostName remoteBuilder.supportedHosts;
   remoteBuilderKeyPath = if pkgs.stdenv.isDarwin then "/var/root/.ssh/nix-remote" else "/root/.ssh/nix-remote";
 in
 {

--- a/modules/nixos/common/remote-builder-key.nix
+++ b/modules/nixos/common/remote-builder-key.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+let
+  remoteBuilderSupportedHosts = [
+    "gateway"
+    "homeserver"
+    "workstation"
+  ];
+  hostName = config.networking.hostName or "";
+  canUseRemoteBuilder = hostName != "attic-cache" && builtins.elem hostName remoteBuilderSupportedHosts;
+  remoteBuilderKeyPath = if pkgs.stdenv.isDarwin then "/var/root/.ssh/nix-remote" else "/root/.ssh/nix-remote";
+in
+{
+  config = lib.mkIf canUseRemoteBuilder {
+    age.secrets.nix-remote-builder-key = {
+      file = ../../../secrets-agenix/nix-remote-builder-key.age;
+      path = remoteBuilderKeyPath;
+      owner = "root";
+      group = "root";
+      mode = "0400";
+    };
+  };
+}

--- a/modules/nixos/common/ssh-keys.nix
+++ b/modules/nixos/common/ssh-keys.nix
@@ -29,8 +29,6 @@ in {
   imports = [
     inputs.ssh-keys-manager.nixosModules.default
     inputs.ssh-keys-manager.nixosModules.ssh-known-hosts
-    # ssh-remote-builder-keys removed - requires sops-nix module
-    # TODO: Create agenix-based alternative for nix remote builder key
   ];
 
   # Note: The per-host NixOS config must set services.ssh-keys-manager.username

--- a/modules/nixos/common/zram.nix
+++ b/modules/nixos/common/zram.nix
@@ -1,0 +1,18 @@
+# modules/nixos/common/zram.nix
+# Enable zram compressed swap for desktop systems
+{ config, lib, ... }:
+
+{
+  config = lib.mkIf config.host.desktop.enable {
+    zramSwap = {
+      enable = true;
+      # Use 50% of RAM for zram - with typical 2-3x compression ratio,
+      # this effectively adds 100-150% of RAM as compressed swap
+      memoryPercent = 50;
+      # Use zstd for better compression ratio
+      algorithm = "zstd";
+      # Higher priority than disk swap (default is 5)
+      priority = 100;
+    };
+  };
+}

--- a/secrets.nix
+++ b/secrets.nix
@@ -5,7 +5,6 @@ let
     attic-cache = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBMzmqOZ301fwZJVQI5KZ9+npuFs+3EvwKet4peLZeLv";
     gateway = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGjM16WJ9SUCs+moDo8QTTbbEJMd0EYZPGItC6oV4WiO root@nixos";
     homeserver = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOo9lHhuHiT1rAF3RcFwSMYYtQvoheU4IxVsCRBKlPFI root@nixoslxc";
-    podman = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOo9lHhuHiT1rAF3RcFwSMYYtQvoheU4IxVsCRBKlPFI root@podman";
     pve-gateway = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKneb67aN01m3ygkITF7BOU4YbKsPRZCErT/d5TVcquy";
     pve-lattitude = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOz/qnrymEHn6b057GKCOMCfB9fK28HkWmZ6MnXblVO2";
     pve-strix = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAgSeJeuivBkeB92lG8Sup+fQl4AwfRWH3XlCJSMQ3j4";
@@ -38,7 +37,6 @@ let
   remoteBuilderClientSecrets = operatorUsers ++ [
     hosts.gateway
     hosts.homeserver
-    hosts.podman
     hosts.workstation
   ];
 

--- a/secrets.nix
+++ b/secrets.nix
@@ -1,6 +1,8 @@
 # Auto-generated secrets.nix for agenix
 # Manually normalized after replacing the old homeserver LXC.
 let
+  remoteBuilder = import ./lib/remote-builder.nix;
+
   hosts = {
     attic-cache = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBMzmqOZ301fwZJVQI5KZ9+npuFs+3EvwKet4peLZeLv";
     gateway = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGjM16WJ9SUCs+moDo8QTTbbEJMd0EYZPGItC6oV4WiO root@nixos";
@@ -34,11 +36,7 @@ let
     hosts.attic-cache
   ];
 
-  remoteBuilderClientSecrets = operatorUsers ++ [
-    hosts.gateway
-    hosts.homeserver
-    hosts.workstation
-  ];
+  remoteBuilderClientSecrets = operatorUsers ++ map (hostName: hosts.${hostName}) remoteBuilder.supportedHosts;
 
   # All hosts that build from this repo should be able to use the attic cache
   atticClientSecrets = operatorUsers ++ [

--- a/secrets.nix
+++ b/secrets.nix
@@ -5,6 +5,7 @@ let
     attic-cache = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBMzmqOZ301fwZJVQI5KZ9+npuFs+3EvwKet4peLZeLv";
     gateway = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGjM16WJ9SUCs+moDo8QTTbbEJMd0EYZPGItC6oV4WiO root@nixos";
     homeserver = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOo9lHhuHiT1rAF3RcFwSMYYtQvoheU4IxVsCRBKlPFI root@nixoslxc";
+    podman = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOo9lHhuHiT1rAF3RcFwSMYYtQvoheU4IxVsCRBKlPFI root@podman";
     pve-gateway = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKneb67aN01m3ygkITF7BOU4YbKsPRZCErT/d5TVcquy";
     pve-lattitude = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOz/qnrymEHn6b057GKCOMCfB9fK28HkWmZ6MnXblVO2";
     pve-strix = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAgSeJeuivBkeB92lG8Sup+fQl4AwfRWH3XlCJSMQ3j4";
@@ -34,6 +35,13 @@ let
     hosts.attic-cache
   ];
 
+  remoteBuilderClientSecrets = operatorUsers ++ [
+    hosts.gateway
+    hosts.homeserver
+    hosts.podman
+    hosts.workstation
+  ];
+
   # All hosts that build from this repo should be able to use the attic cache
   atticClientSecrets = operatorUsers ++ [
     hosts.attic-cache
@@ -55,6 +63,7 @@ in
   "secrets-agenix/attic-client-token.age".publicKeys = atticClientSecrets;
   "secrets-agenix/attic-server-token.age".publicKeys = atticServiceSecrets;
   "secrets-agenix/attic-jwt-secret.age".publicKeys = atticServiceSecrets;
+  "secrets-agenix/nix-remote-builder-key.age".publicKeys = remoteBuilderClientSecrets;
 
   # Operator/user secrets decrypted directly in Home Manager with the stable user key
   "secrets-agenix/github-token.age".publicKeys = userOnlySecrets;


### PR DESCRIPTION
## Summary
- restore the shared remote-builder private key as an agenix-managed secret
- use the shared  path on supported NixOS build clients
- remove gateway's special-case builder override so it uses the same config as the other hosts

## Why
The repo still configured non-cache hosts to use , but the private key stopped being provisioned when the old sops-based remote-builder key module was removed. That left hosts like  trying to offload builds with a missing key, while  had drifted onto a one-off  override.

## Validation
- 
- 
- 
- started  checks for  and ; both now offload to  using  instead of failing on a missing key

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vivaldi browser is now available on workstations
  * zram swap enabled for desktop hosts (compressed swap using ~50% RAM)

* **Chores**
  * Remote build integration expanded with new host/key support and associated secret entry
  * Removed legacy remote-build configuration from gateway
  * Networking reorganized for homeserver and gateway; DNS and DHCP settings adjusted
* **Style**
  * Minor SSH-related comment/import cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->