### PR TITLE
refactor(router): split shared primary/spare role

### DIFF
--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -1,44 +1,20 @@
 { lib, inputs, ... }:
 {
   imports = [
-    ../router/configuration.nix
+    (import ../router/role.nix {
+      sshTarget = "ssh router-backup.deepwatercreature.com";
+      wanDevice = "enp2s0";
+      lanDevice = "enp3s0";
+      managementIpv4Address = "192.168.100.99/24";
+      grafanaDomain = "router-backup.deepwatercreature.com";
+      grafanaDataDir = "/var/log/router-backup/grafana";
+      prometheusStateDir = "router-backup-prometheus";
+      prometheusBindMountPath = "/var/log/router-backup/prometheus";
+      enableLogStorage = false;
+    })
     inputs.disko.nixosModules.disko
     ./disko.nix
   ];
 
   home-manager.extraSpecialArgs.hostName = lib.mkForce "router-backup";
-
-  services.router-homelab.sshTarget = lib.mkForce "ssh router-backup.deepwatercreature.com";
-
-
-  router.monitoring = {
-    grafanaDomain = lib.mkForce "router-backup.deepwatercreature.com";
-    grafanaDataDir = lib.mkForce "/var/log/router-backup/grafana";
-    prometheusStateDir = lib.mkForce "router-backup-prometheus";
-    prometheusBindMountPath = lib.mkForce "/var/log/router-backup/prometheus";
-  };
-
-  # Intel I219 dual-port NIC via PCI passthrough.
-  # Interface names are PCI-bus-derived (enp<bus>s<slot>) — set these to
-  # the actual names observed after first boot on the target cluster node.
-  services.router-networking = {
-    wan.device = lib.mkForce "enp2s0";
-    routedInterfaces.lan.device = lib.mkForce "enp3s0";
-  };
-
-  services.router-optimizations.interfaces = {
-    wan.device = lib.mkForce "enp2s0";
-    lan.device = lib.mkForce "enp3s0";
-  };
-
-  # Keep the backup router reachable on the out-of-band virtio management
-  # network while sharing the same production LAN identity as the primary.
-  services.router-networking.routedInterfaces.management.ipv4Address = lib.mkForce "192.168.100.99/24";
-
-  services.router-firewall.extraInputRules = lib.mkForce ''
-    iifname {"enp3s0"} tcp dport 5201 accept comment "iperf3 from LAN"
-  '';
-
-  # No separate logs disk on backup router — log locally.
-  services.router-log-storage.enable = lib.mkForce false;
 }

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -1,157 +1,20 @@
 {
-  config,
-  pkgs,
-  inputs,
   lib,
   ...
 }:
