### PR TITLE
refactor(sessions): share plasma and lightdm session plumbing

### DIFF
--- a/modules/nixos/sessions/cinnamon.nix
+++ b/modules/nixos/sessions/cinnamon.nix
@@ -2,32 +2,13 @@
 
 {
   imports = [
+    ./lightdm-autologin-support.nix
     ./gnome-keyring-support.nix
     ./whitesur-theme.nix
   ];
 
-  # ===========================================
-  # Base Configuration
-  # ===========================================
-
-  # Enable X11 windowing system.
-  services.xserver.enable = true;
-
   # Enable Cinnamon desktop environment.
   services.xserver.desktopManager.cinnamon.enable = true;
-
-  # Configure autorepeat for Proxmox guest to prevent stuck keypresses
-  services.xserver.autoRepeatDelay = 300;
-  services.xserver.autoRepeatInterval = 40;
-
-  # Enable LightDM display manager for Cinnamon
-  services.xserver.displayManager.lightdm.enable = true;
-
-  # Enable autologin
-  services.displayManager.autoLogin = {
-    enable = true;
-    user = "deepwatrcreatur";
-  };
 
   # ===========================================
   # Cinnamon-Specific Packages

--- a/modules/nixos/sessions/garuda-plasma-theme.nix
+++ b/modules/nixos/sessions/garuda-plasma-theme.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+
+{
+  environment.systemPackages = with pkgs; [
+    beauty-line-icon-theme
+    candy-icons
+    capitaine-cursors
+  ];
+
+  environment.variables = {
+    ICON_THEME = "BeautyLine";
+  };
+}

--- a/modules/nixos/sessions/garuda-themed-kde.nix
+++ b/modules/nixos/sessions/garuda-themed-kde.nix
@@ -1,105 +1,11 @@
 # Configuration for KDE Plasma with Garuda Dragonized theming elements
 {
-  config,
-  pkgs,
-  inputs,
   ...
 }:
 
 {
-  imports = [ ./plasma-kwallet-support.nix ];
-
-  # Import plasma-manager for home-manager integration
-  home-manager.sharedModules = [
-    inputs.plasma-manager.homeManagerModules.plasma-manager
-    ../../kde-plasma.nix
+  imports = [
+    ./plasma-session-base.nix
+    ./garuda-plasma-theme.nix
   ];
-
-  # System packages for theming
-  environment.systemPackages = with pkgs; [
-    # Icon themes (these work across desktop environments)
-    beauty-line-icon-theme # Main Garuda icon theme
-    candy-icons # Complementary icons
-
-    # Cursor themes
-    capitaine-cursors # Clean cursor theme
-
-    # Wallpapers and assets (manual download needed)
-    # garuda-wallpapers would go here if packaged
-
-    # KDE applications and tools
-    kdePackages.plasma-desktop
-    kdePackages.systemsettings
-    kdePackages.plasma-systemmonitor
-    kdePackages.kate
-    kdePackages.dolphin
-    kdePackages.konsole
-
-    # Additional tools for theming
-    dconf-editor # For GTK app theming
-
-    # Fonts that match Garuda's aesthetic
-    # jetbrains-mono  # Temporarily commented out due to build issues
-    fira-code
-    noto-fonts-color-emoji
-  ];
-
-  # Enable KDE Plasma desktop environment
-  services.desktopManager.plasma6.enable = true;
-  services.displayManager.sddm.enable = true;
-
-  # Enable X11 for KDE
-  services.xserver.enable = true;
-
-  services.displayManager = {
-    autoLogin = {
-      enable = true;
-      user = "deepwatrcreatur";
-    };
-  };
-
-  # GTK theming for applications
-  programs.dconf.enable = true;
-
-  # Icon theme configuration (system-wide)
-  environment.variables = {
-    # This may help with icon theme detection
-    ICON_THEME = "BeautyLine";
-  };
-
-  # XDG portals for better desktop integration
-  xdg.portal = {
-    enable = true;
-    extraPortals = [
-      pkgs.xdg-desktop-portal-gtk
-      pkgs.kdePackages.xdg-desktop-portal-kde
-    ];
-  };
-
-  # Fonts configuration
-  fonts = {
-    packages = with pkgs; [
-      noto-fonts
-      noto-fonts-color-emoji
-      # jetbrains-mono  # Temporarily commented out due to build issues
-      fira-code
-      fira-code-symbols
-    ];
-
-    fontconfig = {
-      defaultFonts = {
-        monospace = [ "Fira Code" ]; # Removed JetBrains Mono due to build issues
-        sansSerif = [ "Noto Sans" ];
-        serif = [ "Noto Serif" ];
-        emoji = [ "Noto Color Emoji" ];
-      };
-    };
-  };
 }
-
-# Post-installation steps:
-# 1. Icons should be available system-wide after rebuild
-# 2. For wallpapers, manually download from Garuda's GitLab
-# 3. Configure KDE's theming through System Settings
-# 4. Set BeautyLine as icon theme in KDE settings
-# 5. Extract color schemes from Sweet theme for manual application

--- a/modules/nixos/sessions/kde-x11.nix
+++ b/modules/nixos/sessions/kde-x11.nix
@@ -1,106 +1,16 @@
 # Configuration for KDE Plasma with Garuda Dragonized theming elements, forced to use X11
 {
-  config,
-  pkgs,
-  inputs,
+  lib,
   ...
 }:
 
 {
-  imports = [ ./plasma-kwallet-support.nix ];
-
-  # Import plasma-manager for home-manager integration
-  home-manager.sharedModules = [
-    inputs.plasma-manager.homeManagerModules.plasma-manager
-    ../../kde-plasma.nix
+  imports = [
+    ./plasma-session-base.nix
+    ./garuda-plasma-theme.nix
   ];
 
-  # System packages for theming
-  environment.systemPackages = with pkgs; [
-    # Icon themes (these work across desktop environments)
-    beauty-line-icon-theme # Main Garuda icon theme
-    candy-icons # Complementary icons
-
-    # Cursor themes
-    capitaine-cursors # Clean cursor theme
-
-    # Wallpapers and assets (manual download needed)
-    # garuda-wallpapers would go here if packaged
-
-    # KDE applications and tools
-    kdePackages.plasma-desktop
-    kdePackages.systemsettings
-    kdePackages.plasma-systemmonitor
-    kdePackages.kate
-    kdePackages.dolphin
-    kdePackages.konsole
-
-    # Additional tools for theming
-    dconf-editor # For GTK app theming
-
-    # Fonts that match Garuda's aesthetic
-    # jetbrains-mono  # Temporarily commented out due to build issues
-    fira-code
-    noto-fonts-color-emoji
-  ];
-
-  # Enable KDE Plasma desktop environment
-  services.desktopManager.plasma6.enable = true;
-  services.displayManager.sddm.enable = true;
-
-  # Enable X11 for KDE
   services.xserver.enable = true;
 
-  services.displayManager = {
-    defaultSession = "plasmax11";
-    autoLogin = {
-      enable = true;
-      user = "deepwatrcreatur";
-    };
-  };
-
-  # GTK theming for applications
-  programs.dconf.enable = true;
-
-  # Icon theme configuration (system-wide)
-  environment.variables = {
-    # This may help with icon theme detection
-    ICON_THEME = "BeautyLine";
-  };
-
-  # XDG portals for better desktop integration
-  xdg.portal = {
-    enable = true;
-    extraPortals = [
-      pkgs.xdg-desktop-portal-gtk
-      pkgs.kdePackages.xdg-desktop-portal-kde
-    ];
-  };
-
-  # Fonts configuration
-  fonts = {
-    packages = with pkgs; [
-      noto-fonts
-      noto-fonts-color-emoji
-      # jetbrains-mono  # Temporarily commented out due to build issues
-      fira-code
-      fira-code-symbols
-    ];
-
-    fontconfig = {
-      defaultFonts = {
-        monospace = [ "Fira Code" ]; # Removed JetBrains Mono due to build issues
-        sansSerif = [ "Noto Sans" ];
-        serif = [ "Noto Serif" ];
-        emoji = [ "Noto Color Emoji" ];
-      };
-    };
-  };
+  services.displayManager.defaultSession = lib.mkForce "plasmax11";
 }
-
-# Post-installation steps:
-# 1. Icons should be available system-wide after rebuild
-# 2. For wallpapers, manually download from Garuda's GitLab
-# 3. Configure KDE's theming through System Settings
-# 4. Set BeautyLine as icon theme in KDE settings
-# 5. Extract color schemes from Sweet theme for manual application

--- a/modules/nixos/sessions/lightdm-autologin-support.nix
+++ b/modules/nixos/sessions/lightdm-autologin-support.nix
@@ -1,0 +1,15 @@
+{ lib, ... }:
+
+{
+  services.xserver.enable = lib.mkDefault true;
+
+  services.xserver.autoRepeatDelay = lib.mkDefault 300;
+  services.xserver.autoRepeatInterval = lib.mkDefault 40;
+
+  services.xserver.displayManager.lightdm.enable = lib.mkDefault true;
+
+  services.displayManager.autoLogin = {
+    enable = lib.mkDefault true;
+    user = lib.mkDefault "deepwatrcreatur";
+  };
+}

--- a/modules/nixos/sessions/mate.nix
+++ b/modules/nixos/sessions/mate.nix
@@ -2,28 +2,13 @@
 
 {
   imports = [
+    ./lightdm-autologin-support.nix
     ./gnome-keyring-support.nix
     ./whitesur-theme.nix
   ];
 
-  # Enable X11 windowing system.
-  services.xserver.enable = true;
-
   # Enable MATE desktop environment.
   services.xserver.desktopManager.mate.enable = true;
-
-  # Configure autorepeat for Proxmox guest to prevent stuck keypresses
-  services.xserver.autoRepeatDelay = 300;
-  services.xserver.autoRepeatInterval = 40;
-
-  # Enable LightDM display manager for MATE
-  services.xserver.displayManager.lightdm.enable = true;
-
-  # Enable autologin
-  services.displayManager.autoLogin = {
-    enable = true;
-    user = "deepwatrcreatur";
-  };
 
   # Packages for MATE with WhiteSur theming
   environment.systemPackages = with pkgs; [

--- a/modules/nixos/sessions/plasma-session-base.nix
+++ b/modules/nixos/sessions/plasma-session-base.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+let
+  plasmaManagerModule =
+    if inputs.plasma-manager ? homeManagerModules
+      && inputs.plasma-manager.homeManagerModules ? plasma-manager
+    then
+      inputs.plasma-manager.homeManagerModules.plasma-manager
+    else if inputs.plasma-manager ? homeModules && inputs.plasma-manager.homeModules ? plasma-manager then
+      inputs.plasma-manager.homeModules.plasma-manager
+    else
+      throw "plasma-session-base: plasma-manager flake no longer exposes a plasma-manager home module";
+
+  plasmaBasePackages = with pkgs; [
+    kdePackages.plasma-desktop
+    kdePackages.systemsettings
+    kdePackages.plasma-systemmonitor
+    kdePackages.kate
+    kdePackages.dolphin
+    kdePackages.konsole
+    dconf-editor
+  ];
+
+  plasmaFonts = with pkgs; [
+    noto-fonts
+    noto-fonts-color-emoji
+    fira-code
+    fira-code-symbols
+  ];
+in
+{
+  imports = [ ./plasma-kwallet-support.nix ];
+
+  home-manager.sharedModules = [
+    plasmaManagerModule
+    ../../kde-plasma.nix
+  ];
+
+  services.desktopManager.plasma6.enable = true;
+  services.displayManager.sddm.enable = true;
+
+  services.displayManager = {
+    defaultSession = lib.mkDefault "plasma";
+    autoLogin = {
+      enable = lib.mkDefault true;
+      user = lib.mkDefault "deepwatrcreatur";
+    };
+  };
+
+  programs.dconf.enable = true;
+
+  environment.systemPackages = plasmaBasePackages;
+
+  xdg.portal = {
+    enable = true;
+    extraPortals = [
+      pkgs.xdg-desktop-portal-gtk
+      pkgs.kdePackages.xdg-desktop-portal-kde
+    ];
+  };
+
+  fonts = {
+    packages = plasmaFonts;
+
+    fontconfig.defaultFonts = {
+      monospace = [ "Fira Code" ];
+      sansSerif = [ "Noto Sans" ];
+      serif = [ "Noto Serif" ];
+      emoji = [ "Noto Color Emoji" ];
+    };
+  };
+}

--- a/modules/nixos/sessions/whitesur-themed-kde.nix
+++ b/modules/nixos/sessions/whitesur-themed-kde.nix
@@ -1,103 +1,28 @@
 {
-  config,
-  lib,
   pkgs,
-  inputs,
   ...
 }:
 {
   imports = [
-    ./plasma-kwallet-support.nix
+    ./plasma-session-base.nix
     ./whitesur-theme.nix
   ];
 
-  # KDE Plasma with WhiteSur theming for workstation
-  # Similar aesthetic to COSMIC but with KDE's power and Thunderbird badge support
-
-  # Import plasma-manager for home-manager integration
-  home-manager.sharedModules = [
-    inputs.plasma-manager.homeModules.plasma-manager
-    ../../kde-plasma.nix
-  ];
-
-  # Enable KDE Plasma 6 desktop environment
-  services.desktopManager.plasma6.enable = true;
-  services.displayManager.sddm.enable = true;
-
   services.displayManager = {
-    # Workstation now runs Plasma on Wayland; match SDDM autologin to the
-    # installed session name instead of the legacy X11 session.
     defaultSession = "plasma";
-    autoLogin = {
-      enable = true;
-      user = "deepwatrcreatur";
-    };
   };
 
-  # System packages for KDE and theming
   environment.systemPackages = with pkgs; [
-    # KDE core applications
-    kdePackages.plasma-desktop
-    kdePackages.systemsettings
-    kdePackages.plasma-systemmonitor
-    kdePackages.kate
-    kdePackages.dolphin
-    kdePackages.konsole
-
-    # QML modules for KDE plasmoids (fixes missing module errors)
     kdePackages.bluedevil
-
-    # Utilities
-    dconf-editor # For GTK app theme configuration
-
-    # Thunderbird and mail support
     thunderbird
     libappindicator-gtk3
-
-    # Fonts
-    noto-fonts
-    noto-fonts-color-emoji
-    fira-code
-    fira-code-symbols
   ];
 
-  # GTK theming for non-KDE applications
-  programs.dconf.enable = true;
-
-  # WhiteSur theming configuration
   environment.variables = {
     ICON_THEME = "WhiteSur";
     GTK_THEME = "WhiteSur-Dark";
     GTK_ICON_THEME = "WhiteSur";
     GTK_CURSOR_THEME = "capitaine-cursors";
-  };
-
-  # XDG portals for better desktop integration
-  xdg.portal = {
-    enable = true;
-    extraPortals = [
-      pkgs.xdg-desktop-portal-gtk
-      pkgs.kdePackages.xdg-desktop-portal-kde
-    ];
-  };
-
-  # Fonts configuration
-  fonts = {
-    packages = with pkgs; [
-      noto-fonts
-      noto-fonts-color-emoji
-      fira-code
-      fira-code-symbols
-    ];
-
-    fontconfig = {
-      defaultFonts = {
-        monospace = [ "Fira Code" ];
-        sansSerif = [ "Noto Sans" ];
-        serif = [ "Noto Serif" ];
-        emoji = [ "Noto Color Emoji" ];
-      };
-    };
   };
 
 }


### PR DESCRIPTION
## Summary
- extract shared Plasma desktop plumbing into a reusable session base and separate Garuda theme overlay
- normalize `plasma-manager` integration behind one compatibility path instead of mixing `homeModules` and `homeManagerModules`
- collapse repeated LightDM X11 autologin wiring used by Cinnamon and MATE into a shared support module

## Validation
- nix build .#checks.x86_64-linux.module-loading-eval
- nix build .#nixosConfigurations.workstation.config.system.build.toplevel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
