### PR TITLE
just: align recipes with current flake outputs

### DIFF
--- a/modules/home-manager/common/just.nix
+++ b/modules/home-manager/common/just.nix
@@ -92,7 +92,7 @@ let
 
     # Update macOS system using nh helper
     nh-update:
-        nh darwin switch
+        nh darwin switch -H ${hostname} -f $NH_FLAKE
 
     # Build macOS system without switching
     build-darwin:
@@ -140,7 +140,7 @@ let
 
     # Update NixOS system using nh helper
     nh-update:
-        PATH="/run/current-system/sw/bin:$PATH" nh os switch
+        PATH="/run/current-system/sw/bin:$PATH" nh os switch -H ${hostname} -f $NH_FLAKE
 
     # Build NixOS system without switching
     build-nixos:

--- a/users/deepwatrcreatur/hosts/attic-cache/justfile
+++ b/users/deepwatrcreatur/hosts/attic-cache/justfile
@@ -6,4 +6,4 @@ update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
   sudo nixos-rebuild switch --flake {{dir}}#{{`hostname`}}
 
 nh-update:
-  nh os switch
+  nh os switch -H attic-cache -f /home/deepwatrcreatur/flakes/unified-nix-configuration

--- a/users/deepwatrcreatur/hosts/homeserver/justfile
+++ b/users/deepwatrcreatur/hosts/homeserver/justfile
@@ -7,7 +7,7 @@ update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
 
 # Rebuild using nh (nicer output)
 nh-update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
-  nh os switch {{dir}} -- --flake {{dir}}#homeserver
+  nh os switch -H homeserver -f {{dir}}
 
 # Test build without switching
 test dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
@@ -19,7 +19,7 @@ build dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
 
 # Pull latest and rebuild
 pull-update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
-  cd {{dir}} && git pull && just update
+  cd {{dir}} && git pull --ff-only origin main && just update dir={{dir}}
 
 # Garbage collect old generations
 gc:

--- a/users/deepwatrcreatur/hosts/inference-vm/justfile
+++ b/users/deepwatrcreatur/hosts/inference-vm/justfile
@@ -6,4 +6,4 @@ update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
   /run/wrappers/bin/sudo nixos-rebuild switch --flake {{dir}}#{{`hostname`}}
 
 nh-update:
-  nh os switch
+  nh os switch -H {{`hostname`}} -f /home/deepwatrcreatur/flakes/unified-nix-configuration

--- a/users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/justfile
+++ b/users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/justfile
@@ -4,4 +4,4 @@ update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
   /run/wrappers/bin/sudo nixos-rebuild switch --flake {{dir}}#homeserver
 
 nh-update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
-  nix --experimental-features 'nix-command flakes' run 'github:viperML/nh' -- os switch -H homeserver -f {{dir}}
+  nh os switch -H {{`hostname`}} -f {{dir}}

--- a/users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/justfile
+++ b/users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/justfile
@@ -4,4 +4,4 @@ update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
   /run/wrappers/bin/sudo nixos-rebuild switch --flake {{dir}}#homeserver
 
 nh-update dir="/home/deepwatrcreatur/flakes/unified-nix-configuration":
-  nix --experimental-features 'nix-command flakes' run 'github:viperML/nh' -- os switch {{dir}} -- --flake {{dir}}#homeserver
+  nix --experimental-features 'nix-command flakes' run 'github:viperML/nh' -- os switch -H homeserver -f {{dir}}

--- a/users/root/hosts/attic-cache/justfile
+++ b/users/root/hosts/attic-cache/justfile
@@ -1,4 +1,4 @@
 # users/root/hosts/cache-build-server/justfile
 
 update:
-  nixos-rebuild switch --flake /root/flakes/unified-nix-configuration
+  nixos-rebuild switch --flake /root/flakes/unified-nix-configuration#attic-cache

--- a/users/root/hosts/attic-cache/justfile
+++ b/users/root/hosts/attic-cache/justfile
@@ -1,4 +1,4 @@
-# users/root/hosts/cache-build-server/justfile
+# users/root/hosts/attic-cache/justfile
 
 update:
   nixos-rebuild switch --flake /root/flakes/unified-nix-configuration#attic-cache

--- a/users/root/hosts/proxmox/justfile
+++ b/users/root/hosts/proxmox/justfile
@@ -5,4 +5,4 @@ update:
   home-manager switch --flake $NH_FLAKE#proxmox-root
 
 nh-update:
-  nh home switch $NH_FLAKE#homeConfigurations.proxmox-root.activationPackage
+  nh home switch $NH_FLAKE#proxmox-root


### PR DESCRIPTION
## Summary
- update shared nh recipes to pass explicit host and flake path
- fix host-specific justfiles that still used stale nh or implicit flake targets
- make homeserver pull-update fast-forward main explicitly

## Notes
- this is a narrow follow-up after the flake output/inventory refactor
- no behavior change to output names themselves; this only updates the shell recipes that invoke them
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * System update commands now pass explicit host (-H) and flake (-f) targets to the updater, ensuring updates apply to the intended host/configuration.
  * One update path simplified to call the updater directly (removing an indirect wrapper).
  * Update targets refined to specific configuration outputs where applicable.
  * Git pulls constrained to fast-forward-only and now pass the update directory explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->