### PR TITLE
feat(checks): enforce nixos-base aspect on non-LXC hosts

### DIFF
--- a/den/inventory/hosts.nix
+++ b/den/inventory/hosts.nix
@@ -22,6 +22,7 @@
     hostPath = ../hosts/attic-cache;
     mode = "aspect";
     aspectsList = [
+      "nixos-base"
       "attic-cache-core"
       "attic-cache-build-server"
       "attic-cache-home-manager"

--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -187,6 +187,31 @@ let
         hasLxcCore && !hasNetworkingAspect && !isStaticException)
       aspectInventoryHostNames;
 
+  # Non-LXC aspect hosts that are missing the "nixos-base" aspect.
+  # nixos-base imports hosts/nixos/default.nix which sets the required base
+  # (timezone, openssh defaults).  Hosts that provide equivalent coverage
+  # through a specialised base aspect are listed in nixosBaseExemptHosts.
+  nixosBaseExemptHosts = [
+    # inference-vm-base imports hosts/nixos/inference-vm which provides its
+    # own base configuration tailored for inference workloads.
+    "inference1"
+    "inference2"
+    "inference3"
+    "inference-fresh"
+  ];
+
+  nonLxcHostsMissingNixosBase =
+    builtins.filter
+      (name:
+        let
+          aspects = hostAspectLists.${name};
+          hasLxcCore = builtins.elem "lxc-core" aspects;
+          hasNixosBase = builtins.elem "nixos-base" aspects;
+          isExempt = builtins.elem name nixosBaseExemptHosts;
+        in
+        !hasLxcCore && !hasNixosBase && !isExempt)
+      aspectInventoryHostNames;
+
   unknownAspectRefs =
     builtins.concatLists (
       pkgs.lib.mapAttrsToList
@@ -236,6 +261,10 @@ let
       [ ])
     ++ (if lxcHostsMissingNetworking != [ ] then
       [ "LXC hosts use lxc-core without a networking aspect and are not in lxcStaticNetworkingHosts: ${builtins.concatStringsSep ", " lxcHostsMissingNetworking}" ]
+    else
+      [ ])
+    ++ (if nonLxcHostsMissingNixosBase != [ ] then
+      [ "Non-LXC aspect hosts missing the nixos-base aspect (add nixos-base or add to nixosBaseExemptHosts with justification): ${builtins.concatStringsSep ", " nonLxcHostsMissingNixosBase}" ]
     else
       [ ]);
 


### PR DESCRIPTION
## Summary

- Adds an `inventory-consistency` assertion: every non-LXC aspect-mode NixOS host must include the `nixos-base` aspect (which imports `hosts/nixos/default.nix` — timezone, openssh defaults)
- Exempts `inference{1,2,3}-fresh` which are covered by `inference-vm-base` (their own base)
- Adds `nixos-base` to `attic-cache`'s `aspectsList` — `attic-cache-core` already imports the same file, making this declaratively explicit and idempotent

This closes item D from the improvements backlog.

## Test plan

- [x] `nix build .#checks.x86_64-linux.inventory-consistency` passes
- [ ] Verify new hosts added to the inventory are rejected by CI if they omit `nixos-base` without a justified exemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated attic-cache host provisioning configuration to include additional provisioning aspects.
  * Added validation checks to ensure non-LXC aspect hosts are properly configured with required infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->