### PR TITLE
feat: wrap gh, bw, and attic with fnox

### DIFF
--- a/modules/home-manager/bitwarden-cli.nix
+++ b/modules/home-manager/bitwarden-cli.nix
@@ -47,7 +47,7 @@ in
       home.packages = lib.optionals pkgs.stdenv.isLinux (
         with pkgs;
         [
-          bitwarden-cli
+          (if pkgs ? bw-fnox then bw-fnox else bitwarden-cli)
         ]
       );
     }

--- a/modules/home-manager/common/attic-client.nix
+++ b/modules/home-manager/common/attic-client.nix
@@ -67,7 +67,7 @@ in
 
   config = lib.mkIf cfg.enable {
     # Install attic-client
-    home.packages = [ pkgs.attic-client ];
+    home.packages = [ (if pkgs ? attic-fnox then pkgs.attic-fnox else pkgs.attic-client) ];
 
     # Merge default servers with user-specified servers
     programs.attic-client.servers = lib.mkDefault cfg.defaultServers;

--- a/modules/home-manager/common/fnox.nix
+++ b/modules/home-manager/common/fnox.nix
@@ -17,6 +17,9 @@
         ];
 
         seedSecretSources = {
+          BW_SESSION = [
+            "${config.home.homeDirectory}/.config/sops/BW_SESSION"
+          ];
           GITHUB_TOKEN = [
             "${config.home.homeDirectory}/.config/git/github-token"
             "${config.home.homeDirectory}/.local/share/agenix-user-secrets/github-token"

--- a/modules/home-manager/common/shell-aliases.nix
+++ b/modules/home-manager/common/shell-aliases.nix
@@ -2,6 +2,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 let
@@ -15,15 +16,17 @@ let
 
   # Raw variants that bypass wrapped aliases
   rawAliasesPosix = {
-    gh-raw = "command gh";
+    gh-raw = "${pkgs.gh}/bin/gh";
     opencode-raw = "command opencode";
-    bw-raw = "command bw";
+    bw-raw = "${pkgs.bitwarden-cli}/bin/bw";
+    attic-raw = "${pkgs.attic-client}/bin/attic";
   };
 
   rawAliasesNushell = {
-    gh-raw = "^gh";
+    gh-raw = "^${pkgs.gh}/bin/gh";
     opencode-raw = "^opencode";
-    bw-raw = "^bw";
+    bw-raw = "^${pkgs.bitwarden-cli}/bin/bw";
+    attic-raw = "^${pkgs.attic-client}/bin/attic";
   };
 in
 {

--- a/modules/home-manager/common/tool-aliases.nix
+++ b/modules/home-manager/common/tool-aliases.nix
@@ -43,7 +43,8 @@ let
   # Prefer explicit wrappers via aliases (raw remains available)
   wrappedToolAliases =
     (lib.optionalAttrs (pkgs ? gh-fnox) { gh = "gh-fnox"; })
-    // (lib.optionalAttrs (pkgs ? bw-fnox) { bw = "bw-fnox"; });
+    // (lib.optionalAttrs (pkgs ? bw-fnox) { bw = "bw-fnox"; })
+    // (lib.optionalAttrs (pkgs ? attic-fnox) { attic = "attic-fnox"; });
 in
 {
   options.custom.toolAliases = {

--- a/modules/home-manager/git.nix
+++ b/modules/home-manager/git.nix
@@ -255,7 +255,7 @@ in
       [
         delta
         mergiraf
-        gh
+        (if pkgs ? gh-fnox then gh-fnox else gh)
         lazygit
         difftastic # Add difftastic to the list of packages
       ]

--- a/overlays/packages.nix
+++ b/overlays/packages.nix
@@ -24,4 +24,18 @@
       fnox = final.fnox;
     };
   })
+
+  # Wrapped Bitwarden CLI using fnox-backed session lookup
+  (final: prev: {
+    bw-fnox = final.callPackage ../pkgs/bw-fnox.nix {
+      fnox = final.fnox;
+    };
+  })
+
+  # Wrapped Attic CLI with fnox-backed login token lookup
+  (final: prev: {
+    attic-fnox = final.callPackage ../pkgs/attic-fnox.nix {
+      fnox = final.fnox;
+    };
+  })
 ]

--- a/overlays/packages.nix
+++ b/overlays/packages.nix
@@ -17,4 +17,11 @@
   (final: prev: {
     t3code = prev.callPackage ../pkgs/t3code.nix { };
   })
+
+  # Wrapped GitHub CLI using fnox-backed token lookup
+  (final: prev: {
+    gh-fnox = final.callPackage ../pkgs/gh-fnox.nix {
+      fnox = final.fnox;
+    };
+  })
 ]

