### PR TITLE
refactor(inference): migrate inference-fresh to den aspect; extract NVIDIA module

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,26 @@
+name: Nix checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  inventory-checks:
+    name: Inventory & module checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: inventory-consistency
+        run: nix build .#checks.x86_64-linux.inventory-consistency --no-link --print-build-logs
+
+      - name: module-loading-eval
+        run: nix build .#checks.x86_64-linux.module-loading-eval --no-link --print-build-logs
+
+      - name: ssh-keys-manager-eval
+        run: nix build .#checks.x86_64-linux.ssh-keys-manager-eval --no-link --print-build-logs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v16
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: inventory-consistency
         run: nix build .#checks.x86_64-linux.inventory-consistency --no-link --print-build-logs

--- a/den/aspects/default.nix
+++ b/den/aspects/default.nix
@@ -19,5 +19,6 @@
   podman-lxc-suppressions = context: import ./podman-lxc-suppressions.nix context;
   workstation-desktop = context: import ./workstation-desktop.nix context;
   inference-vm-base = context: import ./inference-vm-base.nix context;
+  inference-vm-nvidia = context: import ./inference-vm-nvidia.nix context;
   inference1-ollama = context: import ./inference1-ollama.nix context;
 }

--- a/den/aspects/inference-vm-nvidia.nix
+++ b/den/aspects/inference-vm-nvidia.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{ ... }:
+{
+  imports = [
+    ../../hosts/nixos/inference-vm/modules/inference-vm-nvidia.nix
+  ];
+}

--- a/den/hosts/inference-fresh/default.nix
+++ b/den/hosts/inference-fresh/default.nix
@@ -3,20 +3,20 @@ let
   den = import ../../lib.nix { inherit lib; };
 in
 den.mkHostModule {
-  name = "inference2";
+  name = "inference-fresh";
   primaryUser = "deepwatrcreatur";
   extraImports = [
-    ../../../hosts/nixos/inference-vm/hosts/inference2/hardware-configuration.nix
+    ../../../hosts/nixos/inference-vm/hosts/inference-fresh/hardware-configuration.nix
     (
       { ... }:
       {
-        networking.hostName = "inference2";
+        networking.hostName = "inference-fresh";
         boot.growPartition = true;
       }
     )
   ];
+  # No inference-vm-nvidia: this host has no GPU and runs without NVIDIA drivers.
   aspectsList = [
     "inference-vm-base"
-    "inference-vm-nvidia"
   ];
 }

--- a/den/hosts/inference1/default.nix
+++ b/den/hosts/inference1/default.nix
@@ -17,6 +17,7 @@ den.mkHostModule {
   ];
   aspectsList = [
     "inference-vm-base"
+    "inference-vm-nvidia"
     "inference1-ollama"
   ];
 }

--- a/den/hosts/inference3/default.nix
+++ b/den/hosts/inference3/default.nix
@@ -17,5 +17,6 @@ den.mkHostModule {
   ];
   aspectsList = [
     "inference-vm-base"
+    "inference-vm-nvidia"
   ];
 }

--- a/den/inventory/hosts.nix
+++ b/den/inventory/hosts.nix
@@ -60,8 +60,8 @@
     kind = "nixos";
     name = "inference-fresh";
     system = "x86_64-linux";
-    hostPath = ../../hosts/nixos/inference-vm/hosts/inference-fresh;
-    mode = "legacy";
+    hostPath = ../hosts/inference-fresh;
+    mode = "aspect";
   };
 
   podman = {

--- a/flake.lock
+++ b/flake.lock
@@ -1139,11 +1139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774660314,
-        "narHash": "sha256-umf6TtAFoC4Il1f8q47cO6ymfmA/YqG2hRdb8n+lAMM=",
+        "lastModified": 1774662670,
+        "narHash": "sha256-NGM4+5IEmwq2HUwl6e3+cVU9R6owVc3BLEilORm7ySI=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "6c784df7c98d9c5a808336f91fe492252614add2",
+        "rev": "7098d903ce0f550ba893e635a1b49411837eed11",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -72,7 +72,7 @@
         "flake-compat": "flake-compat_3",
         "flake-parts": "flake-parts_4",
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -189,7 +189,7 @@
     "cl-nix-lite": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "systems": "systems_8",
         "treefmt-nix": "treefmt-nix_2"
       },
