### PR TITLE
Extract workstation Linuxbrew compat setup

### DIFF
--- a/docs/pr-workstation-linuxbrew-cleanup.md
+++ b/docs/pr-workstation-linuxbrew-cleanup.md
@@ -1,0 +1,17 @@
+## Summary
+
+Extract the Linuxbrew/Homebrew compatibility activation from `hosts/nixos/workstation/default.nix` into the existing reusable `modules/activation-scripts/linux/linuxbrew-system.nix` module.
+
+## Why
+
+The workstation host file should stay focused on host-specific configuration. The Linuxbrew compatibility symlink setup is system-level plumbing and belongs with the Linuxbrew activation module, where it can be reused by other hosts.
+
+## Changes
+
+- remove inline `system.activationScripts.homebrewCompat` from workstation `default.nix`
+- extend `linuxbrew-system.nix` to also create the absolute `/bin` and `/usr/bin` compatibility links Homebrew expects
+- keep the workstation host config limited to enabling the module
+
+## Notes
+
+This is a cleanup/refactor PR only. It should not change intended behavior; it just moves Linuxbrew compatibility setup to the module that already owns Linuxbrew system preparation.

--- a/hosts/nixos/workstation/default.nix
+++ b/hosts/nixos/workstation/default.nix
@@ -63,42 +63,9 @@
   };
 
   # Homebrew is managed via home-manager (modules/home-manager/linuxbrew.nix)
-  # Create /home/linuxbrew with correct ownership for install.sh
+  # System-level Linuxbrew setup and Homebrew compatibility links live in
+  # modules/activation-scripts/linux/linuxbrew-system.nix.
   custom.activation-scripts.linux.linuxbrew-system.enable = true;
-
-  # Symlink nice to /usr/bin for Homebrew's Ruby (needed by some formulae like bd)
-  system.activationScripts.homebrewCompat = ''
-    mkdir -p /usr/bin
-    ln -sf ${pkgs.coreutils}/bin/nice /usr/bin/nice
-
-    # Homebrew's installer uses absolute /bin/* and /usr/bin/* paths.
-    mkdir -p /bin /usr/bin
-    ln -sf ${pkgs.coreutils}/bin/mkdir /bin/mkdir
-    ln -sf ${pkgs.coreutils}/bin/chmod /bin/chmod
-    ln -sf ${pkgs.coreutils}/bin/chown /bin/chown
-    ln -sf ${pkgs.coreutils}/bin/chgrp /bin/chgrp
-    ln -sf ${pkgs.coreutils}/bin/touch /bin/touch
-    ln -sf ${pkgs.coreutils}/bin/readlink /bin/readlink
-    ln -sf ${pkgs.coreutils}/bin/cat /bin/cat
-    ln -sf ${pkgs.coreutils}/bin/sort /bin/sort
-    ln -sf ${pkgs.coreutils}/bin/mv /bin/mv
-    ln -sf ${pkgs.coreutils}/bin/rm /bin/rm
-    ln -sf ${pkgs.coreutils}/bin/ln /bin/ln
-    ln -sf ${pkgs.coreutils}/bin/dirname /bin/dirname
-    ln -sf ${pkgs.coreutils}/bin/basename /bin/basename
-    ln -sf ${pkgs.coreutils}/bin/uname /bin/uname
-    ln -sf ${pkgs.coreutils}/bin/sha256sum /bin/sha256sum
-    ln -sf ${pkgs.gnutar}/bin/tar /bin/tar
-    ln -sf ${pkgs.gzip}/bin/gzip /bin/gzip
-    ln -sf ${pkgs.gnugrep}/bin/grep /bin/grep
-    ln -sf ${pkgs.util-linux}/bin/flock /usr/bin/flock
-    ln -sf ${pkgs.bash}/bin/bash /bin/bash
-    ln -sf ${pkgs.coreutils}/bin/stat /usr/bin/stat
-    ln -sf ${pkgs.coreutils}/bin/cut /usr/bin/cut
-    ln -sf ${pkgs.coreutils}/bin/dirname /usr/bin/dirname
-    ln -sf ${pkgs.coreutils}/bin/sha256sum /usr/bin/sha256sum
-    ln -sf ${pkgs.glibc.bin}/bin/ldd /usr/bin/ldd
-  '';
 
   # Linux-specific wezterm configuration
   programs.wezterm.extraConfig = lib.mkAfter ''

