### PR TITLE
Add RTK to common coding-agent tooling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -558,6 +558,24 @@
         "type": "github"
       }
     },
+    "flake-utils_12": {
+      "inputs": {
+        "systems": "systems_15"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_3"
@@ -1053,6 +1071,27 @@
         "type": "github"
       }
     },
+    "nix-rtk": {
+      "inputs": {
+        "flake-utils": "flake-utils_8",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774000575,
+        "narHash": "sha256-byzJd1FJ0DFxvHTkwEK6K7yPNE7pzR3tbQiERaPqdW0=",
+        "owner": "deepwatrcreatur",
+        "repo": "nix-rtk",
+        "rev": "7879f6dc1d289bef54c2d7f39c4471a6e5376f58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "deepwatrcreatur",
+        "repo": "nix-rtk",
+        "type": "github"
+      }
+    },
     "nix-semaphore": {
       "inputs": {
         "nixpkgs": [
@@ -1097,7 +1136,7 @@
     },
     "nix-whitesur-config": {
       "inputs": {
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_9",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1118,7 +1157,7 @@
     },
     "nixbit": {
       "inputs": {
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_10",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1402,6 +1441,7 @@
         "nix-lightpanda": "nix-lightpanda",
         "nix-linuxbrew": "nix-linuxbrew",
         "nix-router-optimized": "nix-router-optimized",
+        "nix-rtk": "nix-rtk",
         "nix-semaphore": "nix-semaphore",
         "nix-snapd": "nix-snapd",
         "nix-whitesur-config": "nix-whitesur-config",
@@ -1548,6 +1588,21 @@
         "type": "github"
       }
     },
+    "systems_15": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "systems_2": {
       "locked": {
         "lastModified": 1681028828,
@@ -1670,7 +1725,7 @@
     },
     "tesla-inference-flake": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
+        "flake-utils": "flake-utils_11",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1752,7 +1807,7 @@
     },
     "zellij-vivid-rounded": {
       "inputs": {
-        "flake-utils": "flake-utils_11",
+        "flake-utils": "flake-utils_12",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    nix-rtk = {
+      url = "github:deepwatrcreatur/nix-rtk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     nixbit = {
       url = "github:pbek/nixbit";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/home-manager/common/coding-agents.nix
+++ b/modules/home-manager/common/coding-agents.nix
@@ -15,5 +15,6 @@ in
   home.packages = [
     pkgs.claude-monitor
     inputs.claude-statusline-flake.packages.${pkgs.stdenv.hostPlatform.system}.default
+    inputs.nix-rtk.packages.${pkgs.stdenv.hostPlatform.system}.default
   ] ++ map (agent: agent.package) codingAgents;
 }


### PR DESCRIPTION
Summary
- add the nix-rtk flake as an input
- install rtk from that flake in the shared Home Manager coding-agent package set
- lock the new input in flake.lock

Verification
- built nix-rtk successfully and verified rtk 0.31.0
- evaluated the Home Manager package set after adding the new flake input

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new development tool (`nix-rtk`) to the system configuration, making it available as part of the coding environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->