-let
-  # Optional secrets library for graceful degradation when .age files don't exist
-  optSec = import ../../../modules/helpers/optional-secrets.nix { inherit lib; };
-
-  # Define all secrets in one place - they gracefully degrade if files don't exist
-  secrets = optSec.mkSecrets {
-    cloudflare-api-key = {
-      file = ../../../secrets-agenix/cloudflare_ddns_API_token.age;
-    };
-    technitium-api-key = {
-      file = ../../../secrets-agenix/technitium-api-key.age;
-      mode = "0444"; # World-readable for router-dashboard DynamicUser access
-    };
-    tailscale-auth-key = {
-      file = ../../../secrets-agenix/tailscale-auth-key.age;
-    };
-  };
-in
 {
-  # Declarative host configuration
-  host = {
-    type = "router";
-    primaryUser = "deepwatrcreatur";
-    gpu.type = "none";
-    desktop.enable = false;
-    networking = {
-      enableTailscale = true;
-      enableAvahi = false;
-    };
-    services = {
-      enableSsh = true;
-      enableDocker = false;
-      enablePodman = true;
-      iperf3.enable = true;
-    };
-  };
-
-  # I226-V dual-port NIC via PCI passthrough gets PCI-bus-derived names in the VM.
-  # hostpci0 (0000:03:00.0 on host) → enp6s16 (LAN), hostpci1 (0000:04:00.0 on host) → enp6s17 (WAN).
-  # Inside the VM both NICs appear on bus 6 (slots 16/17). Management virtio NIC retains ens18.
-  services.router-networking = {
-    enable = true;
-    wan.device = "enp6s17";
-    routedInterfaces = {
-      lan = {
-        device = "enp6s16";
-        ipv4Address = "10.10.10.1/16";
-        dns = [ "127.0.0.1" ];
-        domains = [ "deepwatercreature.com" ];
-        requiredForOnline = "routable";
-        extraRoutes = [
-          {
-            destination = "10.10.0.0/16";
-            scope = "link";
-          }
-        ];
-      };
-      management = {
-        device = "ens18";
-        ipv4Address = "192.168.100.100/24";
-        prefixDelegationMode = "managed";
-      };
-    };
-  };
-
-  services.router-optimizations = {
-    enable = true;
-    interfaces = {
-      wan = {
-        device = "enp6s17";
-        role = "wan";
-        label = "WAN";
-        bandwidth = "1Gbit";
-      };
-      lan = {
-        device = "enp6s16";
-        role = "lan";
-        label = "LAN";
-      };
-      management = {
-        device = "ens18";
-        role = "management";
-        label = "Management";
-      };
-    };
-    conntrack-max = 262144;
-  };
-
-  services.router-technitium =
-    let
-      hostsData = import ../../../lib/hosts.nix;
-      reservableHosts = lib.filterAttrs (
-        _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null
-      ) hostsData.hosts;
-    in
-    {
-      dhcpReservations = lib.mapAttrs (
-        name: host: {
-          scope = host.dhcpReservation.scope or "LAN";
-          macAddress = host.dhcpReservation.macAddress;
-          ipAddress = host.ip;
-          hostName = name;
-          comments = host.description or "";
-        }
-      ) reservableHosts;
-    };
-
-  services.router-firewall = {
-    enable = true;
-    tailscaleInterface = "tailscale0";
-    trustedTcpPorts = [ 80 443 ];
-    hairpinNat.enable = true;
-    trustedUdpPorts = [ ];
-    wanUdpPorts = [ 41641 ];
-    extraInputRules = ''
-      iifname {"enp6s16"} tcp dport 5201 accept comment "iperf3 from LAN"
-    '';
-  };
-
-  services.router-homelab.sshTarget = "ssh router.deepwatercreature.com";
-
-  imports = [ ../../../modules/nixos/router/common.nix ];
-
-  services.router-dashboard = {
-    links = [
-      {
-        label = "Tech Logs";
-        url = "/logs/technitium.html";
-        icon = "📜";
-      }
-      {
-        label = "Fail2ban";
-        url = "/status/fail2ban.html";
-        icon = "🛡️";
-      }
-    ];
-  };
-
-
-  services.tailscale = {
-    useRoutingFeatures = "server";
-    authKeyFile = secrets.path "tailscale-auth-key";
-    extraUpFlags = lib.optionals (secrets.exists "tailscale-auth-key") [
-      "--advertise-exit-node"
-      "--advertise-routes=10.10.0.0/16"
-    ];
-  };
+  imports = [
+    (import ./role.nix {
+      sshTarget = "ssh router.deepwatercreature.com";
+      wanDevice = "enp6s17";
+      lanDevice = "enp6s16";
+      managementIpv4Address = "192.168.100.100/24";
+      grafanaDomain = "router.deepwatercreature.com";
+      grafanaDataDir = "/var/log/router/grafana";
+      prometheusStateDir = "router-prometheus";
+      prometheusBindMountPath = "/var/log/router/prometheus";
+    })
+  ];
 
   # DNS zone management with static hosts imported from external file.
   # Edit ./dns-zone.nix to manage one or more zones.
@@ -182,73 +45,4 @@ in
       {
         "${dnsConfig.domain}" = mkZone dnsConfig;
       };
-
-  # EFI/Limine bootloader — OVMF QEMU VM with no legacy BIOS.
-  boot.loader.grub.enable = false;
-  boot.loader.limine.enable = true;
-  boot.loader.efi.canTouchEfiVariables = false;
-
-  nix.settings.experimental-features = [
-    "nix-command"
-    "flakes"
-  ];
-
-  my.agenix.machineIdentity.enable = true;
-
-  # Logs disk is on scsi1 (spinning disk), formatted by disko as disk-logs-logs.
-  # router-log-storage handles the mount; disko only formats the partition.
-
-  # Enable podman for containers
-  virtualisation.podman = {
-    enable = true;
-    dockerCompat = true;
-  };
-  virtualisation.oci-containers.backend = "podman";
-
-  # QEMU guest agent for Proxmox
-  services.qemuGuest.enable = true;
-
-  # SSH daemon
-  services.openssh = {
-    enable = true;
-    settings.PermitRootLogin = "prohibit-password";
-    extraConfig = ''
-      Match Address 10.10.10.0/24
-        PermitRootLogin yes
-    '';
-  };
-
-  # Fail2ban for SSH brute-force protection
-  services.fail2ban = {
-    enable = true;
-    maxretry = 5;
-    ignoreIP = [
-      "127.0.0.1/8"
-      "10.10.0.0/16"
-    ];
-  };
-
-  users.users.deepwatrcreatur = {
-    isNormalUser = true;
-    extraGroups = [
-      "wheel"
-    ];
-    shell = pkgs.fish;
-  };
-
-  services.ssh-keys-manager.username = "deepwatrcreatur";
-
-  programs.fish.enable = true;
-
-  security.sudo.wheelNeedsPassword = false;
-
-  environment.systemPackages = with pkgs; [
-    tmux
-  ];
-
-  # Agenix secrets - uses optional-secrets library for graceful degradation
-  age.secrets = secrets.definitions;
-
-  nixpkgs.hostPlatform = "x86_64-linux";
-  system.stateVersion = "25.05";
 }

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -1,0 +1,221 @@
+{
+  sshTarget,
+  wanDevice,
+  lanDevice,
+  managementIpv4Address,
+  grafanaDomain,
+  grafanaDataDir,
+  prometheusStateDir,
+  prometheusBindMountPath,
+  enableLogStorage ? true,
+}:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  optSec = import ../../../modules/helpers/optional-secrets.nix { inherit lib; };
+
+  secrets = optSec.mkSecrets {
+    cloudflare-api-key = {
+      file = ../../../secrets-agenix/cloudflare_ddns_API_token.age;
+    };
+    technitium-api-key = {
+      file = ../../../secrets-agenix/technitium-api-key.age;
+      mode = "0444";
+    };
+    tailscale-auth-key = {
+      file = ../../../secrets-agenix/tailscale-auth-key.age;
+    };
+  };
+
+  hostsData = import ../../../lib/hosts.nix;
+  reservableHosts = lib.filterAttrs (
+    _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null
+  ) hostsData.hosts;
+in
+{
+  imports = [ ../../../modules/nixos/router/common.nix ];
+
+  host = {
+    type = "router";
+    primaryUser = "deepwatrcreatur";
+    gpu.type = "none";
+    desktop.enable = false;
+    networking = {
+      enableTailscale = true;
+      enableAvahi = false;
+    };
+    services = {
+      enableSsh = true;
+      enableDocker = false;
+      enablePodman = true;
+      iperf3.enable = true;
+    };
+  };
+
+  services.router-networking = {
+    enable = true;
+    wan.device = wanDevice;
+    routedInterfaces = {
+      lan = {
+        device = lanDevice;
+        ipv4Address = "10.10.10.1/16";
+        dns = [ "127.0.0.1" ];
+        domains = [ "deepwatercreature.com" ];
+        requiredForOnline = "routable";
+        extraRoutes = [
+          {
+            destination = "10.10.0.0/16";
+            scope = "link";
+          }
+        ];
+      };
+      management = {
+        device = "ens18";
+        ipv4Address = managementIpv4Address;
+        prefixDelegationMode = "managed";
+      };
+    };
+  };
+
+  services.router-optimizations = {
+    enable = true;
+    interfaces = {
+      wan = {
+        device = wanDevice;
+        role = "wan";
+        label = "WAN";
+        bandwidth = "1Gbit";
+      };
+      lan = {
+        device = lanDevice;
+        role = "lan";
+        label = "LAN";
+      };
+      management = {
+        device = "ens18";
+        role = "management";
+        label = "Management";
+      };
+    };
+    conntrack-max = 262144;
+  };
+
+  services.router-technitium = {
+    dhcpReservations = lib.mapAttrs (
+      name: host: {
+        scope = host.dhcpReservation.scope or "LAN";
+        macAddress = host.dhcpReservation.macAddress;
+        ipAddress = host.ip;
+        hostName = name;
+        comments = host.description or "";
+      }
+    ) reservableHosts;
+  };
+
+  services.router-firewall = {
+    enable = true;
+    tailscaleInterface = "tailscale0";
+    trustedTcpPorts = [ 80 443 ];
+    hairpinNat.enable = true;
+    trustedUdpPorts = [ ];
+    wanUdpPorts = [ 41641 ];
+    extraInputRules = ''
+      iifname {"${lanDevice}"} tcp dport 5201 accept comment "iperf3 from LAN"
+    '';
+  };
+
+  services.router-homelab.sshTarget = sshTarget;
+
+  services.router-dashboard = {
+    links = [
+      {
+        label = "Tech Logs";
+        url = "/logs/technitium.html";
+        icon = "📜";
+      }
+      {
+        label = "Fail2ban";
+        url = "/status/fail2ban.html";
+        icon = "🛡️";
+      }
+    ];
+  };
+
+  services.tailscale = {
+    useRoutingFeatures = "server";
+    authKeyFile = secrets.path "tailscale-auth-key";
+    extraUpFlags = lib.optionals (secrets.exists "tailscale-auth-key") [
+      "--advertise-exit-node"
+      "--advertise-routes=10.10.0.0/16"
+    ];
+  };
+
+  router.monitoring = {
+    grafanaDomain = grafanaDomain;
+    grafanaDataDir = grafanaDataDir;
+    prometheusStateDir = prometheusStateDir;
+    prometheusBindMountPath = prometheusBindMountPath;
+  };
+
+  boot.loader.grub.enable = false;
+  boot.loader.limine.enable = true;
+  boot.loader.efi.canTouchEfiVariables = false;
+
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  my.agenix.machineIdentity.enable = true;
+
+  virtualisation.podman = {
+    enable = true;
+    dockerCompat = true;
+  };
+  virtualisation.oci-containers.backend = "podman";
+
+  services.qemuGuest.enable = true;
+
+  services.openssh = {
+    enable = true;
+    settings.PermitRootLogin = "prohibit-password";
+    extraConfig = ''
+      Match Address 10.10.10.0/24
+        PermitRootLogin yes
+    '';
+  };
+
+  services.fail2ban = {
+    enable = true;
+    maxretry = 5;
+    ignoreIP = [
+      "127.0.0.1/8"
+      "10.10.0.0/16"
+    ];
+  };
+
+  users.users.deepwatrcreatur = {
+    isNormalUser = true;
+    extraGroups = [ "wheel" ];
+    shell = pkgs.fish;
+  };
+
+  services.ssh-keys-manager.username = "deepwatrcreatur";
+
+  programs.fish.enable = true;
+
+  security.sudo.wheelNeedsPassword = false;
+
+  environment.systemPackages = with pkgs; [ tmux ];
+
+  age.secrets = secrets.definitions;
+
+  services.router-log-storage.enable = lib.mkForce enableLogStorage;
+
+  nixpkgs.hostPlatform = "x86_64-linux";
+  system.stateVersion = "25.05";
+}

