### PR TITLE
feat(router): improve dashboard operations view

### DIFF
--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -129,7 +129,76 @@ in
   imports = [ ../../../modules/nixos/router/common.nix ];
 
   services.router-dashboard = {
+    refreshInterval = 10;
+    services = [
+      "systemd-networkd"
+      "sshd"
+      "nftables"
+      "caddy"
+      "technitium-dns-server"
+      "tailscaled"
+      "fail2ban"
+      "podman"
+      "prometheus"
+      "grafana"
+      "netdata"
+      "router-dashboard"
+    ];
     links = [
+      {
+        label = "Dashboard";
+        url = "https://dashboard.deepwatercreature.com";
+        icon = "🧭";
+      }
+      {
+        label = "Homelab";
+        url = "https://homelab.deepwatercreature.com";
+        icon = "🏠";
+      }
+      {
+        label = "Grafana";
+        url = "https://grafana.deepwatercreature.com";
+        icon = "📈";
+      }
+      {
+        label = "DNS Admin";
+        url = "http://10.10.10.1:5380/";
+        icon = "🌍";
+      }
+      {
+        label = "Prometheus";
+        url = "http://10.10.10.1:9090/";
+        icon = "🎯";
+      }
+      {
+        label = "Netdata";
+        url = "http://10.10.10.1:19999/";
+        icon = "📊";
+      }
+      {
+        label = "Router SSH";
+        kind = "copy";
+        copyText = "ssh router";
+        icon = "🖥️";
+      }
+      {
+        label = "Backup SSH";
+        kind = "copy";
+        copyText = "ssh router-backup";
+        icon = "🛟";
+      }
+      {
+        label = "Router Mgmt";
+        kind = "copy";
+        copyText = "192.168.100.100";
+        icon = "🔧";
+      }
+      {
+        label = "Backup Mgmt";
+        kind = "copy";
+        copyText = "192.168.100.99";
+        icon = "🧰";
+      }
       {
         label = "Tech Logs";
         url = "/logs/technitium.html";


### PR DESCRIPTION
## Summary
- expand router dashboard quick links around the real router workflow
- surface spare-router SSH and management actions directly in the dashboard
- monitor a broader set of router-critical services in the service widget

## Validation
- nix build .#nixosConfigurations.router.config.system.build.toplevel
- nix build .#nixosConfigurations.router-backup.config.system.build.toplevel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Router dashboard now refreshes every 10 seconds.
  * Added quick-access links to related services (Grafana, Prometheus, Netdata, DNS Admin, Homelab) for improved navigation.
  * Added copy-to-clipboard quick actions for router and backup SSH/management targets, plus local pages for logs and Fail2ban.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->