### PR TITLE
refactor(router): centralize topology and remove hidden defaults

### DIFF
--- a/den/aspects/attic-cache-core.nix
+++ b/den/aspects/attic-cache-core.nix
@@ -1,4 +1,7 @@
 { ... }:
+let
+  hostsData = import ../../lib/hosts.nix;
+in
 { ... }:
 {
   imports = [
@@ -12,5 +15,8 @@
     ../../modules/nixos/attic-observatory.nix
   ];
 
-  host.services.iperf3.enable = true;
+  host.services.iperf3 = {
+    enable = true;
+    bindProbeAddress = hostsData.hosts.attic-cache.ip;
+  };
 }

--- a/den/aspects/homeserver-iperf3.nix
+++ b/den/aspects/homeserver-iperf3.nix
@@ -1,9 +1,15 @@
 { ... }:
+let
+  hostsData = import ../../lib/hosts.nix;
+in
 { ... }:
 {
   imports = [
     ../../modules/nixos/services/iperf3.nix
   ];
 
-  host.services.iperf3.enable = true;
+  host.services.iperf3 = {
+    enable = true;
+    bindProbeAddress = hostsData.hosts.homeserver.ip;
+  };
 }

--- a/docs/agent-handoff-plan-2026-04-02.md
+++ b/docs/agent-handoff-plan-2026-04-02.md
@@ -53,7 +53,7 @@ Do this after PR #9 for `nix-attic-infra` merges and `flake.lock` is updated:
 1. Refactor local Home Manager attic client support to wrap upstream instead of reimplementing it.
 
 Current local file to replace or thin out:
-- [`modules/home-manager/common/attic-client.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/home-manager/common/attic-client.nix)
+- [`modules/home-manager/common/attic-client.nix`](../modules/home-manager/common/attic-client.nix)
 
 Why:
 - it still has older portability/correctness issues that upstream now handles better:
@@ -69,7 +69,7 @@ Target shape:
 2. Consider replacing local Darwin attic shim with an upstream wrapper.
 
 Current local file:
-- [`modules/home-manager/attic-client-darwin.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/home-manager/attic-client-darwin.nix)
+- [`modules/home-manager/attic-client-darwin.nix`](../modules/home-manager/attic-client-darwin.nix)
 
 Likely action:
 - replace with a compatibility shim importing `inputs.nix-attic-infra.homeManagerModules.attic-client-darwin`
@@ -94,14 +94,14 @@ Note:
 ## Repo-local attic module status
 
 Already in good shape:
-- [`modules/nixos/attic-observatory.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/nixos/attic-observatory.nix)
-- [`modules/nixos/attic-post-build-hook.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/nixos/attic-post-build-hook.nix)
+- [`modules/nixos/attic-observatory.nix`](../modules/nixos/attic-observatory.nix)
+- [`modules/nixos/attic-post-build-hook.nix`](../modules/nixos/attic-post-build-hook.nix)
 
 These are already compatibility shims importing upstream implementation.
 
 Not yet upstream-backed:
-- [`modules/home-manager/common/attic-client.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/home-manager/common/attic-client.nix)
-- [`modules/home-manager/attic-client-darwin.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/home-manager/attic-client-darwin.nix)
+- [`modules/home-manager/common/attic-client.nix`](../modules/home-manager/common/attic-client.nix)
+- [`modules/home-manager/attic-client-darwin.nix`](../modules/home-manager/attic-client-darwin.nix)
 
 ## Good validation commands for the follow-up refactor
 
@@ -129,7 +129,7 @@ GIT_SSH_COMMAND='ssh -F /dev/null' git -C /tmp/<repo> push origin <branch>
 ## Router follow-up
 
 Once `router` is back in a known-good booting and routing state, use:
-- [`docs/router-hardening-plan.md`](/home/deepwatrcreatur/flakes/unified-nix-configuration/docs/router-hardening-plan.md)
+- [`docs/router-hardening-plan.md`](./router-hardening-plan.md)
 
 That document captures:
 - the most useful router-specific ideas to borrow from existing Nix router work

