### PR TITLE
feat: router management-plane independence

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -47,6 +47,35 @@ The generic update path on a Proxmox node is:
 home-manager switch --flake .#$(hostname)-root
 ```
 
+<<<<<<< HEAD
+## Router Management Plane
+
+The router management interface (`ens18`, `192.168.100.0/24`) is the **supported
+recovery plane**. It is intentionally independent of WAN and LAN state.
+
+**Recovery guarantees:**
+
+- SSH and all diagnostic services bind to `0.0.0.0`; they are reachable on
+  management even when WAN is absent or the LAN cable is unplugged.
+- `192.168.100.100` (router) and `192.168.100.99` (router-backup) are derived
+  from `lib/hosts.nix` — no raw literals in host config files.
+- Grafana, Prometheus, Netdata, Caddy, and the router dashboard all bind to
+  all interfaces.
+- fail2ban exempts `192.168.100.0/24` from bans so authentication testing
+  from management can never lock you out.
+
+**When the router is broken and you cannot reach `10.10.10.1`:**
+
+1. SSH via management: `ssh deepwatrcreatur@192.168.100.100`
+2. Dashboard via management: `http://192.168.100.100:8888/`
+3. Grafana: `http://192.168.100.100:3001/`
+4. Prometheus: `http://192.168.100.100:9090/`
+5. Technitium DNS admin: `http://192.168.100.100:5380/`
+6. Last resort: Proxmox console → Serial Terminal 0 (ttyS0, 115200 baud)
+
+**Design rule:** any new service added to the router role must be reachable on
+the management interface. Do not bind router services exclusively to the LAN IP.
+
 ## Router Standby / Dev Mode
 
 Both `router` and `router-backup` are designed to boot into a debuggable state

--- a/docs/router-work-items/03-management-plane-independence.md
+++ b/docs/router-work-items/03-management-plane-independence.md
@@ -1,6 +1,6 @@
 # Management Plane Independence
 
-Status: `ready`
+Status: `in-progress`
 Suggested branch: `feat/router-management-plane-independence`
 Priority: `very high`
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -247,9 +247,12 @@ in
   services.fail2ban = {
     enable = true;
     maxretry = 5;
+    # Management CIDR must be exempt: if authentication failures from the
+    # management interface trigger a ban, the recovery path is cut off.
     ignoreIP = [
       "127.0.0.1/8"
       lanNetwork.cidr
+      topology.networks.management.cidr
     ];
   };
 


### PR DESCRIPTION
Implements docs/router-work-items/03-management-plane-independence.md by:

- documenting the management plane (192.168.100.100 / 192.168.100.99) as the supported recovery path in docs/ops.md
- ensuring fail2ban exempts the management CIDR so SSH testing cannot lock out recovery
- keeping management IPs and dashboard links derived from lib/hosts.nix inventory

Validation:
- nix build .#nixosConfigurations.router.config.system.build.toplevel
- nix build .#nixosConfigurations.router-backup.config.system.build.toplevel

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed router management-plane docs with recovery access steps, reachability guarantees for SSH/diagnostics/monitoring, and a design rule requiring new router services to be reachable via the management interface.

* **Bug Fixes**
  * Management subnet exempted from automated lockouts so management access is preserved during recovery.

* **Chores**
  * Updated management-plane workflow status to in-progress and noted a stray merge-conflict marker introduced in the docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->