### PR TITLE
feat(ci): add GitHub Actions checks + LXC networking invariant

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,26 @@
+name: Nix checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  inventory-checks:
+    name: Inventory & module checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: inventory-consistency
+        run: nix build .#checks.x86_64-linux.inventory-consistency --no-link --print-build-logs
+
+      - name: module-loading-eval
+        run: nix build .#checks.x86_64-linux.module-loading-eval --no-link --print-build-logs
+
+      - name: ssh-keys-manager-eval
+        run: nix build .#checks.x86_64-linux.ssh-keys-manager-eval --no-link --print-build-logs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v16
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: inventory-consistency
         run: nix build .#checks.x86_64-linux.inventory-consistency --no-link --print-build-logs

--- a/flake.lock
+++ b/flake.lock
@@ -1139,11 +1139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774660314,
-        "narHash": "sha256-umf6TtAFoC4Il1f8q47cO6ymfmA/YqG2hRdb8n+lAMM=",
+        "lastModified": 1774662670,
+        "narHash": "sha256-NGM4+5IEmwq2HUwl6e3+cVU9R6owVc3BLEilORm7ySI=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "6c784df7c98d9c5a808336f91fe492252614add2",
+        "rev": "7098d903ce0f550ba893e635a1b49411837eed11",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -72,7 +72,7 @@
         "flake-compat": "flake-compat_3",
         "flake-parts": "flake-parts_4",
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -189,7 +189,7 @@
     "cl-nix-lite": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "systems": "systems_8",
         "treefmt-nix": "treefmt-nix_2"
       },
@@ -873,7 +873,9 @@
         "blueprint": "blueprint",
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "systems": "systems_7",
         "treefmt-nix": "treefmt-nix"
       },
@@ -1401,22 +1403,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1766736597,
         "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
         "owner": "nixos",
@@ -1427,6 +1413,22 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1761236834,
+        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1449,22 +1451,6 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1761236834,
-        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
         "lastModified": 1751949589,
         "narHash": "sha256-mgFxAPLWw0Kq+C8P3dRrZrOYEQXOtKuYVlo9xvPntt8=",
         "owner": "NixOS",
@@ -1479,7 +1465,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1773814637,
         "narHash": "sha256-GNU+ooRmrHLfjlMsKdn0prEKVa0faVanm0jrgu1J/gY=",
@@ -1546,7 +1532,7 @@
         "nix-snapd": "nix-snapd",
         "nix-whitesur-config": "nix-whitesur-config",
         "nixbit": "nixbit",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
@@ -1852,7 +1838,7 @@
     },
     "treefmt-nix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1766000401,
@@ -1870,7 +1856,7 @@
     },
     "treefmt-nix_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1766000401,

--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -170,6 +170,32 @@ let
           [ ])
       inventoryHosts;
 
+  # Assert that every aspect host using lxc-core has an explicit networking aspect.
+  # lxc-core sets up the container base but deliberately does not configure networking,
+  # so each LXC host must opt into a networking aspect.  Hosts that use externally
+  # managed static IP (e.g. set by Proxmox) must be explicitly listed below.
+  lxcStaticNetworkingHosts = [
+    "podman"   # static IP assigned by Proxmox DHCP reservation
+    "rustdesk" # static IP assigned by Proxmox DHCP reservation
+  ];
+
+  knownNetworkingAspects = [
+    "lxc-dhcp-networking"
+    "homeserver-networking"
+  ];
+
+  lxcHostsMissingNetworking =
+    builtins.filter
+      (name:
+        let
+          aspects = hostAspectLists.${name};
+          hasLxcCore = builtins.elem "lxc-core" aspects;
+          hasNetworkingAspect = builtins.any (a: builtins.elem a knownNetworkingAspects) aspects;
+          isStaticException = builtins.elem name lxcStaticNetworkingHosts;
+        in
+        hasLxcCore && !hasNetworkingAspect && !isStaticException)
+      aspectInventoryHostNames;
+
   unknownAspectRefs =
     builtins.concatLists (
       pkgs.lib.mapAttrsToList
@@ -215,6 +241,10 @@ let
     ++ (if duplicateIpsExist then [ "Duplicate IP addresses detected in lib/hosts.nix" ] else [ ])
     ++ (if serviceNameCollisions != [ ] then
       [ "Service names in lib/hosts.nix collide with machine hostnames (a CNAME and an A record cannot share a label): ${builtins.concatStringsSep ", " serviceNameCollisions}" ]
+    else
+      [ ])
+    ++ (if lxcHostsMissingNetworking != [ ] then
+      [ "LXC hosts use lxc-core without a networking aspect and are not in lxcStaticNetworkingHosts: ${builtins.concatStringsSep ", " lxcHostsMissingNetworking}" ]
     else
       [ ]);
 


### PR DESCRIPTION
## Summary

- **Add GitHub Actions CI** (`.github/workflows/check.yml`): runs the three nix evaluation checks on every PR and push to main using the DeterminateSystems installer + magic-nix-cache
- **Add LXC networking invariant check**: asserts every host using `lxc-core` has an explicit networking aspect (`lxc-dhcp-networking` or `homeserver-networking`); hosts with Proxmox-managed static IPs (`podman`, `rustdesk`) are in an explicit allowlist

## Context

This repo has three evaluation-only checks in `outputs/checks.nix`:
- `inventory-consistency` — validates den inventory structure, host/service name collisions, legacy host allowlist, proxmox leaves, aspect references
- `module-loading-eval` — tests the auto-import helper functions
- `ssh-keys-manager-eval` — tests module evaluation for the SSH keys manager

Until now these only ran locally. This PR wires them to CI so they run on every PR.

The new `lxcHostsMissingNetworking` check closes a gap noted in `docs/improvements.md` (item D): `lxc-core` sets up the NixOS LXC container base but leaves networking unconfigured by design. Each LXC host must explicitly declare a networking aspect — this check enforces that going forward.

## Test plan

- [ ] CI passes on this PR (all three checks green)
- [ ] Verify `inventory-consistency` output includes the non-fatal notice about missing machine-identity keys (inference1/2/3, phoenix, rustdesk) — those are pre-existing gaps, not regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented new automated CI workflow that executes system consistency and configuration validation checks on all pull requests and commits to the main branch
  * Enhanced validation logic to verify that LXC hosts maintain required networking component configuration, with appropriate exceptions for specific host setups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->