### PR TITLE
refactor(den): derive host leaf aspects from inventory

### DIFF
--- a/den/hosts/attic-cache/default.nix
+++ b/den/hosts/attic-cache/default.nix
@@ -2,11 +2,6 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "attic-cache";
-  aspectsList = [
-    "attic-cache-core"
-    "attic-cache-build-server"
-    "attic-cache-home-manager"
-  ];
 }

--- a/den/hosts/authentik-host/default.nix
+++ b/den/hosts/authentik-host/default.nix
@@ -2,20 +2,10 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "authentik-host";
   primaryUser = "deepwatrcreatur";
   primaryUserImports = [
     ../../../users/deepwatrcreatur/hosts/authentik-host
-  ];
-  aspectsList = [
-    "nixos-base"
-    "lxc-core"
-    "lxc-dhcp-networking"
-    "authentik-native"
-    "authentik-paperless-oidc"
-    "attic-client"
-    "nix-daemon-user-ssh"
-    "home-manager-users"
   ];
 }

--- a/den/hosts/homeserver/default.nix
+++ b/den/hosts/homeserver/default.nix
@@ -2,24 +2,10 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "homeserver";
   primaryUser = "deepwatrcreatur";
   primaryUserImports = [
     ../../../users/deepwatrcreatur/hosts/homeserver
-  ];
-  aspectsList = [
-    "nixos-base"
-    "lxc-core"
-    "attic-client"
-    "rclone-client"
-    "github-token-client"
-    "nix-daemon-user-ssh"
-    "home-manager-users"
-    "homeserver-networking"
-    "homeserver-iperf3"
-    "homeserver-homebridge"
-    "homeserver-semaphore"
-    "rustdesk-server"
   ];
 }

--- a/den/hosts/inference-fresh/default.nix
+++ b/den/hosts/inference-fresh/default.nix
@@ -2,7 +2,7 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "inference-fresh";
   primaryUser = "deepwatrcreatur";
   extraImports = [
@@ -16,7 +16,4 @@ den.mkHostModule {
     )
   ];
   # No inference-vm-nvidia: this host has no GPU and runs without NVIDIA drivers.
-  aspectsList = [
-    "inference-vm-base"
-  ];
 }

--- a/den/hosts/inference1/default.nix
+++ b/den/hosts/inference1/default.nix
@@ -2,7 +2,7 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "inference1";
   primaryUser = "deepwatrcreatur";
   extraImports = [
@@ -14,10 +14,5 @@ den.mkHostModule {
         boot.growPartition = true;
       }
     )
-  ];
-  aspectsList = [
-    "inference-vm-base"
-    "inference-vm-nvidia"
-    "inference1-ollama"
   ];
 }

--- a/den/hosts/inference2/default.nix
+++ b/den/hosts/inference2/default.nix
@@ -2,7 +2,7 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "inference2";
   primaryUser = "deepwatrcreatur";
   extraImports = [
@@ -14,9 +14,5 @@ den.mkHostModule {
         boot.growPartition = true;
       }
     )
-  ];
-  aspectsList = [
-    "inference-vm-base"
-    "inference-vm-nvidia"
   ];
 }

--- a/den/hosts/inference3/default.nix
+++ b/den/hosts/inference3/default.nix
@@ -2,7 +2,7 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "inference3";
   primaryUser = "deepwatrcreatur";
   extraImports = [
@@ -14,9 +14,5 @@ den.mkHostModule {
         boot.growPartition = true;
       }
     )
-  ];
-  aspectsList = [
-    "inference-vm-base"
-    "inference-vm-nvidia"
   ];
 }

--- a/den/hosts/phoenix/default.nix
+++ b/den/hosts/phoenix/default.nix
@@ -2,15 +2,11 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "phoenix";
   primaryUser = "deepwatrcreatur";
   extraImports = [
     ../../../hosts/nixos/phoenix/hardware-configuration.nix
     ../../../hosts/nixos/phoenix/networking.nix
-  ];
-  aspectsList = [
-    "nixos-base"
-    "workstation-desktop"
   ];
 }

--- a/den/hosts/podman/default.nix
+++ b/den/hosts/podman/default.nix
@@ -2,7 +2,7 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "podman";
   primaryUser = "deepwatrcreatur";
   extraGroups = [
@@ -11,16 +11,5 @@ den.mkHostModule {
   ];
   primaryUserImports = [
     ../../../users/deepwatrcreatur/hosts/podman
-  ];
-  aspectsList = [
-    "nixos-base"
-    "lxc-core"
-    "attic-client"
-    "rclone-client"
-    "github-token-client"
-    "nix-daemon-user-ssh"
-    "home-manager-users"
-    "podman-lxc-suppressions"
-    "podman-containers"
   ];
 }

