### PR TITLE
docs(router): add VyOS pattern study work item

### DIFF
--- a/docs/router-work-items/09-vyos-pattern-study.md
+++ b/docs/router-work-items/09-vyos-pattern-study.md
@@ -1,0 +1,67 @@
+# VyOS Pattern Study
+
+Status: `ready`
+Suggested branch: `docs/router-vyos-pattern-study`
+Priority: `low`
+
+## Goal
+
+Study the VyOS codebase and documentation for router-modeling ideas that are
+worth borrowing into this repo's NixOS router structure.
+
+## Why This Matters
+
+VyOS is a router-first declarative system with stronger built-in structure for:
+
+- interface roles
+- firewall and NAT modeling
+- policy routing
+- VPN configuration
+- operator diagnostics and recovery
+
+We do not want to adopt VyOS or recreate its CLI. We do want to identify the
+parts of its design that would improve this repo's router modules and planning.
+
+## Scope
+
+This is a study and recommendation task, not a platform migration task.
+
+The output should be:
+
+- a concise comparison between current repo patterns and VyOS patterns
+- a ranked list of ideas worth borrowing
+- a recommendation for which ideas should become future router work items
+- explicit notes on what should *not* be copied
+
+## Questions To Answer
+
+- How does VyOS model interface roles and dependencies?
+- How does VyOS separate management/control-plane concerns from data-plane
+  forwarding?
+- What NAT/firewall/policy-routing structure is worth imitating?
+- What diagnostics/health model ideas would improve the router dashboard or
+  operator workflow here?
+- Which VyOS ideas are overkill for a homelab and should be ignored?
+
+## Relevant Local Files
+
+- [`docs/router-work-items/README.md`](./README.md)
+- [`docs/router-work-items/05-router-health-model.md`](./05-router-health-model.md)
+- [`docs/router-work-items/06-boot-and-recovery-hardening.md`](./06-boot-and-recovery-hardening.md)
+- [`docs/router-work-items/08-vlans-and-vpn-policy-routing.md`](./08-vlans-and-vpn-policy-routing.md)
+- router role and common modules under `hosts/nixos/router/` and `modules/nixos/router/`
+
+## Deliverable
+
+Add a short design note under `docs/` or expand this work-item file with:
+
+- useful patterns to borrow now
+- useful patterns to defer
+- patterns to reject
+- concrete follow-up PR ideas, if any
+
+## Do Not
+
+- do not migrate to VyOS
+- do not introduce enterprise-only complexity just because VyOS has it
+- do not block current recovery/stability work on this study

--- a/docs/router-work-items/13-vyos-pattern-study.md
+++ b/docs/router-work-items/13-vyos-pattern-study.md
@@ -1,0 +1,51 @@
+Status: ready
+Priority: low
+Branch: docs/router-vyos-pattern-study
+Blocked By: none
+Unblocks: future router module-boundary cleanup
+
+# VyOS Pattern Study
+
+## Goal
+
+Study the VyOS codebase and docs for router-architecture ideas worth borrowing
+into this repo without turning the work into a platform migration.
+
+## Why
+
+VyOS is a mature router-first system with clear patterns around interface-role
+modeling, firewall/NAT boundaries, policy routing, and operator-facing
+diagnostics. Some of those patterns may improve this repo's router structure.
+
+## Scope
+
+- identify concrete VyOS ideas worth borrowing
+- rank them as `borrow`, `defer`, or `reject`
+- keep recommendations grounded in this homelab's real needs
+
+## Focus Areas
+
+- interface role modeling
+- management/control-plane separation
+- firewall/NAT/policy-routing structure
+- diagnostics and operator workflow
+
+## Constraints
+
+- do not treat this as a migration plan
+- do not add enterprise-only complexity without clear homelab payoff
+- prefer actionable follow-up ideas over abstract comparison
+
+## Deliverables
+
+- a short study note with:
+  - patterns to borrow
+  - patterns to defer
+  - patterns to reject
+- any follow-up work items that should be added to this queue
+
+## Validation
+
+- the work-item file is updated with findings
+- any newly discovered work is captured as follow-up queue items instead of
+  being left only in chat or PR comments

--- a/docs/router-work-items/README.md
+++ b/docs/router-work-items/README.md
@@ -55,6 +55,7 @@ Highest value first:
 10. `10-router-kea-module-roadmap.md`
 11. `11-internal-admin-hostnames.md`
 12. `12-vpn-module-hardening-and-tests.md`
+13. `13-vyos-pattern-study.md`
 
 ## Why This Structure
 

--- a/docs/router-work-items/START-HERE.md
+++ b/docs/router-work-items/START-HERE.md
@@ -64,14 +64,8 @@ Preserve these unless the work item explicitly says otherwise:
 
 ## Current High-Value Order
 
-1. [`01-router-recovery-invariants.md`](./01-router-recovery-invariants.md)
-2. [`02-stable-interface-matching.md`](./02-stable-interface-matching.md)
-3. [`03-management-plane-independence.md`](./03-management-plane-independence.md)
-4. [`04-service-dependency-cleanup.md`](./04-service-dependency-cleanup.md)
-5. [`05-router-health-model.md`](./05-router-health-model.md)
-6. [`06-boot-and-recovery-hardening.md`](./06-boot-and-recovery-hardening.md)
-7. [`07-observability-and-flow-logging.md`](./07-observability-and-flow-logging.md)
-8. [`08-vlans-and-vpn-policy-routing.md`](./08-vlans-and-vpn-policy-routing.md)
+Use the ordered list in [`README.md`](./README.md). Do not duplicate or edit a
+second ranked list in this file; `README.md` is the authoritative queue.
 
 ## Fast Start
 

--- a/docs/router-work-items/agent-prompts.md
+++ b/docs/router-work-items/agent-prompts.md
@@ -312,3 +312,28 @@ Important constraints:
 Deliver:
 - branch commit(s)
 - a ranked upstream task breakdown
+## Prompt 13: VyOS Pattern Study
+
+Work on [`13-vyos-pattern-study.md`](./13-vyos-pattern-study.md).
+
+Create a branch named `docs/router-vyos-pattern-study`.
+
+Task:
+- study the VyOS codebase and docs for router-architecture ideas worth
+  borrowing into this repo
+- produce a concise recommendation, not a platform migration
+
+Focus areas:
+- interface role modeling
+- management/control-plane separation
+- firewall/NAT/policy-routing structure
+- diagnostics and operator workflow
+
+Important constraints:
+- do not turn this into "rewrite the router like VyOS"
+- do not add enterprise-only complexity without a homelab payoff
+- prefer concrete follow-up ideas over broad theory
+
+Deliver:
+- branch commit(s)
+- short note listing patterns to borrow, defer, and reject


### PR DESCRIPTION
## Summary
- add a new router work item for studying useful VyOS patterns
- rank it as a low-priority backlog item after the current recovery and routing tasks
- add a matching reusable agent prompt

## Testing
- not run (docs only)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
