### PR TITLE
docs(router): add Kea and VPN follow-up work items

### DIFF
--- a/docs/router-work-items/09-kea-technitium-architecture.md
+++ b/docs/router-work-items/09-kea-technitium-architecture.md
@@ -1,0 +1,53 @@
+# Kea And Technitium Architecture
+
+Status: `ready`
+Suggested branch: `docs/router-kea-technitium-architecture`
+Priority: `high`
+
+## Goal
+
+Design the target architecture for using Kea as the DHCP engine while keeping
+Technitium as the DNS authority and admin UI for homelab DNS.
+
+## Why This Matters
+
+This is the most plausible path toward:
+
+- reliable DHCP lease registration in DNS
+- future DHCP high availability between `router` and `router-backup`
+- eventual support for keeping both LAN ports connected at the same time
+
+It also avoids treating Technitium's built-in DHCP as the long-term HA path.
+
+## Questions To Answer
+
+- What is the cleanest split of responsibility between Kea and Technitium?
+- Should Kea update Technitium via RFC2136/D2 only, or is there any reason to
+  keep Technitium DHCP enabled?
+- What exact pieces are required for DHCPv4 + DDNS with your current LAN model?
+- What does a realistic migration path look like from Technitium DHCP to Kea?
+- What remains unsolved even after DHCP HA is improved?
+
+## Target Direction
+
+Preferred assumption unless research disproves it:
+
+- Kea handles DHCP
+- Kea D2 handles DDNS
+- Technitium remains the DNS server and DNS admin UI
+- Technitium DHCP is disabled in the final target design
+
+## Deliverable
+
+Produce a concise design note under `docs/` or extend this file with:
+
+- recommended architecture
+- migration stages
+- hard blockers / unknowns
+- explicit distinction between DHCP HA and first-hop gateway failover
+
+## Do Not
+
+- do not start implementing Kea yet in this task
+- do not claim that DHCP HA alone solves router failover
+- do not drift into generic enterprise-routing design

--- a/docs/router-work-items/10-router-kea-module-roadmap.md
+++ b/docs/router-work-items/10-router-kea-module-roadmap.md
@@ -1,0 +1,51 @@
+# Router Kea Module Roadmap
+
+Status: `ready`
+Suggested branch: `docs/router-kea-module-roadmap`
+Priority: `high`
+
+## Goal
+
+Define the upstream `nix-router-optimized` module shape for optional Kea
+support so the router flake can offer it without making it the default path.
+
+## Why This Matters
+
+If this is going to be a real option for users, the module boundary should be
+designed deliberately before implementation starts.
+
+## Questions To Answer
+
+- What should the module be called?
+  - `router-kea`
+  - `router-kea-ddns`
+  - one module vs multiple composable modules
+- Which settings belong in the upstream module versus the local repo?
+- How should HA, DDNS, and DNS-server target settings be modeled?
+- Which parts should remain disabled by default?
+
+## Expected Scope
+
+At minimum, the roadmap should cover:
+
+- DHCPv4 basics
+- DDNS integration
+- optional HA modes
+- local-DNS target configuration
+- firewall / interface integration
+- internal-only admin exposure
+
+## Deliverable
+
+Create a design note or expand this file with:
+
+- proposed module boundaries
+- candidate option schema
+- what should be upstreamed first
+- what should stay repo-local initially
+
+## Do Not
+
+- do not write the module in this task
+- do not assume all users want Technitium specifically
+- do not make Kea the new default path

--- a/docs/router-work-items/11-internal-admin-hostnames.md
+++ b/docs/router-work-items/11-internal-admin-hostnames.md
@@ -1,0 +1,44 @@
+# Internal Router Admin Hostnames
+
+Status: `ready`
+Suggested branch: `feat/router-internal-admin-hostnames`
+Priority: `medium`
+
+## Goal
+
+Expose internal-only admin hostnames for router services such as:
+
+- `technitium.deepwatercreature.com`
+- `kea.deepwatercreature.com`
+
+for browsing from the homelab, without turning them into public ingress.
+
+## Why This Matters
+
+Friendly internal names improve operator UX and make it easier to grow a
+multi-service router stack without relying on raw IPs and ports.
+
+## Tasks
+
+- define how internal-only hostnames should be represented in inventory
+- decide whether these belong in `publicIngressServices` or a separate
+  internal/admin hostname list
+- route them through Caddy or another local reverse-proxy path
+- ensure they resolve only inside the homelab / management paths
+
+## Constraints
+
+- these are not public DDNS names
+- do not publish them to Cloudflare/public ingress by default
+- preserve management-plane recovery access by raw IP even if Caddy is broken
+
+## Deliverable
+
+- implementation if feasible, or
+- a concrete plan with the required inventory and Caddy changes
+
+## Validation
+
+- internal DNS resolution works
+- Caddy serves the chosen internal names
+- public ingress checks do not treat them as external names

--- a/docs/router-work-items/11-internal-admin-hostnames.md
+++ b/docs/router-work-items/11-internal-admin-hostnames.md
@@ -21,10 +21,13 @@ multi-service router stack without relying on raw IPs and ports.
 ## Tasks
 
 - define how internal-only hostnames should be represented in inventory
-- decide whether these belong in `publicIngressServices` or a separate
-  internal/admin hostname list
+- use a separate internal/admin hostname list such as
+  `internalAdminHostnames` or `internalIngressServices`; do not place these
+  names under `publicIngressServices`
 - route them through Caddy or another local reverse-proxy path
 - ensure they resolve only inside the homelab / management paths
