### PR TITLE
feat: justfile with nixos-anywhere bootstrap recipes

### DIFF
--- a/docs/nixos-anywhere-bootstrap.md
+++ b/docs/nixos-anywhere-bootstrap.md
@@ -78,12 +78,19 @@ is interrupted, run `just clean-identity <host>` to remove it manually.
 |---|---|---|
 | `hw=` | Auto-generate `hardware-configuration.nix` via `nixos-generate-config` | `hw=hosts/nixos/myhost/hardware-configuration.nix` |
 | `disk=` | disko disk device (label is always `main`) | `disk=/dev/disk/by-id/scsi-0QEMU_...` |
+| `accept_new=true` | Trust-on-first-use SSH host key verification (see note below) | `accept_new=true` |
 | `dir=` | Path to this repo (defaults to `$PWD`) | `dir=/home/user/flakes/unified-nix-configuration` |
+
+> **SSH host key verification**: by default `just install` uses strict host key
+> checking. Since the installer generates a fresh host key you haven't seen
+> before, you have two options:
+> - Pre-verify: `ssh-keyscan <target> >> ~/.ssh/known_hosts` before running install
+> - TOFU opt-in: pass `accept_new=true` — convenient but skips verification
 
 Full example for an inference VM:
 
 ```bash
-just install inference4 10.10.11.134 \
+just install inference4 10.10.11.134 accept_new=true \
     hw=hosts/nixos/inference-vm/hosts/inference4/hardware-configuration.nix \
     disk=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0
 ```

