### PR TITLE
Enable RTK integrations on workstation

### DIFF
--- a/users/deepwatrcreatur/hosts/workstation/default.nix
+++ b/users/deepwatrcreatur/hosts/workstation/default.nix
@@ -22,6 +22,13 @@
 
   programs.dmux.enable = true;
 
+  programs.coding-agents.rtk.integrations = {
+    claude.enable = true;
+    codex.enable = true;
+    gemini.enable = true;
+    opencode.enable = true;
+  };
+
   services.agenix-user-secrets = {
     enable = true;
     secrets = {


### PR DESCRIPTION
## Summary
- update unified-nix-configuration to the latest nix-coding-agents revision
- enable RTK integrations for Claude, Codex, Gemini, and OpenCode on the workstation user config
- keep the change isolated to workstation-scoped Home Manager settings

## Verification
- nix eval .#nixosConfigurations.workstation.config.home-manager.users.deepwatrcreatur.programs.coding-agents.rtk.integrations.claude.enable

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled RTK integrations for coding agents, adding built‑in support for Claude, Codex, Gemini, and OpenCode.
  * These integrations are now active by default, allowing immediate use of the supported agents without additional configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->