+- document validation rules so internal/admin names are excluded from public
+  ingress checks and public DDNS intent stays explicit
 
 ## Constraints
 

--- a/docs/router-work-items/12-vpn-module-hardening-and-tests.md
+++ b/docs/router-work-items/12-vpn-module-hardening-and-tests.md
@@ -1,0 +1,41 @@
+# VPN Module Hardening And Tests
+
+Status: `ready`
+Suggested branch: `docs/router-vpn-module-hardening`
+Priority: `medium`
+
+## Goal
+
+Turn the recent router VPN module review feedback into explicit upstream work
+items for `nix-router-optimized`.
+
+## Why This Matters
+
+Recent feedback on the new `router-tailscale`, `router-wireguard`, and
+`router-openvpn` modules surfaced a real next sprint:
+
+- add evaluation/integration checks
+- add guardrails for silent `routeToWan` no-op cases
+- validate multi-instance OpenVPN interface names
+- centralize WAN-derivation helper logic
+- add a small module-selection decision matrix
+
+## Tasks
+
+- split the feedback into 3-5 PR-sized upstream tasks
+- rank them by value and implementation order
+- identify which tasks should be docs-only versus test/module changes
+
+## Deliverable
+
+Expand this file with:
+
+- a ranked task list
+- suggested branch names
+- suggested test scope
+- which parts belong upstream versus local repo docs
+
+## Do Not
+
+- do not mix router-fleet work with upstream router-flake work invisibly
+- do not implement all fixes in one giant PR

--- a/docs/router-work-items/README.md
+++ b/docs/router-work-items/README.md
@@ -51,6 +51,10 @@ Highest value first:
 6. `06-boot-and-recovery-hardening.md`
 7. `07-observability-and-flow-logging.md`
 8. `08-vlans-and-vpn-policy-routing.md`
+9. `09-kea-technitium-architecture.md`
+10. `10-router-kea-module-roadmap.md`
+11. `11-internal-admin-hostnames.md`
+12. `12-vpn-module-hardening-and-tests.md`
 
 ## Why This Structure
 

--- a/docs/router-work-items/agent-prompts.md
+++ b/docs/router-work-items/agent-prompts.md
@@ -236,3 +236,79 @@ Validation target:
 Deliver:
 - branch commit(s)
 - note any upstream `nix-router-optimized` work that should be split out
+
+## Prompt 9: Kea And Technitium Architecture
+
+Work on [`09-kea-technitium-architecture.md`](./09-kea-technitium-architecture.md).
+
+Create a branch named `docs/router-kea-technitium-architecture`.
+
+Task:
+- design the target architecture for Kea DHCP + Technitium DNS in this homelab
+- make the migration stages explicit
+- distinguish DHCP HA from gateway failover
+
+Important constraints:
+- do not implement Kea yet
+- do not pretend DHCP HA alone solves shared-LAN router failover
+- optimize for the real homelab use case, not generic enterprise routing
+
+Deliver:
+- branch commit(s)
+- a concise architecture note with migration stages and open questions
+
+## Prompt 10: Router Kea Module Roadmap
+
+Work on [`10-router-kea-module-roadmap.md`](./10-router-kea-module-roadmap.md).
+
+Create a branch named `docs/router-kea-module-roadmap`.
+
+Task:
+- define the module/API shape for optional Kea support in `nix-router-optimized`
+- separate what belongs upstream from what should stay repo-local at first
+
+Important constraints:
+- Kea must remain optional
+- do not make Technitium-specific assumptions the upstream module cannot support
+- do not implement the module in this task
+
+Deliver:
+- branch commit(s)
+- proposed module boundaries and option schema ideas
+
+## Prompt 11: Internal Router Admin Hostnames
+
+Work on [`11-internal-admin-hostnames.md`](./11-internal-admin-hostnames.md).
+
+Create a branch named `feat/router-internal-admin-hostnames`.
+
+Task:
+- design or implement internal-only admin hostnames such as
+  `technitium.deepwatercreature.com` and `kea.deepwatercreature.com`
+- keep them out of public DDNS/public ingress
+
+Important constraints:
+- preserve raw management-IP recovery access
+- do not leak internal admin names into Cloudflare/public DNS
+
+Deliver:
+- branch commit(s)
+- summary of inventory/Caddy/DNS changes required
+
+## Prompt 12: VPN Module Hardening And Tests
+
+Work on [`12-vpn-module-hardening-and-tests.md`](./12-vpn-module-hardening-and-tests.md).
+
+Create a branch named `docs/router-vpn-module-hardening`.
+
+Task:
+- turn the recent VPN wrapper review feedback into explicit upstream tasks
+- rank testing, guardrails, docs, and helper-refactor work
+
+Important constraints:
+- split into PR-sized work items
+- do not lump all VPN follow-ups into one change
+
+Deliver:
+- branch commit(s)
+- a ranked upstream task breakdown


### PR DESCRIPTION
Summary:
- add router work items for Kea + Technitium architecture planning
- add a roadmap task for optional upstream router-kea module design
- add an internal admin-hostnames task for services like Technitium and Kea
- split recent VPN wrapper review feedback into an explicit agent task

Testing:
- not run (docs only)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added router infrastructure planning documentation covering DHCP/DNS service architecture, module development roadmap, internal admin interface configuration, and module hardening initiatives to guide upcoming development efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->