--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -179,6 +179,17 @@ let
   routerCaddyHostsMissingInInventory =
     builtins.filter (name: !(builtins.elem name routerPublicIngressServices)) routerCaddyVirtualHostNames;
 
+  routerPrimaryHost = libHosts.router;
+  routerBackupHost = libHosts.router-backup;
+  routerPrimarySshTarget = routerPrimaryHost.sshHostname or routerPrimaryHost.hostname or routerPrimaryHost.ip or null;
+  routerBackupSshTarget = routerBackupHost.sshHostname or routerBackupHost.hostname or routerBackupHost.ip or null;
+  routerSpareModelIssues =
+    (pkgs.lib.optional (routerPrimarySshTarget == null) "router is missing an SSH management target in lib/hosts.nix")
+    ++ (pkgs.lib.optional (routerBackupSshTarget == null) "router-backup is missing an SSH management target in lib/hosts.nix")
+    ++ (pkgs.lib.optional (routerPrimarySshTarget == routerBackupSshTarget) "router and router-backup must not share the same management SSH target")
+    ++ (pkgs.lib.optional ((routerBackupHost.includeDns or true)) "router-backup must stay out of DNS inventory while it is a standby spare")
+    ++ (pkgs.lib.optional ((routerBackupHost.ip or null) != null) "router-backup must not advertise a distinct production IP in lib/hosts.nix");
+
   aspectNames = builtins.attrNames denAspectRegistry;
 
   # Read aspectsList directly from inventory entries (aspect hosts must declare it there).