--- a/den/hosts/router-backup/default.nix
+++ b/den/hosts/router-backup/default.nix
@@ -2,17 +2,11 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "router-backup";
   primaryUser = "deepwatrcreatur";
   primaryUserImports = [
     ../../../users/deepwatrcreatur/hosts/router-backup/default.nix
-  ];
-  aspectsList = [
-    "nixos-base"
-    "home-manager-users"
-    "github-token-client"
-    "router-router"
   ];
   extraImports = [
     ../../../hosts/nixos/router-backup/hardware-configuration.nix

--- a/den/hosts/router-bootstrap/default.nix
+++ b/den/hosts/router-bootstrap/default.nix
@@ -2,13 +2,9 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "router-bootstrap";
   primaryUser = "deepwatrcreatur";
-  aspectsList = [
-    "nixos-base"
-    "bootstrap-base"
-  ];
   extraImports = [
     ../../../hosts/nixos/router-bootstrap/hardware-configuration.nix
   ];

--- a/den/hosts/router/default.nix
+++ b/den/hosts/router/default.nix
@@ -2,17 +2,11 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "router";
   primaryUser = "deepwatrcreatur";
   primaryUserImports = [
     ../../../users/deepwatrcreatur/hosts/router
-  ];
-  aspectsList = [
-    "nixos-base"
-    "home-manager-users"
-    "github-token-client"
-    "router-router"
   ];
   extraImports = [
     ../../../hosts/nixos/router/hardware-configuration.nix

--- a/den/hosts/rustdesk/default.nix
+++ b/den/hosts/rustdesk/default.nix
@@ -2,14 +2,6 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "rustdesk";
-  aspectsList = [
-    "nixos-base"
-    "lxc-core"
-    "attic-client"
-    "nix-daemon-user-ssh"
-    "home-manager-users"
-    "rustdesk-server"
-  ];
 }

--- a/den/hosts/workstation/default.nix
+++ b/den/hosts/workstation/default.nix
@@ -2,7 +2,7 @@
 let
   den = import ../../lib.nix { inherit lib; };
 in
-den.mkHostModule {
+den.mkInventoryHostModule {
   name = "workstation";
   primaryUser = "deepwatrcreatur";
   primaryUserImports = [
@@ -12,10 +12,5 @@ den.mkHostModule {
   extraImports = [
     ../../../hosts/nixos/workstation/hardware-configuration.nix
     ../../../hosts/nixos/workstation/networking.nix
-  ];
-  aspectsList = [
-    "nixos-base"
-    "home-manager-users"
-    "workstation-desktop"
   ];
 }

--- a/den/inventory/hosts.nix
+++ b/den/inventory/hosts.nix
@@ -9,6 +9,8 @@
       "nixos-base"
       "lxc-core"
       "lxc-dhcp-networking"
+      "authentik-native"
+      "authentik-paperless-oidc"
       "attic-client"
       "nix-daemon-user-ssh"
       "home-manager-users"
@@ -39,6 +41,8 @@
       "nixos-base"
       "lxc-core"
       "attic-client"
+      "rclone-client"
+      "github-token-client"
       "nix-daemon-user-ssh"
       "home-manager-users"
       "homeserver-networking"
@@ -59,6 +63,7 @@
     aspectsList = [
       "nixos-base"
       "home-manager-users"
+      "github-token-client"
       "router-router"
     ];
   };
@@ -72,6 +77,8 @@
     mode = "aspect";
     aspectsList = [
       "nixos-base"
+      "home-manager-users"
+      "github-token-client"
       "router-router"
     ];
   };
@@ -147,6 +154,8 @@
       "nixos-base"
       "lxc-core"
       "attic-client"
+      "rclone-client"
+      "github-token-client"
       "nix-daemon-user-ssh"
       "home-manager-users"
       "podman-lxc-suppressions"
@@ -179,6 +188,7 @@
     mode = "aspect";
     aspectsList = [
       "nixos-base"
+      "home-manager-users"
       "workstation-desktop"
     ];
   };

--- a/den/lib.nix
+++ b/den/lib.nix
@@ -2,8 +2,9 @@
 
 let
   aspects = import ./aspects { inherit lib; };
+  inventoryHosts = import ./inventory/hosts.nix;
 in
-{
+rec {
   mkHostModule =
     {
       name,
@@ -33,6 +34,26 @@ in
             }
           )
           aspectsList) ++ extraImports;
+    };
+
+  mkInventoryHostModule =
+    {
+      name,
+      ...
+    }@args:
+    let
+      inventoryEntry =
+        inventoryHosts.${name}
+        or (throw "mkInventoryHostModule: unknown inventory host '${name}'");
+      inventoryAspects =
+        inventoryEntry.aspectsList
+        or (throw "mkInventoryHostModule: host '${name}' has no aspectsList in den/inventory/hosts.nix");
+    in
+    {
+      imports = (mkHostModule ((builtins.removeAttrs args [ "name" ]) // {
+        inherit name;
+        aspectsList = inventoryAspects;
+      })).imports;
     };
 
   # Borrowed from vic/den: select a value by hostname at eval time.


### PR DESCRIPTION
## Summary
- add a den helper that derives host leaf aspect lists from `den/inventory/hosts.nix`
- convert aspect-based den host leaves to use inventory-derived composition instead of repeating `aspectsList`
- keep host-specific imports and user wiring in the leaves while making inventory the single source of truth for aspect membership

## Validation
- nix build .#checks.x86_64-linux.inventory-consistency
- nix build .#checks.x86_64-linux.module-loading-eval
- nix build .#nixosConfigurations.router.config.system.build.toplevel
- nix build .#nixosConfigurations.workstation.config.system.build.toplevel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated host configuration management by migrating from individual host definitions to a centralized inventory-based system. Host aspects are now managed through a unified registry, improving configuration consistency and maintainability across all systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->