--- a/docs/nixos-anywhere-bootstrap.md
+++ b/docs/nixos-anywhere-bootstrap.md
@@ -1,0 +1,131 @@
+# NixOS Anywhere Bootstrap Guide
+
+This guide covers bootstrapping a new NixOS host from this repo using
+[nixos-anywhere](https://github.com/nix-community/nixos-anywhere). The justfile
+recipes in the repo root automate the workflow.
+
+## Why this approach
+
+agenix decrypts secrets at boot using the host's private key. If the key is not
+known to `secrets.nix` at install time, agenix fails on first boot and a second
+rebuild pass is required. By pre-generating the machine identity, adding it to
+`secrets.nix`, rekeying, and seeding the key into the installed system via
+`--extra-files`, agenix works correctly **on first boot** with no second pass.
+
+## Prerequisites
+
+- nixos-anywhere is invoked via `nix run` — no separate install needed
+- Target machine is booted from the NixOS installer ISO and reachable via SSH
+- The host's NixOS config exists in this repo with `my.agenix.machineIdentity.enable = true`
+- For Btrfs/disko hosts: UEFI firmware, disk device path known
+
+## Step-by-step workflow
+
+### 1. Generate the machine identity
+
+```bash
+just gen-identity <host>
+```
+
+This creates a stable ed25519 key pair and:
+- Saves the **public key** to `ssh-keys/agenix-machine-identities/<host>.pub`
+- Holds the **private key** at `/tmp/nix-bootstrap-<host>/machine-identity` (mode 400, dir mode 700) until `just install` consumes and removes it
+
+If a public key already exists for the host, the command is a no-op.
+
+### 2. Add the host to `secrets.nix`
+
+Open `secrets.nix` and add `<host>` to the appropriate recipient groups. The
+`machineRecipients` helper in `lib/agenix-machine-identities.nix` will
+automatically pick up the new `.pub` file by hostname.
+
+Common groups to consider:
+
+| Group | What it grants |
+|---|---|
+| `rootSshKeyHosts` | Auto-deploys the root SSH identity to the host |
+| `atticClientHosts` | Gives the host the attic cache token |
+| Host-specific groups | Service secrets scoped to this host |
+
+### 3. Rekey secrets
+
+```bash
+just rekey
+```
+
+Re-encrypts all `secrets-agenix/*.age` files to include the new host as a
+recipient. This must be done before install — the encrypted secrets are baked
+into the Nix store derivation that nixos-anywhere will deploy.
+
+### 4. Install
+
+```bash
+just install <host> <target-ip>
+```
+
+Runs `nix run github:nix-community/nixos-anywhere` with:
+- `--extra-files` seeding the machine identity to `/var/lib/agenix/machine-identity`
+  on the installed system
+- `--flake .#<host>`
+- `--ssh-option StrictHostKeyChecking=accept-new`
+
+The private key is **deleted from `/tmp`** automatically on success. If install
+is interrupted, run `just clean-identity <host>` to remove it manually.
+
+#### Optional parameters
+
+| Parameter | Purpose | Example |
+|---|---|---|
+| `hw=` | Auto-generate `hardware-configuration.nix` via `nixos-generate-config` | `hw=hosts/nixos/myhost/hardware-configuration.nix` |
+| `disk=` | disko disk device (label is always `main`) | `disk=/dev/disk/by-id/scsi-0QEMU_...` |
+| `dir=` | Path to this repo (defaults to `$PWD`) | `dir=/home/user/flakes/unified-nix-configuration` |
+
+Full example for an inference VM:
+
+```bash
+just install inference4 10.10.11.134 \
+    hw=hosts/nixos/inference-vm/hosts/inference4/hardware-configuration.nix \
+    disk=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0
+```
+
+### 5. Commit
+
+After install completes, `just install` prints a `git status` of the files that
+changed. Commit them:
+
+```bash
+git add ssh-keys/agenix-machine-identities/<host>.pub secrets-agenix/
+git commit -m "feat: add <host> machine identity and rekey secrets"
+```
+
+### 6. User secrets (post-install)
+
+System-level secrets (`/run/agenix/`) are handled by the steps above. User
+secrets (`~/.config/sops/`, fnox store) are a separate layer deployed by
+Ansible:
+
+```bash
+cd ansible
+ansible-playbook playbooks/setup-secrets.yml -l <host>
+```
+
+## Quick reference
+
+```bash
+just gen-identity <host>          # Step 1: generate identity
+# edit secrets.nix
+just rekey                         # Step 3: rekey
+just install <host> <ip>           # Step 4: install
+
+just clean-identity <host>         # Manual cleanup if install was interrupted
+just rekey                         # Re-run any time secrets.nix changes
+```
+
+## How it fits with the existing Ansible playbook
+
+`ansible/playbooks/bootstrap-nixos-inference.yml` uses a post-install approach:
+it generates the machine identity *after* nixos-anywhere finishes and then
+rekeys. This means the first boot has no working agenix secrets and requires a
+follow-up `nixos-rebuild switch`. The justfile approach avoids this by
+pre-seeding the identity, making it the preferred path for new hosts. The
+Ansible playbook remains useful for bulk inference VM deployments via inventory.

--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ gen-identity host dir=`pwd`:
         exit 0
     fi
 
-    mkdir -p "$keydir"
+    install -d -m 700 "$keydir"
     ssh-keygen -t ed25519 -N '' \
         -C "agenix-machine-identity {{host}}" \
         -f "$keydir/machine-identity"
@@ -46,12 +46,13 @@ gen-identity host dir=`pwd`:
 
     echo ""
     echo "  public key  → $pubkey_dst"
-    echo "  private key → $keydir/machine-identity"
+    echo "  private key → $keydir/machine-identity  ⚠ delete after install"
     echo ""
     echo "Next steps:"
     echo "  1. Add {{host}} to the appropriate recipient groups in secrets.nix"
     echo "  2. just rekey"
     echo "  3. just install {{host}} <target-ip>"
+    echo "  4. just clean-identity {{host}}  # remove private key from /tmp"
 
 # Step 3 — install NixOS on a new host via nixos-anywhere.
 # Seeds the machine identity into the installed system via --extra-files so
@@ -112,8 +113,24 @@ install host target hw="" disk="" dir=`pwd`:
 
     "${cmd[@]}"
 
+    # Private key no longer needed locally — the installed system has its copy
+    rm -rf "$keydir"
     echo ""
-    echo "Install complete. Review and commit before next rebuild:"
+    echo "Install complete. Private key removed from $keydir."
+    echo ""
+    echo "Review and commit before next rebuild:"
     git -C "{{dir}}" status --short \
         "ssh-keys/agenix-machine-identities/{{host}}.pub" \
         "secrets-agenix/"
+
+# Remove a host's temporary private key from /tmp if install was interrupted.
+# Under normal circumstances 'just install' cleans up automatically.
+clean-identity host:
+    #!/usr/bin/env bash
+    keydir="/tmp/nix-bootstrap-{{host}}"
+    if [ -d "$keydir" ]; then
+        rm -rf "$keydir"
+        echo "Removed $keydir"
+    else
+        echo "Nothing to clean for {{host}}"
+    fi

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ gen-identity host dir=`pwd`:
     fi
 
     install -d -m 700 "$keydir"
+    install -d -m 755 "$(dirname "$pubkey_dst")"
     ssh-keygen -t ed25519 -N '' \
         -C "agenix-machine-identity {{host}}" \
         -f "$keydir/machine-identity"
@@ -61,15 +62,17 @@ gen-identity host dir=`pwd`:
 # Prerequisites: gen-identity done, secrets.nix updated, rekey done.
 #
 # Optional parameters:
-#   hw     path for auto-generated hardware-configuration.nix (empty = skip)
-#   disk   disko disk device path, e.g. /dev/disk/by-id/...  (empty = skip)
+#   hw          path for auto-generated hardware-configuration.nix (empty = skip)
+#   disk        disko disk device path, e.g. /dev/disk/by-id/...  (empty = skip)
+#   accept_new  set to "true" to pass StrictHostKeyChecking=accept-new (TOFU —
+#               only use when you cannot pre-verify the installer host key)
 #
 # Example:
 #   just install gateway 10.10.10.1
-#   just install inference1 10.10.11.131 \
+#   just install inference1 10.10.11.131 accept_new=true \
 #       hw=hosts/nixos/inference-vm/hosts/inference1/hardware-configuration.nix \
 #       disk=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0
-install host target hw="" disk="" dir=`pwd`:
+install host target hw="" disk="" accept_new="" dir=`pwd`:
     #!/usr/bin/env bash
     set -euo pipefail
     keydir="/tmp/nix-bootstrap-{{host}}"
@@ -83,6 +86,10 @@ install host target hw="" disk="" dir=`pwd`:
     if [ ! -f "$pubkey" ]; then
         echo "Error: no public key at $pubkey"
         echo "Run: just gen-identity {{host}}"
+        exit 1
+    fi
+    if [ -n "{{hw}}" ] && [ ! -f "{{dir}}/{{hw}}" ]; then
+        echo "Error: hw path not found: {{dir}}/{{hw}}"
         exit 1
     fi
 
@@ -99,8 +106,13 @@ install host target hw="" disk="" dir=`pwd`:
         nix run {{nixos_anywhere_url}} --
         --extra-files "$extra"
         --flake "{{dir}}#{{host}}"
-        --ssh-option StrictHostKeyChecking=accept-new
     )
