### PR TITLE
fix(router): pull Technitium NTP sync null-scope fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1181,16 +1181,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1775208563,
+        "lastModified": 1775210595,
         "narHash": "sha256-bs+BKYQBxMjOPj/49ZRIY1gyC8HEXdegEp3OvsKAHNM=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "13edc7d2a0470f80bc89171b1c5c08469bf5952c",
+        "rev": "37caf4d6a7b2341f368f848b7242f601a9db6bde",
         "type": "github"
       },
       "original": {
         "owner": "deepwatrcreatur",
-        "ref": "fix/technitium-ntp-null-scopes",
         "repo": "nix-router-optimized",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1181,15 +1181,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1775176663,
-        "narHash": "sha256-RNVw7tgfPpqNnmMEyLWTZ7igmah3GjYehPLJZZgywQo=",
+        "lastModified": 1775208563,
+        "narHash": "sha256-bs+BKYQBxMjOPj/49ZRIY1gyC8HEXdegEp3OvsKAHNM=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "46a97441d174d392a7552cac6961f346cade9815",
+        "rev": "13edc7d2a0470f80bc89171b1c5c08469bf5952c",
         "type": "github"
       },
       "original": {
         "owner": "deepwatrcreatur",
+        "ref": "fix/technitium-ntp-null-scopes",
         "repo": "nix-router-optimized",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
     };
 
     nix-router-optimized = {
-      url = "github:deepwatrcreatur/nix-router-optimized/fix/technitium-ntp-null-scopes";
+      url = "github:deepwatrcreatur/nix-router-optimized";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
     };
 
     nix-router-optimized = {
-      url = "github:deepwatrcreatur/nix-router-optimized";
+      url = "github:deepwatrcreatur/nix-router-optimized/fix/technitium-ntp-null-scopes";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
Summary:
- update nix-router-optimized to include the Technitium NTP sync null-scope fix
- prevent router activation from failing when Technitium returns a null DHCP scopes list

Testing:
- nix build .#nixosConfigurations.router.config.system.build.toplevel

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