@@ -873,7 +873,9 @@
         "blueprint": "blueprint",
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "systems": "systems_7",
         "treefmt-nix": "treefmt-nix"
       },
@@ -1401,22 +1403,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1766736597,
         "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
         "owner": "nixos",
@@ -1427,6 +1413,22 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1761236834,
+        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1449,22 +1451,6 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1761236834,
-        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
         "lastModified": 1751949589,
         "narHash": "sha256-mgFxAPLWw0Kq+C8P3dRrZrOYEQXOtKuYVlo9xvPntt8=",
         "owner": "NixOS",
@@ -1479,7 +1465,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1773814637,
         "narHash": "sha256-GNU+ooRmrHLfjlMsKdn0prEKVa0faVanm0jrgu1J/gY=",
@@ -1546,7 +1532,7 @@
         "nix-snapd": "nix-snapd",
         "nix-whitesur-config": "nix-whitesur-config",
         "nixbit": "nixbit",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
@@ -1852,7 +1838,7 @@
     },
     "treefmt-nix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1766000401,
@@ -1870,7 +1856,7 @@
     },
     "treefmt-nix_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1766000401,

--- a/hosts/nixos/inference-vm/default.nix
+++ b/hosts/nixos/inference-vm/default.nix
@@ -13,7 +13,7 @@ let
     let
       items = builtins.readDir dir;
       isNixFile = name: type: type == "regular" && lib.hasSuffix ".nix" name;
-      excludeList = [ "gpu-infrastructure.nix" "ollama.nix" "llama-cpp.nix" ];
+      excludeList = [ "gpu-infrastructure.nix" "ollama.nix" "llama-cpp.nix" "inference-vm-nvidia.nix" ];
       shouldInclude = name: !(builtins.elem name excludeList);
       nixFileNames = lib.filter shouldInclude (lib.attrNames (lib.filterAttrs isNixFile items));
     in

--- a/hosts/nixos/inference-vm/modules/configuration.nix
+++ b/hosts/nixos/inference-vm/modules/configuration.nix
@@ -24,29 +24,12 @@
 
   my.root-ssh-identity.enable = true;
 
-  # Nixpkgs configuration
-  nixpkgs = {
-    config.allowUnfree = true;
-    config.allowUnsupportedSystem = true; # Allow unsupported packages like cuDNN
-    config.cudaForwardCompat = false; # Skip cuda_compat build
-  };
+  # Nixpkgs configuration — GPU-specific flags live in inference-vm-nvidia.nix
+  nixpkgs.config.allowUnfree = true;
 
   # Attic client configuration (using agenix for token)
   # The nix-attic-infra module is disabled since it requires sops-nix internally
   # Configure attic manually via the attic CLI using the token from agenix
-
-  # GPU Infrastructure configuration - Tesla P40 optimized
-  hardware.nvidia = {
-    modesetting.enable = true;
-    powerManagement.enable = false; # Disable for Tesla P40 stability
-    open = false; # Use proprietary driver
-  };
-  hardware.graphics.enable = true;
-
-  # Add OpenWebUI package for web interface to Ollama
-  environment.systemPackages = with pkgs; [
-    open-webui # Web interface for Ollama
-  ];
 
   # Base VM configuration for inference machines and services
   services = {
@@ -98,5 +81,4 @@
   networking.firewall.enable = false;
 
   system.stateVersion = "25.05";
-  services.xserver.videoDrivers = [ "nvidia" ];
 }

--- a/hosts/nixos/inference-vm/modules/inference-vm-nvidia.nix
+++ b/hosts/nixos/inference-vm/modules/inference-vm-nvidia.nix
@@ -1,0 +1,22 @@
+{ pkgs, ... }:
+
+# NVIDIA driver configuration for GPU inference VMs (Tesla P40 / Pascal class).
+# Separated from configuration.nix so that non-GPU inference hosts (e.g.
+# inference-fresh) can use inference-vm-base without pulling in NVIDIA drivers.
+{
+  nixpkgs.config.allowUnsupportedSystem = true; # allow cuDNN and CUDA packages
+  nixpkgs.config.cudaForwardCompat = false; # skip cuda_compat build overhead
+
+  hardware.nvidia = {
+    modesetting.enable = true;
+    powerManagement.enable = false; # disable for Tesla P40 stability
+    open = false; # use proprietary driver
+  };
+  hardware.graphics.enable = true;
+  services.xserver.videoDrivers = [ "nvidia" ];
+
+  # OpenWebUI — web interface for Ollama; only meaningful with GPU-backed inference
+  environment.systemPackages = with pkgs; [
+    open-webui
+  ];
+}

