### PR TITLE
refactor: drop redundant set -euo pipefail from fnox wrappers

### DIFF
--- a/pkgs/attic-fnox.nix
+++ b/pkgs/attic-fnox.nix
@@ -15,8 +15,6 @@ let
     ];
 
     text = ''
-      set -euo pipefail
-
       token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/sops/attic-client-token
       token=""
 

--- a/pkgs/bw-fnox.nix
+++ b/pkgs/bw-fnox.nix
@@ -15,8 +15,6 @@ let
     ];
 
     text = ''
-      set -euo pipefail
-
       session_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/sops/BW_SESSION
 
       if [ -z "''${BW_SESSION:-}" ]; then

--- a/pkgs/gh-fnox.nix
+++ b/pkgs/gh-fnox.nix
@@ -15,8 +15,6 @@ let
     ];
 
     text = ''
-      set -euo pipefail
-
       token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/git/github-token
 
       if [ -z "''${GH_TOKEN:-}" ]; then


### PR DESCRIPTION
## Summary

- `writeShellApplication` automatically prepends `set -eu -o pipefail` to generated scripts; the explicit `set -euo pipefail` at the top of each wrapper's `text` block was a no-op
- Removed from `pkgs/gh-fnox.nix`, `pkgs/bw-fnox.nix`, and `pkgs/attic-fnox.nix`

No behaviour change.

## Test plan

- [ ] Verify `gh`, `bw`, and `attic` wrappers still function correctly after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell script configurations in wrapper scripts for `attic-fnox`, `bw-fnox`, and `gh-fnox` packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->