### PR TITLE
feat(gateway): wire NTP server via DHCP option 42

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1159,11 +1159,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774665971,
-        "narHash": "sha256-wBaPJ5V+PYUS+PnaZEv3gTXNkVmwvvW0SaIzc1gCN4w=",
+        "lastModified": 1774719620,
+        "narHash": "sha256-Zt2KJxAbPJr9On9A451W7Sk0wa72YfrsTXNEOiIWEnw=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "cf7d52b8d028255c21480e6175f40025d0b32e9f",
+        "rev": "5645062f3b8937d7befa8ef4d4935096438b6875",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/gateway/networking.nix
+++ b/hosts/nixos/gateway/networking.nix
@@ -12,6 +12,8 @@
     enable = true;
     provider = "technitium";
     searchDomains = [ "deepwatercreature.com" ];
+    # Advertise the gateway's chrony instance to all LAN clients via DHCP option 42.
+    ntpServers = [ "10.10.10.1" ];
     technitium = {
       blockListPresets = [
         "hagezi-normal"


### PR DESCRIPTION
## Summary

- Sets `services.router-dns-service.ntpServers = ["10.10.10.1"]` in the gateway networking config
- This will cause a `technitium-sync-ntp-option` systemd service to push the gateway's chrony address to all Technitium DHCP scopes as option 42 on activation
- Clients that renew their DHCP lease will automatically discover the local NTP server

**Depends on:** [nix-router-optimized PR #1](https://github.com/deepwatrcreatur/nix-router-optimized/pull/1) — the `ntpServers` option must be in the upstream module before this flake lock is updated.

Closes item G from the improvements backlog.

## Test plan

- [ ] Merge nix-router-optimized PR #1 and update flake lock
- [ ] `nixos-rebuild test` on gateway — verify `technitium-sync-ntp-option.service` succeeds
- [ ] Check Technitium web UI: DHCP scope → Options → option 42 shows `10.10.10.1`
- [ ] Renew a client lease and verify it receives NTP server `10.10.10.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gateway network configuration to advertise the designated time server to clients on the local network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->