+
+    # TOFU opt-in: only skip host key verification when explicitly requested.
+    # To pre-verify instead: ssh-keyscan <target> >> ~/.ssh/known_hosts
+    if [ "{{accept_new}}" = "true" ]; then
+        cmd+=(--ssh-option StrictHostKeyChecking=accept-new)
+    fi
 
     if [ -n "{{hw}}" ]; then
         cmd+=(--generate-hardware-config nixos-generate-config "{{dir}}/{{hw}}")

--- a/justfile
+++ b/justfile
@@ -1,0 +1,119 @@
+# justfile — repo-wide operations
+# Host-specific rebuilds live in users/{user}/hosts/{host}/justfile
+#
+# nixos-anywhere bootstrap workflow:
+#   1. just gen-identity <host>           # generate stable machine identity
+#   2. Edit secrets.nix — add <host> to relevant recipient groups
+#   3. just rekey                          # re-encrypt secrets for new recipient
+#   4. just install <host> <target-ip>     # install NixOS, agenix works on first boot
+
+agenix_url        := "github:ryantm/agenix"
+nixos_anywhere_url := "github:nix-community/nixos-anywhere"
+
+# ---------------------------------------------------------------------------
+# Secrets
+# ---------------------------------------------------------------------------
+
+# Re-encrypt all agenix secrets after editing secrets.nix
+rekey dir=`pwd`:
+    nix run {{agenix_url}} -- -r --rules "{{dir}}/secrets.nix"
+
+# ---------------------------------------------------------------------------
+# nixos-anywhere bootstrap
+# ---------------------------------------------------------------------------
+
+# Step 1 — generate a stable machine identity for a new host.
+# Writes the public key to ssh-keys/agenix-machine-identities/<host>.pub
+# and keeps the private key at /tmp/nix-bootstrap-<host>/machine-identity
+# for use by 'just install'.
+gen-identity host dir=`pwd`:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pubkey_dst="{{dir}}/ssh-keys/agenix-machine-identities/{{host}}.pub"
+    keydir="/tmp/nix-bootstrap-{{host}}"
+
+    if [ -f "$pubkey_dst" ]; then
+        echo "Identity already exists: $pubkey_dst"
+        exit 0
+    fi
+
+    mkdir -p "$keydir"
+    ssh-keygen -t ed25519 -N '' \
+        -C "agenix-machine-identity {{host}}" \
+        -f "$keydir/machine-identity"
+    chmod 400 "$keydir/machine-identity"
+    cp "$keydir/machine-identity.pub" "$pubkey_dst"
+
+    echo ""
+    echo "  public key  → $pubkey_dst"
+    echo "  private key → $keydir/machine-identity"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Add {{host}} to the appropriate recipient groups in secrets.nix"
+    echo "  2. just rekey"
+    echo "  3. just install {{host}} <target-ip>"
+
+# Step 3 — install NixOS on a new host via nixos-anywhere.
+# Seeds the machine identity into the installed system via --extra-files so
+# agenix can decrypt secrets on first boot without a second rebuild pass.
+#
+# Prerequisites: gen-identity done, secrets.nix updated, rekey done.
+#
+# Optional parameters:
+#   hw     path for auto-generated hardware-configuration.nix (empty = skip)
+#   disk   disko disk device path, e.g. /dev/disk/by-id/...  (empty = skip)
+#
+# Example:
+#   just install gateway 10.10.10.1
+#   just install inference1 10.10.11.131 \
+#       hw=hosts/nixos/inference-vm/hosts/inference1/hardware-configuration.nix \
+#       disk=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0
+install host target hw="" disk="" dir=`pwd`:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    keydir="/tmp/nix-bootstrap-{{host}}"
+    pubkey="{{dir}}/ssh-keys/agenix-machine-identities/{{host}}.pub"
+
+    if [ ! -f "$keydir/machine-identity" ]; then
+        echo "Error: no identity at $keydir/machine-identity"
+        echo "Run: just gen-identity {{host}}"
+        exit 1
+    fi
+    if [ ! -f "$pubkey" ]; then
+        echo "Error: no public key at $pubkey"
+        echo "Run: just gen-identity {{host}}"
+        exit 1
+    fi
+
+    # Build the extra-files tree that nixos-anywhere merges into the new system
+    extra="$(mktemp -d)"
+    trap 'rm -rf "$extra"' EXIT
+
+    install -d -m 700 "$extra/var/lib/agenix"
+    install -m 400 "$keydir/machine-identity"     "$extra/var/lib/agenix/machine-identity"
+    install -m 644 "$keydir/machine-identity.pub" "$extra/var/lib/agenix/machine-identity.pub"
+
+    # Build the nixos-anywhere command
+    cmd=(
+        nix run {{nixos_anywhere_url}} --
+        --extra-files "$extra"
+        --flake "{{dir}}#{{host}}"
+        --ssh-option StrictHostKeyChecking=accept-new
+    )
+
+    if [ -n "{{hw}}" ]; then
+        cmd+=(--generate-hardware-config nixos-generate-config "{{dir}}/{{hw}}")
+    fi
+    if [ -n "{{disk}}" ]; then
+        cmd+=(--disk main "{{disk}}")
+    fi
+
+    cmd+=(root@{{target}})
+
+    "${cmd[@]}"
+
+    echo ""
+    echo "Install complete. Review and commit before next rebuild:"
+    git -C "{{dir}}" status --short \
+        "ssh-keys/agenix-machine-identities/{{host}}.pub" \
+        "secrets-agenix/"


