### PR TITLE
feat: add router bootstrap output

### DIFF
--- a/den/aspects/bootstrap-base.nix
+++ b/den/aspects/bootstrap-base.nix
@@ -1,0 +1,9 @@
+{ ... }:
+{ inputs, ... }:
+{
+  imports = [
+    inputs.disko.nixosModules.disko
+    ../../hosts/nixos/inference-vm/modules/disko.nix
+    ../../hosts/nixos/router-bootstrap/configuration.nix
+  ];
+}

--- a/den/aspects/default.nix
+++ b/den/aspects/default.nix
@@ -24,4 +24,5 @@
   inference1-ollama = context: import ./inference1-ollama.nix context;
   gateway-router = context: import ./gateway-router.nix context;
   router-router = context: import ./router-router.nix context;
+  bootstrap-base = context: import ./bootstrap-base.nix context;
 }

--- a/den/hosts/router-bootstrap/default.nix
+++ b/den/hosts/router-bootstrap/default.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+let
+  den = import ../../lib.nix { inherit lib; };
+in
+den.mkHostModule {
+  name = "router-bootstrap";
+  primaryUser = "deepwatrcreatur";
+  aspectsList = [
+    "nixos-base"
+    "bootstrap-base"
+  ];
+  extraImports = [
+    ../../../hosts/nixos/router-bootstrap/hardware-configuration.nix
+  ];
+}

--- a/den/inventory/hosts.nix
+++ b/den/inventory/hosts.nix
@@ -75,6 +75,19 @@
     ];
   };
 
+  router-bootstrap = {
+    kind = "nixos";
+    name = "router-bootstrap";
+    system = "x86_64-linux";
+    hostPath = ../hosts/router-bootstrap;
+    isDesktop = false;
+    mode = "aspect";
+    aspectsList = [
+      "nixos-base"
+      "bootstrap-base"
+    ];
+  };
+
   inference1 = {
     kind = "nixos";
     name = "inference1";

--- a/hosts/nixos/router-bootstrap/configuration.nix
+++ b/hosts/nixos/router-bootstrap/configuration.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  imports = [
+    ../../../modules/nixos/bootstrap/base.nix
+  ];
+
+  networking.hostName = "router-bootstrap";
+}

--- a/hosts/nixos/router-bootstrap/hardware-configuration.nix
+++ b/hosts/nixos/router-bootstrap/hardware-configuration.nix
@@ -1,0 +1,30 @@
+# This file is intentionally minimal for first-stage VM installs. Shared disk
+# layout lives in ../../inference-vm/modules/disko.nix and bootstrap settings
+# live in ../../../modules/nixos/bootstrap/base.nix.
+{
+  lib,
+  modulesPath,
+  ...
+}:
+
+{
+  imports = [
+    (modulesPath + "/profiles/qemu-guest.nix")
+  ];
+
+  boot.initrd.availableKernelModules = [
+    "uhci_hcd"
+    "ehci_pci"
+    "ahci"
+    "virtio_pci"
+    "virtio_scsi"
+    "sd_mod"
+    "sr_mod"
+  ];
+  boot.initrd.kernelModules = [ ];
+  boot.kernelModules = [ ];
+  boot.extraModulePackages = [ ];
+
+  networking.useDHCP = lib.mkDefault true;
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+}

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -61,6 +61,14 @@
       description = "Next-generation router/firewall output running NixOS";
     };
 