--- a/docs/agent-handoff-plan-2026-04-02.md
+++ b/docs/agent-handoff-plan-2026-04-02.md
@@ -1,0 +1,137 @@
+# Agent Handoff Plan
+
+Date: 2026-04-02
+
+## Current repo state
+
+- Repository: `unified-nix-configuration`
+- Current local branch during this session: `refactor/den-inventory-aspects`
+- Work completed in this repo during the immediately preceding sessions:
+  - router / router-backup cleanup and management-IP model
+  - router dashboard PRs and structural follow-up PRs
+  - den/aspect follow-up PRs
+  - desktop session / keyring cleanup
+
+This handoff file is specifically for the latest upstream work on Attic-related flakes and the likely follow-up work in this repo.
+
+## Upstream PRs opened
+
+### nix-attic-infra
+
+- PR: <https://github.com/deepwatrcreatur/nix-attic-infra/pull/9>
+- Branch: `ci/expand-flake-evaluation-checks`
+- Commit: `19a210c`
+
+Summary:
+- replaces the shallow flake module-import check with representative NixOS and Home Manager evaluations
+- adds `home-manager` as a flake input so shipped HM modules are actually exercised in CI
+- fixes a dormant issue in `modules/home-manager/attic-client-darwin.nix` that the stronger evaluation surfaced
+
+Validation already run:
+- `nix flake check --no-build /tmp/nix-attic-infra`
+- `nix build /tmp/nix-attic-infra#checks.x86_64-linux.home-manager-attic-client-darwin-eval`
+
+### attic-observatory
+
+- PR: <https://github.com/deepwatrcreatur/attic-observatory/pull/6>
+- Branch: `ci/add-flake-checks-and-app`
+- Commit: `324822b`
+
+Summary:
+- adds flake-level unit test checks around the existing Python test suite
+- adds `apps.default` so the dashboard can be launched with `nix run`
+- adds a small dev shell and updates README workflow docs
+
+Validation already run:
+- `nix flake check --no-build /tmp/attic-observatory`
+- `nix build /tmp/attic-observatory#checks.x86_64-linux.unit-tests`
+
+## Most useful next work in this repo
+
+Do this after PR #9 for `nix-attic-infra` merges and `flake.lock` is updated:
+
+1. Refactor local Home Manager attic client support to wrap upstream instead of reimplementing it.
+
+Current local file to replace or thin out:
+- [`modules/home-manager/common/attic-client.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/home-manager/common/attic-client.nix)
+
+Why:
+- it still has older portability/correctness issues that upstream now handles better:
+  - unquoted TOML server keys
+  - GNU `sed -i`
+  - weak hardcoded shell aliases
+
+Target shape:
+- import `inputs.nix-attic-infra.homeManagerModules.attic-client`
+- keep only repo-specific defaults and overlays locally
+- preserve any desired `fnox` token fallback only if still needed
+
+2. Consider replacing local Darwin attic shim with an upstream wrapper.
+
+Current local file:
+- [`modules/home-manager/attic-client-darwin.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/home-manager/attic-client-darwin.nix)
+
+Likely action:
+- replace with a compatibility shim importing `inputs.nix-attic-infra.homeManagerModules.attic-client-darwin`
+- or delete if no local path compatibility is required
+
+3. Refresh `flake.lock` once upstream PRs merge.
+
+Commands:
+```fish
+cd ~/flakes/unified-nix-configuration
+nix flake lock --update-input nix-attic-infra
+```
+
+Optional once `attic-observatory` PR merges:
+```fish
+nix flake lock --update-input nix-attic-infra
+```
+
+Note:
+- `attic-observatory` is pulled transitively by `nix-attic-infra`, so the important lock update here is still the `nix-attic-infra` input.
+
+## Repo-local attic module status
+
+Already in good shape:
+- [`modules/nixos/attic-observatory.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/nixos/attic-observatory.nix)
+- [`modules/nixos/attic-post-build-hook.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/nixos/attic-post-build-hook.nix)
+
+These are already compatibility shims importing upstream implementation.
+
+Not yet upstream-backed:
+- [`modules/home-manager/common/attic-client.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/home-manager/common/attic-client.nix)
+- [`modules/home-manager/attic-client-darwin.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/modules/home-manager/attic-client-darwin.nix)
+
+## Good validation commands for the follow-up refactor
+
+After switching this repo to consume the improved upstream HM modules:
+
+```fish
+nix flake check --no-build
+nix build .#homeConfigurations.root@attic-cache.activationPackage
+nix build .#darwinConfigurations.macminim4.system
+```
+
+If those exact outputs fail for unrelated existing reasons, at minimum evaluate the relevant module paths and the host(s) that consume attic HM config.
+
+## Operational note
+
+When pushing to GitHub from this host, plain `git push` may fail because `~/.ssh/config` permissions are broken.
+
+Working fallback used successfully in this session:
+```fish
+GIT_SSH_COMMAND='ssh -F /dev/null' git -C /tmp/<repo> push origin <branch>
+```
+
+`gh pr create` may also need escalated/network-enabled execution in this environment.
+
+## Router follow-up
+
+Once `router` is back in a known-good booting and routing state, use:
+- [`docs/router-hardening-plan.md`](/home/deepwatrcreatur/flakes/unified-nix-configuration/docs/router-hardening-plan.md)
+
+That document captures:
+- the most useful router-specific ideas to borrow from existing Nix router work
+- the target fault-tolerance model
+- separate branch/PR tracks that other agents can pick up in parallel

--- a/docs/router-hardening-plan.md
+++ b/docs/router-hardening-plan.md
@@ -196,6 +196,11 @@ later work once `router` is stable again.
   Worth considering if future router hardware or hypervisor topology uses
   multiple uplinks and you want link redundancy or throughput aggregation.
 
+- `vpn policy routing`
+  High-value future work for subnet- or device-specific VPN egress, especially
+  if you want a dedicated SSID/VLAN or specific hosts to exit via a VPN
+  provider while the rest of the network uses the normal WAN path.
+
 ### Situational / Lower Priority
 
 - `macvlan`
@@ -221,5 +226,28 @@ opt-in work streams rather than part of baseline hardening:
 - `feat/router-vlans`
 - `feat/router-bridging`
 - `feat/router-bonding`
+- `feat/router-vpn-policy-routing`
 - `feat/router-macvlan`
 - `feat/router-non-nft-firewall` only if a real use case emerges
+
+## VPN Use Cases Worth Planning For
+
+These are good candidates once the router is stable again.
+
+### Preferred
+
+- Per-SSID or per-VLAN VPN egress
+  Example: a dedicated Wi-Fi network whose clients always exit through a VPN
+  provider while the main LAN continues to use the normal WAN path.
+
+- Per-device VPN egress
+  Example: route a known workstation or reserved client IP through a VPN
+  tunnel when desired, without changing the rest of the network.
+
+### Lower Value / More Fragile
+
+- Per-domain or per-service geo-routing via router DNS or policy tricks
+  Example: trying to make only Facebook or only a subset of websites appear as
+  US-origin traffic. This is usually brittle because of CDNs, shared
+  infrastructure, HTTPS, and application behavior. Prefer per-device or
+  per-subnet routing instead.