--- a/modules/activation-scripts/linux/linuxbrew-system.nix
+++ b/modules/activation-scripts/linux/linuxbrew-system.nix
@@ -7,7 +7,35 @@
 
 let
   cfg = config.custom.activation-scripts.linux.linuxbrew-system;
-  
+  compatLinks = [
+    [ "${pkgs.coreutils}/bin/nice" "/usr/bin/nice" ]
+    [ "${pkgs.coreutils}/bin/mkdir" "/bin/mkdir" ]
+    [ "${pkgs.coreutils}/bin/chmod" "/bin/chmod" ]
+    [ "${pkgs.coreutils}/bin/chown" "/bin/chown" ]
+    [ "${pkgs.coreutils}/bin/chgrp" "/bin/chgrp" ]
+    [ "${pkgs.coreutils}/bin/touch" "/bin/touch" ]
+    [ "${pkgs.coreutils}/bin/readlink" "/bin/readlink" ]
+    [ "${pkgs.coreutils}/bin/cat" "/bin/cat" ]
+    [ "${pkgs.coreutils}/bin/sort" "/bin/sort" ]
+    [ "${pkgs.coreutils}/bin/mv" "/bin/mv" ]
+    [ "${pkgs.coreutils}/bin/rm" "/bin/rm" ]
+    [ "${pkgs.coreutils}/bin/ln" "/bin/ln" ]
+    [ "${pkgs.coreutils}/bin/dirname" "/bin/dirname" ]
+    [ "${pkgs.coreutils}/bin/basename" "/bin/basename" ]
+    [ "${pkgs.coreutils}/bin/uname" "/bin/uname" ]
+    [ "${pkgs.coreutils}/bin/sha256sum" "/bin/sha256sum" ]
+    [ "${pkgs.gnutar}/bin/tar" "/bin/tar" ]
+    [ "${pkgs.gzip}/bin/gzip" "/bin/gzip" ]
+    [ "${pkgs.gnugrep}/bin/grep" "/bin/grep" ]
+    [ "${pkgs.bash}/bin/bash" "/bin/bash" ]
+    [ "${pkgs.util-linux}/bin/flock" "/usr/bin/flock" ]
+    [ "${pkgs.coreutils}/bin/stat" "/usr/bin/stat" ]
+    [ "${pkgs.coreutils}/bin/cut" "/usr/bin/cut" ]
+    [ "${pkgs.coreutils}/bin/dirname" "/usr/bin/dirname" ]
+    [ "${pkgs.coreutils}/bin/sha256sum" "/usr/bin/sha256sum" ]
+    [ "${pkgs.glibc.bin}/bin/ldd" "/usr/bin/ldd" ]
+  ];
+
   linuxbrewSystemScript = pkgs.writeShellScript "linuxbrew-system.sh" ''
     # Create linuxbrew directory with proper permissions
     if [ ! -d /home/linuxbrew ]; then
@@ -21,6 +49,10 @@ let
         chmod 755 /home/linuxbrew
       fi
     fi
+
+    # Homebrew's installer expects a handful of absolute /bin and /usr/bin paths.
+    mkdir -p /bin /usr/bin
+    ${lib.concatMapStringsSep "\n" (link: ''ln -sf ${builtins.elemAt link 0} ${builtins.elemAt link 1}'') compatLinks}
   '';
 in
 {
@@ -30,7 +62,7 @@ in
 
   config = lib.mkIf cfg.enable {
     system.activationScripts.linuxbrew.text = lib.mkAfter ''
-      echo "Running Linuxbrew system setup script..."
+      echo "Running Linuxbrew system setup script and compatibility link setup..."
       ${linuxbrewSystemScript}
     '';
   };


### PR DESCRIPTION
## Summary
Extract the Linuxbrew/Homebrew compatibility activation from  into the existing reusable  module.

## Why
The workstation host file should stay focused on host-specific configuration. The Linuxbrew compatibility symlink setup is system-level plumbing and belongs with the Linuxbrew activation module, where it can be reused by other hosts.

## Changes
- remove inline  from workstation 
- extend  to also create the absolute  and  compatibility links Homebrew expects
- keep the workstation host config limited to enabling the module

## Notes
This is a cleanup/refactor PR only. It should not change intended behavior; it just moves Linuxbrew compatibility setup to the module that already owns Linuxbrew system preparation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