--- a/pkgs/attic-fnox.nix
+++ b/pkgs/attic-fnox.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  symlinkJoin,
+  writeShellApplication,
+  attic-client,
+  fnox,
+}:
+let
+  wrapped = writeShellApplication {
+    name = "attic-fnox";
+
+    runtimeInputs = [
+      attic-client
+      fnox
+    ];
+
+    text = ''
+      set -euo pipefail
+
+      token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/sops/attic-client-token
+      token=""
+
+      get_token() {
+        local resolved=""
+        resolved="$(fnox get ATTIC_CLIENT_JWT_TOKEN 2>/dev/null || true)"
+        if [ -n "$resolved" ]; then
+          printf '%s' "$resolved"
+          return 0
+        fi
+
+        if [ -f "$token_file" ]; then
+          tr -d '\n' < "$token_file"
+          return 0
+        fi
+
+        return 1
+      }
+
+      if [ "$#" -ge 1 ] && [ "$1" = "login" ]; then
+        if [ "$#" -eq 3 ]; then
+          token="$(get_token || true)"
+          if [ -n "$token" ]; then
+            exec attic login "$2" "$3" "$token"
+          fi
+        fi
+      fi
+
+      exec attic "$@"
+    '';
+  };
+in
+symlinkJoin {
+  name = "attic-fnox";
+  paths = [ wrapped ];
+
+  postBuild = ''
+    ln -s "$out/bin/attic-fnox" "$out/bin/attic"
+  '';
+
+  meta = {
+    description = "Attic CLI wrapper that can source the login token via fnox";
+    homepage = "https://github.com/zhaofengli/attic";
+    mainProgram = "attic";
+    platforms = attic-client.meta.platforms or lib.platforms.all;
+  };
+}

--- a/pkgs/bw-fnox.nix
+++ b/pkgs/bw-fnox.nix
@@ -25,7 +25,9 @@ let
           export BW_SESSION="$session"
         elif [ -f "$session_file" ]; then
           session="$(tr -d '\n' < "$session_file")"
-          export BW_SESSION="$session"
+          if [ -n "$session" ]; then
+            export BW_SESSION="$session"
+          fi
         fi
       fi
 

--- a/pkgs/bw-fnox.nix
+++ b/pkgs/bw-fnox.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  symlinkJoin,
+  writeShellApplication,
+  bitwarden-cli,
+  fnox,
+}:
+let
+  wrapped = writeShellApplication {
+    name = "bw-fnox";
+
+    runtimeInputs = [
+      bitwarden-cli
+      fnox
+    ];
+
+    text = ''
+      set -euo pipefail
+
+      session_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/sops/BW_SESSION
+
+      if [ -z "''${BW_SESSION:-}" ]; then
+        session="$(fnox get BW_SESSION 2>/dev/null || true)"
+        if [ -n "$session" ]; then
+          export BW_SESSION="$session"
+        elif [ -f "$session_file" ]; then
+          session="$(tr -d '\n' < "$session_file")"
+          export BW_SESSION="$session"
+        fi
+      fi
+
+      exec bw "$@"
+    '';
+  };
+in
+symlinkJoin {
+  name = "bw-fnox";
+  paths = [ wrapped ];
+
+  postBuild = ''
+    ln -s "$out/bin/bw-fnox" "$out/bin/bw"
+  '';
+
+  meta = {
+    description = "Bitwarden CLI wrapper that sources BW_SESSION via fnox with file fallback";
+    homepage = "https://bitwarden.com/help/cli/";
+    mainProgram = "bw";
+    platforms = bitwarden-cli.meta.platforms or lib.platforms.all;
+  };
+}

--- a/pkgs/gh-fnox.nix
+++ b/pkgs/gh-fnox.nix
@@ -1,44 +1,54 @@
 {
   lib,
+  symlinkJoin,
   writeShellApplication,
   gh,
   fnox,
 }:
