### PR TITLE
fix(router): add vm recovery console support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1159,16 +1159,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1775171534,
-        "narHash": "sha256-S2trnbSPYWBg3yi+G7yUZh9OzFd1phJl+H5SsSXn+IE=",
+        "lastModified": 1775176663,
+        "narHash": "sha256-RNVw7tgfPpqNnmMEyLWTZ7igmah3GjYehPLJZZgywQo=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "8185b2ee1c9ef6509b03b4cf8eaadc8aa54d7ac5",
+        "rev": "46a97441d174d392a7552cac6961f346cade9815",
         "type": "github"
       },
       "original": {
         "owner": "deepwatrcreatur",
-        "ref": "feat/router-tailscale",
         "repo": "nix-router-optimized",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -118,8 +118,7 @@
     };
 
     nix-router-optimized = {
-      # Temporary branch pin while testing upstream router-tailscale integration.
-      url = "github:deepwatrcreatur/nix-router-optimized/feat/router-tailscale";
+      url = "github:deepwatrcreatur/nix-router-optimized";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -51,7 +51,6 @@ in
     services = {
       enableSsh = true;
       enableDocker = false;
-      enablePodman = true;
       iperf3.enable = true;
     };
   };
@@ -162,6 +161,7 @@ in
   boot.loader.grub.enable = false;
   boot.loader.limine.enable = true;
   boot.loader.efi.canTouchEfiVariables = false;
+  boot.kernelParams = [ "console=ttyS0,115200" ];
 
   nix.settings.experimental-features = [
     "nix-command"
@@ -170,13 +170,12 @@ in
 
   my.agenix.machineIdentity.enable = true;
 
-  virtualisation.podman = {
-    enable = true;
-    dockerCompat = true;
-  };
-  virtualisation.oci-containers.backend = "podman";
-
   services.qemuGuest.enable = true;
+  services.fstrim.enable = true;
+
+  # Proxmox recovery path: keep a serial console available even when SSH or the
+  # graphical console path is broken.
+  systemd.services."serial-getty@ttyS0".enable = true;
 
   services.openssh = {
     enable = true;


### PR DESCRIPTION
## Summary
- add Proxmox-friendly serial console support to the shared router VM role
- keep qemu guest agent enabled in the role so Proxmox recovery tools work after a successful switch
- remove the stale Podman-specific router wiring instead of explicitly disabling Podman

## Validation
- nix build .#nixosConfigurations.router.config.system.build.toplevel
- nix build .#nixosConfigurations.router-backup.config.system.build.toplevel

## Notes
- the live Proxmox VM 110 on pve-z170 was also updated with serial0 socket and vga serial0 so a future generation with console=ttyS0 and serial-getty can be recovered from qm terminal
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