### PR DESCRIPTION
## Summary

Adds a root-level `justfile` with three composable recipes for bootstrapping new NixOS hosts via nixos-anywhere.

- **`gen-identity <host>`** — generates a stable ed25519 machine identity locally before install, saving the public key to `ssh-keys/agenix-machine-identities/<host>.pub` and the private key to `/tmp/nix-bootstrap-<host>/` for use by `install`
- **`rekey`** — re-encrypts all agenix secrets after editing `secrets.nix`
- **`install <host> <target-ip> [hw=] [disk=]`** — runs nixos-anywhere with `--extra-files` seeding the machine identity into the installed system

### Why `--extra-files` instead of the post-install Ansible approach

The existing `bootstrap-nixos-inference.yml` generates the machine identity *after* nixos-anywhere finishes, requiring a second `nixos-rebuild switch` before agenix secrets are available. By pre-generating the identity, adding it to `secrets.nix`, rekeying, and seeding it via `--extra-files`, agenix can decrypt secrets correctly **on first boot** with no second pass.

### Full workflow

```bash
just gen-identity gateway
# Edit secrets.nix: add gateway to relevant recipient groups
just rekey
just install gateway 10.10.10.1

# With optional hardware config generation and disko disk selection:
just install inference4 10.10.11.134 \
    hw=hosts/nixos/inference-vm/hosts/inference4/hardware-configuration.nix \
    disk=/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-scsi0
```

## Test plan

- [ ] `just --list` shows all three recipes cleanly
- [ ] `just gen-identity testhost` creates key pair and saves public key to correct path
- [ ] `just rekey` successfully rekeys secrets
- [ ] `just install` correctly builds the `--extra-files` tree and passes args to nixos-anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive bootstrap guide with step-by-step instructions for provisioning new NixOS hosts, including identity generation, host registration, secret management, and installation procedures.

* **New Features**
  * Added utility commands for host identity generation, secret rekeying, and streamlined NixOS installation with configurable hardware and disk options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->