--- a/docs/router-hardening-plan.md
+++ b/docs/router-hardening-plan.md
@@ -1,0 +1,178 @@
+# Router Hardening Plan
+
+This document is for follow-up work after `router` is back in a known-good state:
+
+- boots reliably
+- routes traffic again
+- management IP is reachable
+- `router-backup` remains consistent with the same production router role
+
+It is intentionally scoped for parallel agent work on separate branches.
+
+## Current Recovery Context
+
+Recent failure behavior showed:
+
+- `LAN` never got `10.10.10.1`
+- `WAN` still acquired DHCP
+- monitoring services waited on `10.10.10.1` and cascaded into repeated failures
+- recovery was made harder by weak out-of-band behavior
+
+The key lesson is not that LAN should become optional. The lesson is:
+
+- `management` must stay available even when `LAN` or `WAN` is broken
+- interface identity and service dependency handling need to be more robust
+
+## Borrowed Ideas Worth Stealing
+
+The best ideas to borrow from router-focused Nix work, especially `chayleaf/nixos-router`, are:
+
+1. Stable interface matching.
+   Match by stable device properties instead of trusting kernel-assigned names.
+
+2. Per-interface dependent services.
+   Services should depend on the interface they actually need, not on a generic host-wide assumption.
+
+3. Degraded operation model.
+   `management` should remain usable even if `LAN` or `WAN` is down.
+
+4. More explicit router-role boundaries.
+   Router networking/firewall/monitoring dependencies should be modeled as router concerns, not incidental host behavior.
+
+## What Not To Do
+
+- Do not fork and replace the repo with `chayleaf/nixos-router`.
+- Do not make the router silently "healthy" without LAN.
+- Do not make management depend on LAN or WAN success.
+- Do not make monitoring services block boot in ways that hide the real failure.
+
+## Target End State
+
+After the hardening work:
+
+- `management` comes up independently and early
+- `LAN` and `WAN` can fail independently without losing recovery access
+- router health is explicit:
+  - management up
+  - LAN missing
+  - WAN missing
+- interface identity is stable across VM/hardware churn
+- monitoring/dashboard degrade cleanly instead of hanging on missing LAN IP
+
+## Recommended Branches
+
+These are intended as separate PRs.
+
+### 1. `refactor/router-stable-interface-matching`
+
+Goal:
+- stop relying on fragile interface names for `router` and `router-backup`
+
+Tasks:
+- inspect the current `nix-router-optimized` router-networking options and determine the cleanest stable match path
+- if possible, add support for matching by MAC, PCI path, or systemd `.link` match config
+- update `router` and `router-backup` to use stable matching for:
+  - LAN
+  - WAN
+  - management
+- document the expected mapping in repo docs
+
+Success criteria:
+- interface assignment does not depend on `ens*` vs `enp*` naming drift
+
+### 2. `refactor/router-service-dependencies`
+
+Goal:
+- stop using broad "wait for `10.10.10.1`" behavior where interface-specific dependencies are more correct
+
+Tasks:
+- audit services that currently wait on the LAN IP:
+  - Prometheus
+  - Grafana
+  - Netdata
+  - router-dashboard
+  - any other router-side services with pre-start polling
+- replace IP polling with clearer dependency logic where possible
+- keep true LAN-dependent services LAN-aware
+- keep management-plane services runnable without LAN
+
+Success criteria:
+- broken LAN does not make observability and management look uniformly dead
+
+### 3. `feat/router-management-plane-independence`
+
+Goal:
+- make management availability a first-class invariant
+
+Tasks:
+- ensure management IP setup is independent from LAN/WAN success
+- ensure SSH and dashboard bind in a way that still works on management when LAN fails
+- ensure router dashboard links and health checks reflect management-first recovery
+- verify `router` and `router-backup` both preserve their distinct management IPs
+
+Success criteria:
+- if LAN breaks, `192.168.100.100` and `192.168.100.99` still remain useful for recovery
+
+### 4. `feat/router-health-model`
+
+Goal:
+- represent router health explicitly instead of inferring it from individual service failures
+
+Tasks:
+- add explicit health checks for:
+  - management address present
+  - LAN address present
+  - WAN address present or WAN link state known
+- surface these in the dashboard
+- distinguish:
+  - healthy
+  - degraded: LAN missing
+  - degraded: WAN missing
+  - degraded: management missing
+
+Success criteria:
+- operator can immediately see the real failure domain
+
+### 5. `refactor/router-boot-recovery`
+
+Goal:
+- make VM recovery paths reliable and permanent
+
+Tasks:
+- verify and keep:
+  - Proxmox serial console
+  - guest serial console config
+  - qemu guest agent
+- document exact recovery workflow from Proxmox host
+- consider a check or doc to verify the active bootloader entry contains expected kernel args
+
+Success criteria:
+- future router lockouts are diagnosable without guesswork
+
+## Ordering
+
+Recommended order after router recovery:
+
+1. `refactor/router-stable-interface-matching`
+2. `feat/router-management-plane-independence`
+3. `refactor/router-service-dependencies`
+4. `feat/router-health-model`
+5. `refactor/router-boot-recovery`
+
+## Preconditions
+
+Other agents should not start these branches until:
+
+- `router` is booting the intended generation
+- `router` is routing again
+- management IP is reachable
+- current router and router-backup configs are pulled and switchable
+
+## Notes For Agents
+
+- Keep changes PR-sized and narrowly scoped.
+- Do not mix recovery work with refactor work.
+- Preserve the current router/spare model:
+  - shared production identity
+  - distinct management identities
+- Prefer explicit invariants and checks over hidden convenience behavior.

--- a/docs/router-hardening-plan.md
+++ b/docs/router-hardening-plan.md
@@ -176,3 +176,50 @@ Other agents should not start these branches until:
   - shared production identity
   - distinct management identities
 - Prefer explicit invariants and checks over hidden convenience behavior.
+
+## Future Networking Capabilities
+
+These are not part of immediate router recovery. They are worth tracking for
+later work once `router` is stable again.
+
+### High Value For This Repo
+
+- `vlan`
+  Add first-class VLAN modeling if you want segmented LANs, guest networks, or
+  separate management/storage domains.
+
+- `bridge`
+  Useful if the router needs to bridge virtual or physical interfaces in a more
+  explicit way than today, especially for VM/lab scenarios.
+
+- `bonding`
+  Worth considering if future router hardware or hypervisor topology uses
+  multiple uplinks and you want link redundancy or throughput aggregation.
+
+### Situational / Lower Priority
+
+- `macvlan`
+  Potentially useful for service-isolation edge cases, but not an obvious
+  router requirement for the current design.
+
+- `notnft`
+  Only worth tracking if there is a real need to support a non-`nftables`
+  firewall path. Current router direction should stay nftables-first unless a
+  concrete requirement appears.
+
+### Probably Not Worth Prioritizing Now
+
+- `6-to-4`
+  Add only if you actually intend to do tunnel-based IPv6 transition work.
+  It does not look like a near-term need for the current homelab.
+
+## Post-Recovery Branch Ideas
+
+If the above become relevant after router recovery, treat them as separate,
+opt-in work streams rather than part of baseline hardening:
+
+- `feat/router-vlans`
+- `feat/router-bridging`
+- `feat/router-bonding`
+- `feat/router-macvlan`
+- `feat/router-non-nft-firewall` only if a real use case emerges

--- a/hosts/nixos-lxc/attic-cache/default.nix
+++ b/hosts/nixos-lxc/attic-cache/default.nix
@@ -3,8 +3,14 @@
   inputs,
   ...
 }:
+let
+  hostsData = import ../../../lib/hosts.nix;
+in
 {
-  host.services.iperf3.enable = true;
+  host.services.iperf3 = {
+    enable = true;
+    bindProbeAddress = hostsData.hosts.attic-cache.ip;
+  };
 
   imports = [
     ../../../modules/nixos/services/iperf3.nix

--- a/hosts/nixos-lxc/homeserver/default.nix
+++ b/hosts/nixos-lxc/homeserver/default.nix
@@ -5,12 +5,16 @@
 }:
 let
   atticClientTokenFile = ../../../secrets-agenix/attic-client-token.age;
+  hostsData = import ../../../lib/hosts.nix;
 in
 {
   # Declarative host configuration
   host.type = "lxc";
   host.networking.enableTailscale = false; # LXC containers can't run Tailscale
-  host.services.iperf3.enable = true;
+  host.services.iperf3 = {
+    enable = true;
+    bindProbeAddress = hostsData.hosts.homeserver.ip;
+  };
   host.services.enablePodman = true;
 
   imports = [

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -6,20 +6,22 @@
 }:
 let
   topology = config.router.topology;
-  routerHost = topology.hosts.router;
-  backupHost = topology.hosts.router-backup;
+  routerHost = topology.routerHost;
+  backupHost = topology.backupHost;
+  domain = topology.domain;
   lanNetwork = topology.networks.lan;
   managementNetwork = topology.networks.management;
+  mkFqdn = label: "${label}.${domain}";
 in
 {
   imports = [
     (import ../router/role.nix {
-      sshTarget = "ssh router-backup.deepwatercreature.com";
+      sshTarget = "ssh router-backup";
       wanDevice = "enp2s0";
       lanDevice = "enp3s0";
       lanIpv4Address = "${routerHost.ip}/${toString lanNetwork.prefixLength}";
       managementIpv4Address = "${backupHost.sshHostname}/${toString managementNetwork.prefixLength}";
-      grafanaDomain = "router-backup.deepwatercreature.com";
+      grafanaDomain = mkFqdn "router-backup";
       grafanaDataDir = "/var/log/router-backup/grafana";
       prometheusStateDir = "router-backup-prometheus";
       prometheusBindMountPath = "/var/log/router-backup/prometheus";

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -3,6 +3,8 @@ let
   hostsData = import ../../../lib/hosts.nix;
   routerHost = hostsData.hosts.router;
   backupHost = hostsData.hosts.router-backup;
+  lanNetwork = hostsData.networks.lan;
+  managementNetwork = hostsData.networks.management;
 in
 {
   imports = [
@@ -10,8 +12,8 @@ in
       sshTarget = "ssh router-backup.deepwatercreature.com";
       wanDevice = "enp2s0";
       lanDevice = "enp3s0";
-      lanIpv4Address = "${routerHost.ip}/16";
-      managementIpv4Address = "${backupHost.sshHostname}/24";
+      lanIpv4Address = "${routerHost.ip}/${toString lanNetwork.prefixLength}";
+      managementIpv4Address = "${backupHost.sshHostname}/${toString managementNetwork.prefixLength}";
       grafanaDomain = "router-backup.deepwatercreature.com";
       grafanaDataDir = "/var/log/router-backup/grafana";
       prometheusStateDir = "router-backup-prometheus";

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -1,10 +1,15 @@
-{ lib, inputs, ... }:
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
 let
-  hostsData = import ../../../lib/hosts.nix;
-  routerHost = hostsData.hosts.router;
-  backupHost = hostsData.hosts.router-backup;
-  lanNetwork = hostsData.networks.lan;
-  managementNetwork = hostsData.networks.management;
+  topology = config.router.topology;
+  routerHost = topology.hosts.router;
+  backupHost = topology.hosts.router-backup;
+  lanNetwork = topology.networks.lan;
+  managementNetwork = topology.networks.management;
 in
 {
   imports = [

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -1,11 +1,17 @@
 { lib, inputs, ... }:
+let
+  hostsData = import ../../../lib/hosts.nix;
+  routerHost = hostsData.hosts.router;
+  backupHost = hostsData.hosts.router-backup;
+in
 {
   imports = [
     (import ../router/role.nix {
       sshTarget = "ssh router-backup.deepwatercreature.com";
       wanDevice = "enp2s0";
       lanDevice = "enp3s0";
-      managementIpv4Address = "192.168.100.99/24";
+      lanIpv4Address = "${routerHost.ip}/16";
+      managementIpv4Address = "${backupHost.sshHostname}/24";
       grafanaDomain = "router-backup.deepwatercreature.com";
       grafanaDataDir = "/var/log/router-backup/grafana";
       prometheusStateDir = "router-backup-prometheus";

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -66,7 +66,7 @@ in
       # Router dashboard
       "dashboard.deepwatercreature.com" = {
         extraConfig = ''
-          reverse_proxy 10.10.10.1:8888
+          reverse_proxy 127.0.0.1:8888
         '';
       };
 
@@ -74,7 +74,7 @@ in
         extraConfig = ''
           @trusted remote_ip 10.10.0.0/16 100.64.0.0/10
           handle @trusted {
-            reverse_proxy 10.10.10.1:8888
+            reverse_proxy 127.0.0.1:8888
           }
 
           respond "Access restricted to home LAN and Tailnet" 403
@@ -116,7 +116,7 @@ in
       };
       "grafana.deepwatercreature.com" = {
         extraConfig = ''
-          reverse_proxy 10.10.10.1:3001
+          reverse_proxy 127.0.0.1:3001
         '';
       };
     };

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -1,11 +1,11 @@
 { config, pkgs, lib, ... }:
 
 let
-  hostsData = import ../../../lib/hosts.nix;
-  routerHost = hostsData.hosts.router;
-  lanNetwork = hostsData.networks.lan;
+  topology = config.router.topology;
+  routerHost = topology.hosts.router;
+  lanNetwork = topology.networks.lan;
   ddnsLabels = routerHost.ddnsServices or [ ];
-  ddnsDomainsLine = lib.concatStringsSep " " ([ hostsData.domain ] ++ ddnsLabels);
+  ddnsDomainsLine = lib.concatStringsSep " " ([ topology.domain ] ++ ddnsLabels);
 
   # Optional secrets library for graceful degradation
   optSec = import ../../../modules/helpers/optional-secrets.nix { inherit lib; };

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -3,6 +3,7 @@
 let
   hostsData = import ../../../lib/hosts.nix;
   routerHost = hostsData.hosts.router;
+  lanNetwork = hostsData.networks.lan;
   ddnsLabels = routerHost.ddnsServices or [ ];
   ddnsDomainsLine = lib.concatStringsSep " " ([ hostsData.domain ] ++ ddnsLabels);
 
@@ -72,7 +73,7 @@ in
 
       "homelab.deepwatercreature.com" = {
         extraConfig = ''
-          @trusted remote_ip 10.10.0.0/16 100.64.0.0/10
+          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10
           handle @trusted {
             reverse_proxy 127.0.0.1:8888
           }

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -2,10 +2,14 @@
 
 let
   topology = config.router.topology;
-  routerHost = topology.hosts.router;
+  routerHost = topology.routerHost;
   lanNetwork = topology.networks.lan;
+  homeAssistantHost = topology.hosts.homeassistant;
+  authentikHost = topology.hosts.authentik-host;
+  podmanHost = topology.hosts.podman;
   ddnsLabels = routerHost.ddnsServices or [ ];
   ddnsDomainsLine = lib.concatStringsSep " " ([ topology.domain ] ++ ddnsLabels);
+  mkFqdn = label: "${label}.${topology.domain}";
 
   # Optional secrets library for graceful degradation
   optSec = import ../../../modules/helpers/optional-secrets.nix { inherit lib; };
@@ -51,27 +55,27 @@ in
 
     virtualHosts = {
       # Main domain - redirect to www or dashboard
-      "deepwatercreature.com" = {
+      "${topology.domain}" = {
         extraConfig = ''
           redir https://x.com/deepwatrcreatur permanent
         '';
       };
 
       # WWW subdomain - serve main site or redirect to dashboard
-      "www.deepwatercreature.com" = {
+      "${mkFqdn "www"}" = {
         extraConfig = ''
           redir https://x.com/deepwatrcreatur permanent
         '';
       };
 
       # Router dashboard
-      "dashboard.deepwatercreature.com" = {
+      "${mkFqdn "dashboard"}" = {
         extraConfig = ''
           reverse_proxy 127.0.0.1:8888
         '';
       };
 
-      "homelab.deepwatercreature.com" = {
+      "${mkFqdn "homelab"}" = {
         extraConfig = ''
           @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10
           handle @trusted {
@@ -82,40 +86,40 @@ in
         '';
       };
 
-      "home-assistant.deepwatercreature.com" = {
+      "${mkFqdn "home-assistant"}" = {
         extraConfig = ''
-          reverse_proxy 10.10.11.18:8123
+          reverse_proxy ${homeAssistantHost.ip}:8123
         '';
       };
 
-      "authentik.deepwatercreature.com" = {
+      "${mkFqdn "authentik"}" = {
         extraConfig = ''
-          reverse_proxy 10.10.11.70:9000
+          reverse_proxy ${authentikHost.ip}:9000
         '';
       };
 
-      "paperless.deepwatercreature.com" = {
+      "${mkFqdn "paperless"}" = {
         extraConfig = ''
-          reverse_proxy 10.10.11.84:18000
+          reverse_proxy ${podmanHost.ip}:18000
         '';
       };
 
-      "nightscout.deepwatercreature.com" = {
+      "${mkFqdn "nightscout"}" = {
         extraConfig = ''
-          reverse_proxy 10.10.11.84:11337
+          reverse_proxy ${podmanHost.ip}:11337
         '';
       };
 
-      "scrypted.deepwatercreature.com" = {
+      "${mkFqdn "scrypted"}" = {
         extraConfig = ''
-          reverse_proxy https://10.10.11.84:10443 {
+          reverse_proxy https://${podmanHost.ip}:10443 {
             transport http {
               tls_insecure_skip_verify
             }
           }
         '';
       };
-      "grafana.deepwatercreature.com" = {
+      "${mkFqdn "grafana"}" = {
         extraConfig = ''
           reverse_proxy 127.0.0.1:3001
         '';

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -2,13 +2,20 @@
   lib,
   ...
 }:
+let
+  hostsData = import ../../../lib/hosts.nix;
+  routerHost = hostsData.hosts.router;
+  backupHost = hostsData.hosts.router-backup;
+  lanIpv4Address = "${routerHost.ip}/16";
+  managementIpv4Address = "${routerHost.sshHostname}/24";
+in
 {
   imports = [
     (import ./role.nix {
       sshTarget = "ssh router.deepwatercreature.com";
       wanDevice = "enp6s17";
       lanDevice = "enp6s16";
-      managementIpv4Address = "192.168.100.100/24";
+      inherit lanIpv4Address managementIpv4Address;
       grafanaDomain = "router.deepwatercreature.com";
       grafanaDataDir = "/var/log/router/grafana";
       prometheusStateDir = "router-prometheus";
@@ -49,32 +56,32 @@
       }
       {
         label = "DNS Admin Mgmt";
-        url = "http://192.168.100.100:5380/";
+        url = "http://${routerHost.sshHostname}:5380/";
         icon = "🌍";
       }
       {
         label = "Prometheus Mgmt";
-        url = "http://192.168.100.100:9090/";
+        url = "http://${routerHost.sshHostname}:9090/";
         icon = "🎯";
       }
       {
         label = "Netdata Mgmt";
-        url = "http://192.168.100.100:19999/";
+        url = "http://${routerHost.sshHostname}:19999/";
         icon = "📊";
       }
       {
         label = "DNS Admin LAN";
-        url = "http://10.10.10.1:5380/";
+        url = "http://${routerHost.ip}:5380/";
         icon = "🌍";
       }
       {
         label = "Prometheus LAN";
-        url = "http://10.10.10.1:9090/";
+        url = "http://${routerHost.ip}:9090/";
         icon = "🎯";
       }
       {
         label = "Netdata LAN";
-        url = "http://10.10.10.1:19999/";
+        url = "http://${routerHost.ip}:19999/";
         icon = "📊";
       }
       {
@@ -92,13 +99,13 @@
       {
         label = "Router Mgmt";
         kind = "copy";
-        copyText = "192.168.100.100";
+        copyText = routerHost.sshHostname;
         icon = "🔧";
       }
       {
         label = "Backup Mgmt";
         kind = "copy";
-        copyText = "192.168.100.99";
+        copyText = backupHost.sshHostname;
         icon = "🧰";
       }
       {
@@ -124,7 +131,7 @@
         "10.10.11.0/24"
       ];
       mkZone = zone: {
-        nameserverIP = zone.nameserverIP or "10.10.10.1";
+        nameserverIP = zone.nameserverIP or routerHost.ip;
         allowDynamicUpdates = zone.allowDynamicUpdates or true;
         aliases = zone.aliases or { };
         staticHosts = lib.mapAttrs (_name: host: {

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -5,21 +5,23 @@
 }:
 let
   topology = config.router.topology;
-  routerHost = topology.hosts.router;
-  backupHost = topology.hosts.router-backup;
+  routerHost = topology.routerHost;
+  backupHost = topology.backupHost;
+  domain = topology.domain;
   lanNetwork = topology.networks.lan;
   managementNetwork = topology.networks.management;
   lanIpv4Address = "${routerHost.ip}/${toString lanNetwork.prefixLength}";
   managementIpv4Address = "${routerHost.sshHostname}/${toString managementNetwork.prefixLength}";
+  mkFqdn = label: "${label}.${domain}";
 in
 {
   imports = [
     (import ./role.nix {
-      sshTarget = "ssh router.deepwatercreature.com";
+      sshTarget = "ssh router";
       wanDevice = "enp6s17";
       lanDevice = "enp6s16";
       inherit lanIpv4Address managementIpv4Address;
-      grafanaDomain = "router.deepwatercreature.com";
+      grafanaDomain = mkFqdn "router";
       grafanaDataDir = "/var/log/router/grafana";
       prometheusStateDir = "router-prometheus";
       prometheusBindMountPath = "/var/log/router/prometheus";
@@ -44,17 +46,17 @@ in
     links = lib.mkForce [
       {
         label = "Dashboard";
-        url = "https://dashboard.deepwatercreature.com";
+        url = "https://${mkFqdn "dashboard"}";
         icon = "🧭";
       }
       {
         label = "Homelab";
-        url = "https://homelab.deepwatercreature.com";
+        url = "https://${mkFqdn "homelab"}";
         icon = "🏠";
       }
       {
         label = "Grafana";
-        url = "https://grafana.deepwatercreature.com";
+        url = "https://${mkFqdn "grafana"}";
         icon = "📈";
       }
       {

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -26,7 +26,6 @@
       "technitium-dns-server"
       "tailscaled"
       "fail2ban"
-      "podman"
       "prometheus"
       "grafana"
       "netdata"
@@ -49,17 +48,32 @@
         icon = "📈";
       }
       {
-        label = "DNS Admin";
+        label = "DNS Admin Mgmt";
+        url = "http://192.168.100.100:5380/";
+        icon = "🌍";
+      }
+      {
+        label = "Prometheus Mgmt";
+        url = "http://192.168.100.100:9090/";
+        icon = "🎯";
+      }
+      {
+        label = "Netdata Mgmt";
+        url = "http://192.168.100.100:19999/";
+        icon = "📊";
+      }
+      {
+        label = "DNS Admin LAN";
         url = "http://10.10.10.1:5380/";
         icon = "🌍";
       }
       {
-        label = "Prometheus";
+        label = "Prometheus LAN";
         url = "http://10.10.10.1:9090/";
         icon = "🎯";
       }
       {
-        label = "Netdata";
+        label = "Netdata LAN";
         url = "http://10.10.10.1:19999/";
         icon = "📊";
       }

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -6,8 +6,10 @@ let
   hostsData = import ../../../lib/hosts.nix;
   routerHost = hostsData.hosts.router;
   backupHost = hostsData.hosts.router-backup;
-  lanIpv4Address = "${routerHost.ip}/16";
-  managementIpv4Address = "${routerHost.sshHostname}/24";
+  lanNetwork = hostsData.networks.lan;
+  managementNetwork = hostsData.networks.management;
+  lanIpv4Address = "${routerHost.ip}/${toString lanNetwork.prefixLength}";
+  managementIpv4Address = "${routerHost.sshHostname}/${toString managementNetwork.prefixLength}";
 in
 {
   imports = [

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -1,13 +1,14 @@
 {
+  config,
   lib,
   ...
 }:
 let
-  hostsData = import ../../../lib/hosts.nix;
-  routerHost = hostsData.hosts.router;
-  backupHost = hostsData.hosts.router-backup;
-  lanNetwork = hostsData.networks.lan;
-  managementNetwork = hostsData.networks.management;
+  topology = config.router.topology;
+  routerHost = topology.hosts.router;
+  backupHost = topology.hosts.router-backup;
+  lanNetwork = topology.networks.lan;
+  managementNetwork = topology.networks.management;
   lanIpv4Address = "${routerHost.ip}/${toString lanNetwork.prefixLength}";
   managementIpv4Address = "${routerHost.sshHostname}/${toString managementNetwork.prefixLength}";
 in

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -1,9 +1,10 @@
 {
+  config,
   ...
 }:
 let
-  hostsData = import ../../../lib/hosts.nix;
-  routerHost = hostsData.hosts.router;
+  topology = config.router.topology;
+  routerHost = topology.hosts.router;
 in
 {
   networking.hostName = "router";

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -4,16 +4,16 @@
 }:
 let
   topology = config.router.topology;
-  routerHost = topology.hosts.router;
+  routerHost = topology.routerHost;
 in
 {
   networking.hostName = "router";
-  networking.domain = "deepwatercreature.com";
+  networking.domain = topology.domain;
 
   services.router-dns-service = {
     enable = true;
     provider = "technitium";
-    searchDomains = [ "deepwatercreature.com" ];
+    searchDomains = [ topology.domain ];
     # Advertise the router's chrony instance to all LAN clients via DHCP option 42.
     ntpServers = [ routerHost.ip ];
     technitium = {

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -1,7 +1,10 @@
 {
   ...
 }:
-
+let
+  hostsData = import ../../../lib/hosts.nix;
+  routerHost = hostsData.hosts.router;
+in
 {
   networking.hostName = "router";
   networking.domain = "deepwatercreature.com";
@@ -11,7 +14,7 @@
     provider = "technitium";
     searchDomains = [ "deepwatercreature.com" ];
     # Advertise the router's chrony instance to all LAN clients via DHCP option 42.
-    ntpServers = [ "10.10.10.1" ];
+    ntpServers = [ routerHost.ip ];
     technitium = {
       blockListPresets = [
         "hagezi-normal"

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -54,7 +54,10 @@ in
     services = {
       enableSsh = true;
       enableDocker = false;
-      iperf3.enable = true;
+      iperf3 = {
+        enable = true;
+        bindProbeAddress = topology.routerHost.ip;
+      };
     };
   };
 
@@ -66,7 +69,7 @@ in
         device = lanDevice;
         ipv4Address = lanIpv4Address;
         dns = [ "127.0.0.1" ];
-        domains = [ "deepwatercreature.com" ];
+        domains = [ topology.domain ];
         requiredForOnline = "routable";
         extraRoutes = [
           {
@@ -188,7 +191,7 @@ in
     enable = true;
     settings.PermitRootLogin = "prohibit-password";
     extraConfig = ''
-      Match Address 10.10.10.0/24
+      Match Address ${lanNetwork.cidr}
         PermitRootLogin yes
     '';
   };

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -17,6 +17,7 @@
 }:
 let
   optSec = import ../../../modules/helpers/optional-secrets.nix { inherit lib; };
+  managementListenAddress = builtins.head (lib.splitString "/" managementIpv4Address);
 
   secrets = optSec.mkSecrets {
     cloudflare-api-key = {
@@ -126,6 +127,7 @@ in
   };
 
   services.router-homelab.sshTarget = sshTarget;
+  services.router-homelab.listenAddress = managementListenAddress;
 
   services.router-dashboard = {
     links = [
@@ -154,9 +156,12 @@ in
   router.monitoring = {
     grafanaDomain = grafanaDomain;
     grafanaDataDir = grafanaDataDir;
+    listenAddress = lib.mkForce "0.0.0.0";
     prometheusStateDir = prometheusStateDir;
     prometheusBindMountPath = prometheusBindMountPath;
   };
+
+  services.netdata.config.global."bind to" = "0.0.0.0";
 
   boot.loader.grub.enable = false;
   boot.loader.limine.enable = true;

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -35,7 +35,6 @@ let
 
   topology = config.router.topology;
   lanNetwork = topology.networks.lan;
-  infrastructureNetwork = topology.networks.infrastructure;
   reservableHosts = lib.filterAttrs (
     _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null
   ) topology.hosts;
@@ -192,7 +191,7 @@ in
     enable = true;
     settings.PermitRootLogin = "prohibit-password";
     extraConfig = ''
-      Match Address ${infrastructureNetwork.cidr}
+      Match Address ${lanNetwork.cidr}
         PermitRootLogin yes
     '';
   };

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -2,6 +2,7 @@
   sshTarget,
   wanDevice,
   lanDevice,
+  lanIpv4Address,
   managementIpv4Address,
   grafanaDomain,
   grafanaDataDir,
@@ -62,7 +63,7 @@ in
     routedInterfaces = {
       lan = {
         device = lanDevice;
-        ipv4Address = "10.10.10.1/16";
+        ipv4Address = lanIpv4Address;
         dns = [ "127.0.0.1" ];
         domains = [ "deepwatercreature.com" ];
         requiredForOnline = "routable";

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -34,6 +34,7 @@ let
   };
 
   hostsData = import ../../../lib/hosts.nix;
+  lanNetwork = hostsData.networks.lan;
   reservableHosts = lib.filterAttrs (
     _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null
   ) hostsData.hosts;
@@ -69,7 +70,7 @@ in
         requiredForOnline = "routable";
         extraRoutes = [
           {
-            destination = "10.10.0.0/16";
+            destination = lanNetwork.cidr;
             scope = "link";
           }
         ];
@@ -149,7 +150,7 @@ in
     enable = true;
     authKeyFile = secrets.path "tailscale-auth-key";
     advertiseExitNode = secrets.exists "tailscale-auth-key";
-    advertiseRoutes = lib.optionals (secrets.exists "tailscale-auth-key") [ "10.10.0.0/16" ];
+    advertiseRoutes = lib.optionals (secrets.exists "tailscale-auth-key") [ lanNetwork.cidr ];
     trustedInterface = true;
     openFirewall = true;
   };
@@ -197,7 +198,7 @@ in
     maxretry = 5;
     ignoreIP = [
       "127.0.0.1/8"
-      "10.10.0.0/16"
+      lanNetwork.cidr
     ];
   };
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -35,6 +35,7 @@ let
 
   topology = config.router.topology;
   lanNetwork = topology.networks.lan;
+  infrastructureNetwork = topology.networks.infrastructure;
   reservableHosts = lib.filterAttrs (
     _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null
   ) topology.hosts;
@@ -132,7 +133,7 @@ in
   };
 
   services.router-homelab.sshTarget = sshTarget;
-  services.router-homelab.listenAddress = managementListenAddress;
+  services.router-homelab.listenAddress = "0.0.0.0";
 
   services.router-dashboard = {
     links = [
@@ -191,7 +192,7 @@ in
     enable = true;
     settings.PermitRootLogin = "prohibit-password";
     extraConfig = ''
-      Match Address ${lanNetwork.cidr}
+      Match Address ${infrastructureNetwork.cidr}
         PermitRootLogin yes
     '';
   };

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -33,11 +33,11 @@ let
     };
   };
 
-  hostsData = import ../../../lib/hosts.nix;
-  lanNetwork = hostsData.networks.lan;
+  topology = config.router.topology;
+  lanNetwork = topology.networks.lan;
   reservableHosts = lib.filterAttrs (
     _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null
-  ) hostsData.hosts;
+  ) topology.hosts;
 in
 {
   imports = [ ../../../modules/nixos/router/common.nix ];

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -14,11 +14,6 @@
       prefixLength = 16;
     };
 
-    infrastructure = {
-      cidr = "10.10.10.0/24";
-      prefixLength = 24;
-    };
-
     management = {
       cidr = "192.168.100.0/24";
       prefixLength = 24;

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -14,6 +14,11 @@
       prefixLength = 16;
     };
 
+    infrastructure = {
+      cidr = "10.10.10.0/24";
+      prefixLength = 24;
+    };
+
     management = {
       cidr = "192.168.100.0/24";
       prefixLength = 24;

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -5,6 +5,21 @@
   # Domain for all hosts
   domain = "deepwatercreature.com";
 
+  # Shared network definitions for the homelab router role. Host entries below
+  # should derive their concrete addresses from these where possible instead of
+  # repeating raw CIDR/prefix literals across modules.
+  networks = {
+    lan = {
+      cidr = "10.10.0.0/16";
+      prefixLength = 16;
+    };
+
+    management = {
+      cidr = "192.168.100.0/24";
+      prefixLength = 24;
+    };
+  };
+
   # Host definitions
   # Each host can have:
   #   ip: IPv4 address (required)

--- a/modules/nixos/router/common.nix
+++ b/modules/nixos/router/common.nix
@@ -3,25 +3,6 @@ let
   hostsData = import ../../../lib/hosts.nix;
   routerHost = hostsData.hosts.router;
   backupHost = hostsData.hosts.router-backup;
-  wildcardFromCidr =
-    cidr:
-    let
-      parts = lib.splitString "/" cidr;
-      ip = builtins.elemAt parts 0;
-      prefixLength = lib.toInt (builtins.elemAt parts 1);
-      octets = lib.splitString "." ip;
-      fixedOctets = prefixLength / 8;
-      renderedOctets =
-        lib.imap0
-          (
-            index: octet:
-            if index < fixedOctets then octet else "*"
-          )
-          octets;
-    in
-    lib.concatStringsSep "." renderedOctets;
-  lanWildcard = wildcardFromCidr hostsData.networks.lan.cidr;
-  managementWildcard = wildcardFromCidr hostsData.networks.management.cidr;
 in
 {
   options.router.topology = lib.mkOption {
@@ -41,7 +22,7 @@ in
   # Shared defaults for router and router-backup.
   config.services.router-homelab = {
     enable = lib.mkDefault true;
-    netdataAllowConnectionsFrom = lib.mkDefault "${lanWildcard} ${managementWildcard}";
+    netdataAllowConnectionsFrom = lib.mkDefault "${hostsData.networks.lan.cidr} ${hostsData.networks.management.cidr}";
   };
 
   config.router.monitoring = {

--- a/modules/nixos/router/common.nix
+++ b/modules/nixos/router/common.nix
@@ -1,12 +1,31 @@
 { config, lib, ... }:
+let
+  hostsData = import ../../../lib/hosts.nix;
+  routerHost = hostsData.hosts.router;
+  backupHost = hostsData.hosts.router-backup;
+in
 {
+  options.router.topology = lib.mkOption {
+    type = lib.types.attrs;
+    readOnly = true;
+    description = "Shared router inventory and network topology derived from lib/hosts.nix.";
+  };
+
+  config.router.topology = {
+    domain = hostsData.domain;
+    hosts = hostsData.hosts;
+    routerHost = routerHost;
+    backupHost = backupHost;
+    networks = hostsData.networks;
+  };
+
   # Shared defaults for router and router-backup.
-  services.router-homelab = {
+  config.services.router-homelab = {
     enable = lib.mkDefault true;
     netdataAllowConnectionsFrom = lib.mkDefault "10.10.* 192.168.100.*";
   };
 
-  router.monitoring = {
+  config.router.monitoring = {
     grafanaDomain = lib.mkDefault "router.deepwatercreature.com";
     grafanaDataDir = lib.mkDefault "/var/log/router/grafana";
     listenAddress = lib.mkDefault "0.0.0.0";
@@ -17,7 +36,7 @@
 
   # Logs disk is on scsi1 (spinning disk), formatted by disko as disk-logs-logs.
   # router-log-storage handles the mount; disko only formats the partition.
-  services.router-log-storage = {
+  config.services.router-log-storage = {
     enable = lib.mkDefault true;
     device = "/dev/disk/by-partlabel/disk-logs-logs";
     mountPoint = "/var/log/router";

--- a/modules/nixos/router/common.nix
+++ b/modules/nixos/router/common.nix
@@ -3,6 +3,25 @@ let
   hostsData = import ../../../lib/hosts.nix;
   routerHost = hostsData.hosts.router;
   backupHost = hostsData.hosts.router-backup;
+  wildcardFromCidr =
+    cidr:
+    let
+      parts = lib.splitString "/" cidr;
+      ip = builtins.elemAt parts 0;
+      prefixLength = lib.toInt (builtins.elemAt parts 1);
+      octets = lib.splitString "." ip;
+      fixedOctets = prefixLength / 8;
+      renderedOctets =
+        lib.imap0
+          (
+            index: octet:
+            if index < fixedOctets then octet else "*"
+          )
+          octets;
+    in
+    lib.concatStringsSep "." renderedOctets;
+  lanWildcard = wildcardFromCidr hostsData.networks.lan.cidr;
+  managementWildcard = wildcardFromCidr hostsData.networks.management.cidr;
 in
 {
   options.router.topology = lib.mkOption {
@@ -22,11 +41,11 @@ in
   # Shared defaults for router and router-backup.
   config.services.router-homelab = {
     enable = lib.mkDefault true;
-    netdataAllowConnectionsFrom = lib.mkDefault "10.10.* 192.168.100.*";
+    netdataAllowConnectionsFrom = lib.mkDefault "${lanWildcard} ${managementWildcard}";
   };
 
   config.router.monitoring = {
-    grafanaDomain = lib.mkDefault "router.deepwatercreature.com";
+    grafanaDomain = lib.mkDefault "router.${hostsData.domain}";
     grafanaDataDir = lib.mkDefault "/var/log/router/grafana";
     listenAddress = lib.mkDefault "0.0.0.0";
     prometheusStateDir = lib.mkDefault "router-prometheus";

--- a/modules/nixos/router/common.nix
+++ b/modules/nixos/router/common.nix
@@ -3,13 +3,13 @@
   # Shared defaults for router and router-backup.
   services.router-homelab = {
     enable = lib.mkDefault true;
-    netdataAllowConnectionsFrom = lib.mkDefault "10.10.*";
-    waitForListenAddress = lib.mkDefault true;
+    netdataAllowConnectionsFrom = lib.mkDefault "10.10.* 192.168.100.*";
   };
 
   router.monitoring = {
     grafanaDomain = lib.mkDefault "router.deepwatercreature.com";
     grafanaDataDir = lib.mkDefault "/var/log/router/grafana";
+    listenAddress = lib.mkDefault "0.0.0.0";
     prometheusStateDir = lib.mkDefault "router-prometheus";
     prometheusBindMountPath = lib.mkDefault "/var/log/router/prometheus";
     prometheusRetentionSize = lib.mkDefault "40GB";

--- a/modules/nixos/services/iperf3.nix
+++ b/modules/nixos/services/iperf3.nix
@@ -13,13 +13,20 @@ in
     enable = lib.mkEnableOption "LAN-bound iperf3 server";
 
     bindProbeAddress = lib.mkOption {
-      type = lib.types.str;
-      default = "10.10.10.1";
+      type = lib.types.nullOr lib.types.str;
+      default = null;
       description = "Address used to discover the LAN source IP for iperf3 binding.";
     };
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.bindProbeAddress != null;
+        message = "host.services.iperf3.bindProbeAddress must be set explicitly when iperf3 is enabled.";
+      }
+    ];
+
     networking.firewall.allowedTCPPorts = lib.mkIf config.networking.firewall.enable [ 5201 ];
 
     systemd.services.iperf3 = {

--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -151,9 +151,12 @@ let
     builtins.filter (name: name != "@" && !(builtins.elem name routerPublicIngressServices)) routerDdnsServices;
 
   routerCaddyFile = builtins.readFile ../hosts/nixos/router/caddy.nix;
-  routerCaddyVirtualHostMatches =
+  routerCaddyLiteralVirtualHostMatches =
     builtins.split "\n[[:space:]]*\"([a-z0-9-]+)\\.deepwatercreature\\.com\"[[:space:]]*=" routerCaddyFile;
-  routerCaddyVirtualHostNames =
+  routerCaddyMkFqdnVirtualHostMatches =
+    builtins.split "mkFqdn \"([a-z0-9-]+)\"" routerCaddyFile;
+  matchCapturesToNames =
+    matches:
     builtins.attrNames (
       builtins.listToAttrs (
         builtins.concatLists (
@@ -168,8 +171,17 @@ let
               else
                 [ ]
             )
-            routerCaddyVirtualHostMatches
+            matches
         )
+      )
+    );
+  routerCaddyVirtualHostNames =
+    builtins.attrNames (
+      builtins.listToAttrs (
+        map (name: {
+          inherit name;
+          value = true;
+        }) ((matchCapturesToNames routerCaddyLiteralVirtualHostMatches) ++ (matchCapturesToNames routerCaddyMkFqdnVirtualHostMatches))
       )
     );
 


### PR DESCRIPTION
## Summary
- centralize router addresses, subnets, and domain-derived values behind shared inventory/topology data
- make router and router-backup consume router.topology instead of re-importing host inventory ad hoc
- remove hidden router-specific defaults from the reusable iperf3 module by requiring explicit bind probe addresses

## Validation
- nix build .#nixosConfigurations.router.config.system.build.toplevel
- nix build .#nixosConfigurations.router-backup.config.system.build.toplevel
- nix build .#nixosConfigurations.attic-cache.config.system.build.toplevel

## Notes
- nix build .#nixosConfigurations.homeserver.config.system.build.toplevel progressed through the iperf3 option change and then failed on a pre-existing binary-cache inconsistency from attic-cache, not on this refactor.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topology-driven configuration: dynamic domains, host IPs, and network CIDRs now drive router, DNS, proxy, and monitoring settings.
  * iperf3 can now bind per-host probe addresses, configurable per topology.

* **Documentation**
  * Added router hardening roadmap with recovery guidance and PR workstreams.
  * Added agent handoff plan detailing repo context, validation steps, and next tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->