+    router-bootstrap = {
+      ip = null;
+      sshUser = "deepwatrcreatur";
+      includeDns = false;
+      includeSsh = false;
+      description = "Minimal bootstrap output for router-class installs";
+    };
+
     # Proxmox Hypervisors
     pve-gateway = {
       ip = "10.10.11.52";

--- a/modules/nixos/bootstrap/base.nix
+++ b/modules/nixos/bootstrap/base.nix
@@ -23,7 +23,7 @@ in
 
   programs.ssh.startAgent = false;
 
-  environment.systemPackages = lib.mkForce (
+  environment.systemPackages = lib.mkDefault (
     with pkgs;
     [
       attic-client
@@ -61,7 +61,7 @@ in
 
   services.openssh = {
     enable = true;
-    settings.PermitRootLogin = "yes";
+    settings.PermitRootLogin = "prohibit-password";
   };
   services.qemuGuest.enable = true;
   services.fstrim.enable = true;
@@ -104,8 +104,8 @@ in
     Host attic-cache 10.10.11.39
       User deepwatrcreatur
       IdentityFile /root/.ssh/nix-remote
-      StrictHostKeyChecking no
-      UserKnownHostsFile /dev/null
+      StrictHostKeyChecking accept-new
+      UserKnownHostsFile /root/.ssh/known_hosts
   '';
 
   system.stateVersion = "25.11";

--- a/modules/nixos/bootstrap/base.nix
+++ b/modules/nixos/bootstrap/base.nix
@@ -27,6 +27,7 @@ in
     with pkgs;
     [
       attic-client
+      bashInteractive
       btrfs-progs
       curl
       git
@@ -70,7 +71,7 @@ in
     loader = {
       systemd-boot.enable = lib.mkForce false;
       limine.enable = true;
-      efi.canTouchEfiVariables = true;
+      efi.canTouchEfiVariables = false;
     };
     kernelParams = [ "console=ttyS0,115200" ];
   };

--- a/modules/nixos/bootstrap/base.nix
+++ b/modules/nixos/bootstrap/base.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  deepwatrcreaturStableKey = lib.strings.trim (
+    builtins.readFile ../../../ssh-keys/deepwatrcreatur-stable-identity.pub
+  );
+  rootStableKey = lib.strings.trim (builtins.readFile ../../../ssh-keys/root-stable-identity.pub);
+in
+{
+  imports = [
+    ../../common/nix-settings.nix
+    ../common/nix-ci-netrc.nix
+    ../snapper.nix
+  ];
+
+  # Keep bootstrap installs on the public/local caches only.
+  myModules.caches.enableAttic = lib.mkDefault true;
+  myModules.caches.enableNixCi = lib.mkDefault false;
+
+  programs.ssh.startAgent = false;
+
+  environment.systemPackages = lib.mkForce (
+    with pkgs;
+    [
+      attic-client
+      btrfs-progs
+      curl
+      git
+      just
+      snapper
+      tmux
+    ]
+  );
+
+  users.users.deepwatrcreatur = {
+    isNormalUser = true;
+    description = "Anwer Khan";
+    home = "/home/deepwatrcreatur";
+    extraGroups = [
+      "networkmanager"
+      "snapper"
+      "wheel"
+    ];
+    shell = pkgs.fish;
+    openssh.authorizedKeys.keys = [ deepwatrcreaturStableKey ];
+  };
+
+  users.users.root = {
+    shell = pkgs.bashInteractive;
+    openssh.authorizedKeys.keys = [ rootStableKey ];
+  };
+
+  networking.useDHCP = lib.mkDefault true;
+  networking.networkmanager.enable = true;
+  networking.firewall.enable = false;
+
+  services.openssh = {
+    enable = true;
+    settings.PermitRootLogin = "yes";
+  };
+  services.qemuGuest.enable = true;
+  services.fstrim.enable = true;
+
+  boot = {
+    growPartition = true;
+    loader = {
+      systemd-boot.enable = lib.mkForce false;
+      limine.enable = true;
+      efi.canTouchEfiVariables = true;
+    };
+    kernelParams = [ "console=ttyS0,115200" ];
+  };
+
+  systemd.services."serial-getty@ttyS0".enable = true;
+
+  security.sudo.wheelNeedsPassword = false;
+
+  # Bootstrap images need the builder configuration even before any host-specific
+  # agenix secrets exist. The key can be seeded manually at /root/.ssh/nix-remote.
+  nix.distributedBuilds = true;
+  nix.buildMachines = [
+    {
+      hostName = "10.10.11.39";
+      system = "x86_64-linux";
+      maxJobs = 8;
+      speedFactor = 2;
+      supportedFeatures = [
+        "nixos-test"
+        "benchmark"
+        "big-parallel"
+        "kvm"
+      ];
+      sshUser = "deepwatrcreatur";
+      sshKey = "/root/.ssh/nix-remote";
+    }
+  ];
+
+  programs.ssh.extraConfig = ''
+    Host attic-cache 10.10.11.39
+      User deepwatrcreatur
+      IdentityFile /root/.ssh/nix-remote
+      StrictHostKeyChecking no
+      UserKnownHostsFile /dev/null
+  '';
+
+  system.stateVersion = "25.11";
+}


### PR DESCRIPTION
Summary:
- add a minimal router-bootstrap NixOS output for first-stage installs
- include limine, btrfs, snapper, caches, experimental nix features, and remote builder access
- keep the bootstrap closure small so it can be built from installer environments more reliably

Validation:
- nix eval .#nixosConfigurations.router-bootstrap.config.boot.loader.limine.enable
- nix eval .#nixosConfigurations.router-bootstrap.config.fileSystems
- nix eval .#nixosConfigurations.router-bootstrap.config.nix.buildMachines
- nix build --no-link .#nixosConfigurations.router-bootstrap.config.system.build.toplevel
- copied the repo into the live ISO with scp and started a router-bootstrap build there after cleaning the installer store
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a router bootstrap environment for minimal router-class installs.
  * New host entry and host module for "router-bootstrap" with aspect-based wiring.
  * Minimal hardware profile for first-stage VM installs (QEMU guest, DHCP defaults).
  * Bootstrap system defaults: essential system packages, user accounts, SSH enabled with root restrictions.
  * Boot and console settings optimized for serial/QEMU environments.
  * Enabled distributed build support and remote builder configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->