@@ -300,6 +311,7 @@ let
       [ "Caddy virtualHosts in hosts/nixos/router/caddy.nix are missing from router.publicIngressServices: ${builtins.concatStringsSep ", " routerCaddyHostsMissingInInventory}" ]
     else
       [ ])
+    ++ (if routerSpareModelIssues != [ ] then routerSpareModelIssues else [ ])
     ++ (if lxcHostsMissingNetworking != [ ] then
       [ "LXC hosts use lxc-core without a networking aspect and are not in lxcStaticNetworkingHosts: ${builtins.concatStringsSep ", " lxcHostsMissingNetworking}" ]
     else


### PR DESCRIPTION
## Summary
- extract the shared production router role into a dedicated module consumed by both router hosts
- stop making router-backup inherit the full primary router host and then override it piecemeal
- add inventory checks that enforce the intended spare-router management model

## Why
This revisits the earlier router/router-backup structural work in a form that is easier to reason about and review:
- shared production-router behavior now lives in one place
- primary/spare differences are explicit constructor-style parameters
- the spare-router invariants are checked instead of living only in docs

## Validation
- nix build .#checks.x86_64-linux.inventory-consistency
- nix build .#nixosConfigurations.router.config.system.build.toplevel
- nix build .#nixosConfigurations.router-backup.config.system.build.toplevel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized router configuration for improved consistency between primary and backup instances.

* **Tests**
  * Added validation checks to ensure router redundancy configuration and prevent misconfiguration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->