### PR TITLE
refactor(attic): use upstream home-manager modules

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -835,6 +835,27 @@
     "home-manager_3": {
       "inputs": {
         "nixpkgs": [
+          "nix-attic-infra",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775080052,
+        "narHash": "sha256-jAB4ZZbx8ECu9GcE/PUUwT+wpooZ0Ssmn2imB8PVTdM=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "6267895e9898399f0ce2fe79b645e9ee4858aaff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_4": {
+      "inputs": {
+        "nixpkgs": [
           "nix-linuxbrew",
           "nixpkgs"
         ]
@@ -946,16 +967,17 @@
         "flake-utils": [
           "flake-utils"
         ],
+        "home-manager": "home-manager_3",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773621656,
-        "narHash": "sha256-fI+zrTJuxLV0YwlWnQnHzz81qwKoN5s2g/zwn6cs3dU=",
+        "lastModified": 1775126295,
+        "narHash": "sha256-0QiLWBwPpRzMGyI2ZN+J2f0oZsA7MAurE3MWLwPhXa4=",
         "owner": "deepwatrcreatur",
         "repo": "nix-attic-infra",
-        "rev": "6c963661dea080dfc335b256fdc2022032de4f67",
+        "rev": "cfa2bdac61190da7514c655dc5e7f942c5aa8b14",
         "type": "github"
       },
       "original": {
@@ -1112,7 +1134,7 @@
     "nix-linuxbrew": {
       "inputs": {
         "flake-utils": "flake-utils_6",
-        "home-manager": "home-manager_3",
+        "home-manager": "home-manager_4",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/modules/home-manager/attic-client-darwin.nix
+++ b/modules/home-manager/attic-client-darwin.nix
@@ -1,10 +1,5 @@
-{ config, lib, ... }:
+{ inputs, ... }:
 
 {
-  # attic-client service is only available on NixOS/Linux systems
-  # On macOS, we use the attic-client package directly without a service
-  programs.attic-client.enable = lib.mkDefault true;
-
-  # Enable user Nix configuration for Determinate Nix systems
-  services.nix-user-config.enable = lib.mkDefault true;
+  imports = [ inputs.nix-attic-infra.homeManagerModules.attic-client-darwin ];
 }

--- a/modules/home-manager/attic-client-darwin.nix
+++ b/modules/home-manager/attic-client-darwin.nix
@@ -1,5 +1,8 @@
-{ inputs, ... }:
+{ inputs, lib, ... }:
 
 {
   imports = [ inputs.nix-attic-infra.homeManagerModules.attic-client-darwin ];
+
+  programs.attic-client.enable = lib.mkDefault true;
+  services.nix-user-config.enable = lib.mkDefault true;
 }

--- a/modules/home-manager/common/attic-client.nix
+++ b/modules/home-manager/common/attic-client.nix
@@ -8,44 +8,24 @@
 let
   cfg = config.programs.attic-client;
   atticCache = import ../../../lib/attic-cache.nix;
-  atticServerType = lib.types.submodule {
-    options = {
-      endpoint = lib.mkOption {
-        type = lib.types.str;
-        description = "Attic server endpoint URL";
-      };
-
-      tokenPath = lib.mkOption {
-        type = lib.types.str;
-        default = "${config.home.homeDirectory}/.config/sops/attic-client-token";
-        description = "Path to the token file used for this server.";
-      };
-
-      aliases = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        description = "Optional attic push/pull alias names for this server.";
-      };
+  defaultTokenPath = "${config.home.homeDirectory}/.config/sops/attic-client-token";
+  defaultServers = {
+    ${atticCache.serverName} = {
+      endpoint = atticCache.serverEndpoint;
+      tokenPath = defaultTokenPath;
+      aliases = [ "cache" ];
+    };
+    "${atticCache.serverName}-local" = {
+      endpoint = atticCache.serverEndpoint;
+      tokenPath = defaultTokenPath;
+      aliases = [ "local" ];
     };
   };
 in
 {
   imports = [ inputs.nix-attic-infra.homeManagerModules.attic-client ];
 
-  options.programs.attic-client.defaultServers = lib.mkOption {
-    type = lib.types.attrsOf atticServerType;
-    default = {
-      ${atticCache.serverName} = {
-        endpoint = atticCache.serverEndpoint;
-      };
-      "${atticCache.serverName}-local" = {
-        endpoint = atticCache.serverEndpoint;
-      };
-    };
-    description = "Repository default Attic servers layered onto the upstream module.";
-  };
-
   config = lib.mkIf cfg.enable {
-    programs.attic-client.servers = lib.mkDefault cfg.defaultServers;
+    programs.attic-client.servers = lib.mkDefault defaultServers;
   };
 }

--- a/modules/home-manager/common/attic-client.nix
+++ b/modules/home-manager/common/attic-client.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   inputs,
   ...
 }:
@@ -9,121 +8,44 @@
 let
   cfg = config.programs.attic-client;
   atticCache = import ../../../lib/attic-cache.nix;
+  atticServerType = lib.types.submodule {
+    options = {
+      endpoint = lib.mkOption {
+        type = lib.types.str;
+        description = "Attic server endpoint URL";
+      };
+
+      tokenPath = lib.mkOption {
+        type = lib.types.str;
+        default = "${config.home.homeDirectory}/.config/sops/attic-client-token";
+        description = "Path to the token file used for this server.";
+      };
+
+      aliases = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Optional attic push/pull alias names for this server.";
+      };
+    };
+  };
 in
 {
-  options.programs.attic-client = {
-    enable = lib.mkEnableOption "Attic binary cache client" // {
-      default = false;
-      description = "Whether to enable Attic binary cache client with SOPS-managed authentication";
-    };
+  imports = [ inputs.nix-attic-infra.homeManagerModules.attic-client ];
 
-    servers = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options = {
-            endpoint = lib.mkOption {
-              type = lib.types.str;
-              description = "Attic server endpoint URL";
-            };
-            tokenPath = lib.mkOption {
-              type = lib.types.str;
-              default = "${config.home.homeDirectory}/.config/sops/attic-client-token";
-              description = "Path to the SOPS-decrypted token file";
-            };
-          };
-        }
-      );
-      default = { };
-      description = "Attic servers configuration";
-    };
-
-    defaultServers = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options = {
-            endpoint = lib.mkOption {
-              type = lib.types.str;
-              description = "Attic server endpoint URL";
-            };
-            tokenPath = lib.mkOption {
-              type = lib.types.str;
-              default = "${config.home.homeDirectory}/.config/sops/attic-client-token";
-              description = "Path to the SOPS-decrypted token file";
-            };
-          };
-        }
-      );
-      default = {
-        ${atticCache.serverName} = {
-          endpoint = atticCache.serverEndpoint;
-        };
-        "${atticCache.serverName}-local" = {
-          endpoint = atticCache.serverEndpoint;
-        };
+  options.programs.attic-client.defaultServers = lib.mkOption {
+    type = lib.types.attrsOf atticServerType;
+    default = {
+      ${atticCache.serverName} = {
+        endpoint = atticCache.serverEndpoint;
       };
-      description = "Default Attic servers (can be overridden)";
+      "${atticCache.serverName}-local" = {
+        endpoint = atticCache.serverEndpoint;
+      };
     };
+    description = "Repository default Attic servers layered onto the upstream module.";
   };
 
   config = lib.mkIf cfg.enable {
-    # Install attic-client
-    home.packages = [ (if pkgs ? attic-fnox then pkgs.attic-fnox else pkgs.attic-client) ];
-
-    # Merge default servers with user-specified servers
     programs.attic-client.servers = lib.mkDefault cfg.defaultServers;
-
-    # Create Attic client configuration template
-    home.file.".config/attic/config.toml".text =
-      let
-        allServers = cfg.defaultServers // cfg.servers;
-        serverConfigs = lib.mapAttrsToList (name: server: ''
-          [servers.${name}]
-          endpoint = "${server.endpoint}"
-          token = "@ATTIC_CLIENT_TOKEN_${lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] name)}@"
-        '') allServers;
-      in
-      lib.concatStringsSep "\n\n" serverConfigs;
-
-    # Home activation script to substitute tokens
-    home.activation.attic-config = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      $DRY_RUN_CMD mkdir -p ${config.home.homeDirectory}/.config/attic
-
-      if [[ -f ${config.home.homeDirectory}/.config/attic/config.toml ]]; then
-        config_file="${config.home.homeDirectory}/.config/attic/config.toml"
-        temp_file="/tmp/attic-config-$$.toml"
-
-        # Copy the template
-        cp "$config_file" "$temp_file"
-
-        # Try to get token from fnox
-        fnox_token=$(fnox get ATTIC_CLIENT_JWT_TOKEN 2>/dev/null || echo "")
-
-        ${lib.concatStringsSep "\n        " (
-          lib.mapAttrsToList (name: server: ''
-            # Substitute token for ${name}
-            placeholder="@ATTIC_CLIENT_TOKEN_${lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] name)}@"
-
-            if [[ -n "$fnox_token" ]]; then
-               $DRY_RUN_CMD sed -i "s|$placeholder|$fnox_token|g" "$temp_file"
-            elif [[ -f "${server.tokenPath}" ]]; then
-              token=$(cat "${server.tokenPath}")
-              $DRY_RUN_CMD sed -i "s|$placeholder|$token|g" "$temp_file"
-            else
-              $VERBOSE_ECHO "Warning: Token not found in fnox or file for ${name}: ${server.tokenPath}"
-            fi
-          '') (cfg.defaultServers // cfg.servers)
-        )}
-
-        # Move the configured file into place
-        $DRY_RUN_CMD mv "$temp_file" "$config_file"
-        $VERBOSE_ECHO "Attic client configuration updated with tokens"
-      fi
-    '';
-
-    # Add shell aliases for convenience
-    home.shellAliases = {
-      attic-push-local = "attic push cache-local";
-      attic-push-cache = "attic push attic-cache";
-    };
   };
 }

--- a/modules/home-manager/common/tool-aliases.nix
+++ b/modules/home-manager/common/tool-aliases.nix
@@ -45,7 +45,11 @@ let
   wrappedToolAliases =
     (lib.optionalAttrs (pkgs ? gh-fnox) { gh = "gh-fnox"; })
     // (lib.optionalAttrs (pkgs ? bw-fnox) { bw = "bw-fnox"; })
-    // (lib.optionalAttrs (pkgs ? attic-fnox) { attic = "attic-fnox"; });
+    // (
+      lib.optionalAttrs ((pkgs ? attic-fnox) && !(config.programs.attic-client.enable or false)) {
+        attic = "attic-fnox";
+      }
+    );
 in
 {
   options.custom.toolAliases = {


### PR DESCRIPTION
## Summary
- update the nix-attic-infra input to the merged upstream revision
- replace the local Home Manager attic client implementation with a thin wrapper over upstream
- replace the Darwin attic shim with a compatibility import of the upstream Darwin module

## Validation
- nix build .#homeConfigurations.proxmox-root.activationPackage
- nix flake check --no-build (still hits the pre-existing nixos_lxc_without_determinate bootstrap import issue)
- nix build .#darwinConfigurations.macminim4.system (still hits the pre-existing cross-system ssh-config-generated realisation issue from this Linux host)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized attic-client configuration to use shared, centralized modules for macOS and common behavior.
  * Removed local option declarations in favor of centralized handling.

* **New Features**
  * Default server entries and a default token path are now provided when attic-client is enabled.
  * A command-line alias for the attic tool is added automatically when the package is available and attic-client is not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->