--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -27,7 +27,6 @@ let
   inventoryHomeNames = names inventoryHomes;
   legacyHostAllowlist = [
     "gateway"
-    "inference-fresh"
   ];
 
   hostNamesExpectedInLib =

--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -170,6 +170,32 @@ let
           [ ])
       inventoryHosts;
 
+  # Assert that every aspect host using lxc-core has an explicit networking aspect.
+  # lxc-core sets up the container base but deliberately does not configure networking,
+  # so each LXC host must opt into a networking aspect.  Hosts that use externally
+  # managed static IP (e.g. set by Proxmox) must be explicitly listed below.
+  lxcStaticNetworkingHosts = [
+    "podman"   # static IP assigned by Proxmox DHCP reservation
+    "rustdesk" # static IP assigned by Proxmox DHCP reservation
+  ];
+
+  knownNetworkingAspects = [
+    "lxc-dhcp-networking"
+    "homeserver-networking"
+  ];
+
+  lxcHostsMissingNetworking =
+    builtins.filter
+      (name:
+        let
+          aspects = hostAspectLists.${name};
+          hasLxcCore = builtins.elem "lxc-core" aspects;
+          hasNetworkingAspect = builtins.any (a: builtins.elem a knownNetworkingAspects) aspects;
+          isStaticException = builtins.elem name lxcStaticNetworkingHosts;
+        in
+        hasLxcCore && !hasNetworkingAspect && !isStaticException)
+      aspectInventoryHostNames;
+
   unknownAspectRefs =
     builtins.concatLists (
       pkgs.lib.mapAttrsToList
@@ -215,6 +241,10 @@ let
     ++ (if duplicateIpsExist then [ "Duplicate IP addresses detected in lib/hosts.nix" ] else [ ])
     ++ (if serviceNameCollisions != [ ] then
       [ "Service names in lib/hosts.nix collide with machine hostnames (a CNAME and an A record cannot share a label): ${builtins.concatStringsSep ", " serviceNameCollisions}" ]
+    else
+      [ ])
+    ++ (if lxcHostsMissingNetworking != [ ] then
+      [ "LXC hosts use lxc-core without a networking aspect and are not in lxcStaticNetworkingHosts: ${builtins.concatStringsSep ", " lxcHostsMissingNetworking}" ]
     else
       [ ]);
 


### PR DESCRIPTION
## Summary

- **Extract NVIDIA/GPU config** from the shared `inference-vm/modules/configuration.nix` into a new `inference-vm-nvidia.nix` module — `hardware.nvidia`, `hardware.graphics`, `services.xserver.videoDrivers`, CUDA nixpkgs flags, and `open-webui`
- **Add `inference-vm-nvidia` aspect** so GPU hosts opt in explicitly; add it to inference1/2/3
- **Migrate `inference-fresh`** from legacy to den aspect model using only `inference-vm-base` (no GPU drivers)
- **Remove `inference-fresh` from `legacyHostAllowlist`** — only `gateway` remains in the legacy allowlist

## Why

`inference-fresh` is a test/fresh-install inference VM with no GPU. It was blocked from using `inference-vm-base` because that aspect pulled in NVIDIA drivers via the shared `configuration.nix`. This PR fixes the root cause by separating GPU config from base config, then migrates the host.

## Inventory check before / after

| metric | before | after |
|---|---|---|
| `checked-legacy-hosts` | 2 | **1** |
| `checked-den-aspect-hosts` | 10 | **11** |

## Test plan

- [ ] CI passes (inventory-consistency, module-loading-eval, ssh-keys-manager-eval)
- [ ] Verify inference1/2/3 aspectsLists still include `inference-vm-nvidia` — GPU behaviour unchanged
- [ ] `inference-fresh` builds without NVIDIA options (evaluation only; no hardware to test against)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation checks for infrastructure configuration.
  * New `inference-fresh` host configuration for CPU-only inference VM deployments.
  * Made NVIDIA GPU support modular and optional for inference VM environments.

* **Chores**
  * Refactored GPU-specific configurations into separate, optional components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->