### PR TITLE
router: add recovery invariant assertions

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -54,7 +54,7 @@ even with all production cables unplugged.
 
 **What this means in practice:**
 
-- The production LAN static IP (`10.10.10.1/24`) is configured with
+- The production LAN static IP (`10.10.10.1/16`) is configured with
   `ConfigureWithoutCarrier = true`, so it remains present even when the
   data-plane NIC has no link.
 - Management IP is on a separate NIC (`ens18`) and is independent of WAN/LAN
@@ -69,7 +69,10 @@ even with all production cables unplugged.
 **When swapping to the backup router:**
 
 1. Unplug WAN and LAN cables from the production router.
-2. Plug them into the backup router (same NIC names: `enp2s0` WAN, `enp3s0` LAN).
+2. Plug them into the backup router.
+   Current interface names differ by host:
+   - `router`: WAN `enp6s17`, LAN `enp6s16`
+   - `router-backup`: WAN `enp2s0`, LAN `enp3s0`
 3. Both routers share the same production LAN identity (`10.10.10.1`), so no
    DNS or DHCP reconfiguration is needed on clients.
 4. Use the management IP to reach the new active router after cutover.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -47,6 +47,40 @@ The generic update path on a Proxmox node is:
 home-manager switch --flake .#$(hostname)-root
 ```
 
+## Router Standby / Dev Mode
+
+Both `router` and `router-backup` are designed to boot into a debuggable state
+even with all production cables unplugged.
+
+**What this means in practice:**
+
+- The production LAN static IP (`10.10.10.1/24`) is configured with
+  `ConfigureWithoutCarrier = true`, so it remains present even when the
+  data-plane NIC has no link.
+- Management IP is on a separate NIC (`ens18`) and is independent of WAN/LAN
+  carrier state.
+- Monitoring services (Prometheus, Grafana, Netdata) come up in a
+  degraded-but-functional state once the LAN address exists, even if no LAN
+  traffic flows.
+- The serial console (`ttyS0` at 115200 baud) is always enabled as a recovery
+  path when SSH or the graphical console is unavailable (Proxmox → Console →
+  Serial Terminal 0).
+
+**When swapping to the backup router:**
+
+1. Unplug WAN and LAN cables from the production router.
+2. Plug them into the backup router (same NIC names: `enp2s0` WAN, `enp3s0` LAN).
+3. Both routers share the same production LAN identity (`10.10.10.1`), so no
+   DNS or DHCP reconfiguration is needed on clients.
+4. Use the management IP to reach the new active router after cutover.
+
+**If monitoring looks broken after unplugging cables:**
+
+Prometheus and Grafana bind to `0.0.0.0` and should come up once the LAN
+address is present. If a service is stuck in `activating`, check
+`systemctl status <service>` — it may be waiting on the log storage mount
+(`/var/log/router`) rather than on the LAN address.
+
 ## Git / Agent Notes
 
 - Agents should commit without GPG signing to avoid pinentry failures.

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -68,3 +68,11 @@ After enabling clustering, still verify the standby router manually:
 - the `LAN` DHCP scope exists on `router-backup`
 - the dynamic pool matches the intended standby settings
 - only the active router is connected to production WAN/LAN
+
+## Standby / Dev Router Behavior
+
+When a router is used as a spare or dev box:
+
+- the management IP on the virtio interface stays reachable even with WAN/LAN unplugged
+- the production LAN IP (`10.10.10.1/16`) remains configured without carrier so dashboard and monitoring can start in a degraded state
+- LAN/WAN-dependent checks are expected to show degraded or failed until cables are reattached

--- a/docs/router-work-items/01-router-recovery-invariants.md
+++ b/docs/router-work-items/01-router-recovery-invariants.md
@@ -1,6 +1,6 @@
 # Router Recovery Invariants
 
-Status: `ready`
+Status: `done`
 Suggested branch: `fix/router-recovery-invariants`
 Priority: `highest`
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -42,6 +42,43 @@ in
 {
   imports = [ ../../../modules/nixos/router/common.nix ];
 
+  # Recovery invariants: these assertions fail the build if the properties
+  # that make the router usable in standby/dev mode are ever regressed.
+  assertions = [
+    {
+      assertion =
+        (config.systemd.network.networks."20-router-lan".networkConfig.ConfigureWithoutCarrier or false) == true;
+      message = ''
+        Router invariant violated: 20-router-lan must have ConfigureWithoutCarrier = true.
+        Without this, the LAN static IP disappears when the data-plane cable is unplugged,
+        causing monitoring (Prometheus, Grafana, Netdata) to cascade into failure on standby/dev boxes.
+      '';
+    }
+    {
+      assertion = config.services.qemuGuest.enable;
+      message = ''
+        Router invariant violated: services.qemuGuest.enable must be true.
+        The QEMU guest agent is required for Proxmox to report accurate VM state and
+        to support clean shutdown/snapshot from the hypervisor.
+      '';
+    }
+    {
+      assertion = builtins.elem "console=ttyS0,115200" config.boot.kernelParams;
+      message = ''
+        Router invariant violated: boot.kernelParams must include "console=ttyS0,115200".
+        The serial console is the recovery path when SSH and the graphical console are broken.
+      '';
+    }
+    {
+      assertion = !builtins.elem "podman" (config.services.router-dashboard.services or []);
+      message = ''
+        Router invariant violated: "podman" must not appear in router-dashboard.services.
+        Podman was removed from the router role; leaving it in the dashboard list causes
+        the status panel to show a permanently-failed service that no longer exists.
+      '';
+    }
+  ];
+
   host = {
     type = "router";
     primaryUser = "deepwatrcreatur";

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -18,6 +18,7 @@
 }:
 let
   optSec = import ../../../modules/helpers/optional-secrets.nix { inherit lib; };
+  getAttrByPath = lib.attrsets.attrByPath;
   managementListenAddress = builtins.head (lib.splitString "/" managementIpv4Address);
 
   secrets = optSec.mkSecrets {
@@ -47,7 +48,11 @@ in
   assertions = [
     {
       assertion =
-        (config.systemd.network.networks."20-router-lan".networkConfig.ConfigureWithoutCarrier or false) == true;
+        getAttrByPath
+          [ "systemd" "network" "networks" "20-router-lan" "networkConfig" "ConfigureWithoutCarrier" ]
+          false
+          config
+        == true;
       message = ''
         Router invariant violated: 20-router-lan must have ConfigureWithoutCarrier = true.
         Without this, the LAN static IP disappears when the data-plane cable is unplugged,
@@ -70,7 +75,8 @@ in
       '';
     }
     {
-      assertion = !builtins.elem "podman" (config.services.router-dashboard.services or []);
+      assertion =
+        !builtins.elem "podman" (getAttrByPath [ "services" "router-dashboard" "services" ] [ ] config);
       message = ''
         Router invariant violated: "podman" must not appear in router-dashboard.services.
         Podman was removed from the router role; leaving it in the dashboard list causes


### PR DESCRIPTION
## Summary
- add build-time assertions for the router recovery invariants that recently proved critical
- document standby/dev router behavior in ops and cutover docs
- mark the recovery-invariants work item as done

## Why
The router is now expected to boot into a debuggable state even with production NICs unplugged. This PR makes the key assumptions explicit so future refactors fail fast instead of silently regressing recovery behavior.

## Validation
- nix build .#nixosConfigurations.router.config.system.build.toplevel
- nix build .#nixosConfigurations.router-backup.config.system.build.toplevel

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for router standby/dev mode: isolated boot behavior, static LAN presence without carrier, degraded-but-functional monitoring startup, serial console recovery, cutover checklist, and troubleshooting for monitoring activation issues.

* **Chores**
  * Added automated safety checks to enforce standby/dev operational requirements during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->