+let
+  wrapped = writeShellApplication {
+    name = "gh-fnox";
 
-writeShellApplication {
-  name = "gh-fnox";
+    runtimeInputs = [
+      gh
+      fnox
+    ];
 
-  runtimeInputs = [
-    gh
-    fnox
-  ];
+    text = ''
+      set -euo pipefail
 
-  text = ''
-    set -euo pipefail
+      token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/git/github-token
 
-    token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/git/github-token
-
-    if [ -z "''${GH_TOKEN:-}" ]; then
-      if [ -n "''${GITHUB_TOKEN:-}" ]; then
-        export GH_TOKEN="$GITHUB_TOKEN"
-      else
-        token="$(fnox get GITHUB_TOKEN 2>/dev/null || true)"
-        if [ -n "$token" ]; then
-          export GH_TOKEN="$token"
-        elif [ -f "$token_file" ]; then
-          token="$(tr -d '\n' < "$token_file")"
-          export GH_TOKEN="$token"
+      if [ -z "''${GH_TOKEN:-}" ]; then
+        if [ -n "''${GITHUB_TOKEN:-}" ]; then
+          export GH_TOKEN="$GITHUB_TOKEN"
+        else
+          token="$(fnox get GITHUB_TOKEN 2>/dev/null || true)"
+          if [ -n "$token" ]; then
+            export GH_TOKEN="$token"
+          elif [ -f "$token_file" ]; then
+            token="$(tr -d '\n' < "$token_file")"
+            export GH_TOKEN="$token"
+          fi
         fi
       fi
-    fi
 
-    exec gh "$@"
+      exec gh "$@"
+    '';
+  };
+in
+symlinkJoin {
+  name = "gh-fnox";
+  paths = [ wrapped ];
+
+  postBuild = ''
+    ln -s "$out/bin/gh-fnox" "$out/bin/gh"
   '';
 
   meta = {
     description = "GitHub CLI wrapper that sources GH_TOKEN via fnox with file fallback";
     homepage = "https://github.com/cli/cli";
-    mainProgram = "gh-fnox";
+    mainProgram = "gh";
     platforms = gh.meta.platforms or lib.platforms.all;
   };
 }

--- a/pkgs/gh-fnox.nix
+++ b/pkgs/gh-fnox.nix
@@ -28,7 +28,9 @@ let
             export GH_TOKEN="$token"
           elif [ -f "$token_file" ]; then
             token="$(tr -d '\n' < "$token_file")"
-            export GH_TOKEN="$token"
+            if [ -n "$token" ]; then
+              export GH_TOKEN="$token"
+            fi
           fi
         fi
       fi

--- a/pkgs/gh-fnox.nix
+++ b/pkgs/gh-fnox.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  writeShellApplication,
+  gh,
+  fnox,
+}:
+
+writeShellApplication {
+  name = "gh-fnox";
+
+  runtimeInputs = [
+    gh
+    fnox
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/git/github-token
+
+    if [ -z "''${GH_TOKEN:-}" ]; then
+      if [ -n "''${GITHUB_TOKEN:-}" ]; then
+        export GH_TOKEN="$GITHUB_TOKEN"
+      else
+        token="$(fnox get GITHUB_TOKEN 2>/dev/null || true)"
+        if [ -n "$token" ]; then
+          export GH_TOKEN="$token"
+        elif [ -f "$token_file" ]; then
+          token="$(tr -d '\n' < "$token_file")"
+          export GH_TOKEN="$token"
+        fi
+      fi
+    fi
+
+    exec gh "$@"
+  '';
+
+  meta = {
+    description = "GitHub CLI wrapper that sources GH_TOKEN via fnox with file fallback";
+    homepage = "https://github.com/cli/cli";
+    mainProgram = "gh-fnox";
+    platforms = gh.meta.platforms or lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- add wrapped gh, bw, and attic packages backed by fnox secret lookup
- install the wrapped binaries as the actual command names so hooks, agents, and other non-interactive callers use them too
- keep explicit raw escape hatches via gh-raw, bw-raw, and attic-raw
- seed fnox with BW_SESSION and reuse existing github and attic token sources

## Behavior
- gh sources GH_TOKEN from GH_TOKEN, GITHUB_TOKEN, fnox, or ~/.config/git/github-token
- bw sources BW_SESSION from fnox or ~/.config/sops/BW_SESSION
- attic makes the token optional for attic login NAME URL by sourcing ATTIC_CLIENT_JWT_TOKEN from fnox or ~/.config/sops/attic-client-token

## Validation
- nix build succeeded for gh-fnox, bw-fnox, and attic-fnox
- nix eval confirmed fish aliases resolve to gh-fnox, bw-fnox, and attic-fnox
- nix eval confirmed gh-raw, bw-raw, and attic-raw point at the underlying package binaries