### PR TITLE
docs(router): clean management docs and add follow-up tasks

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -47,7 +47,6 @@ The generic update path on a Proxmox node is:
 home-manager switch --flake .#$(hostname)-root
 ```
 
-<<<<<<< HEAD
 ## Router Management Plane
 
 The router management interface (`ens18`, `192.168.100.0/24`) is the **supported

--- a/docs/router-work-items/03-management-plane-independence.md
+++ b/docs/router-work-items/03-management-plane-independence.md
@@ -1,6 +1,6 @@
 # Management Plane Independence
 
-Status: `in-progress`
+Status: `done`
 Suggested branch: `feat/router-management-plane-independence`
 Priority: `very high`
 
@@ -46,6 +46,24 @@ intentional design, not an accident.
 - eval/build of router and router-backup
 - manual management reachability after switch
 - dashboard links render correctly for management and LAN
+
+## Outcome
+
+Completed via PR `#53` on April 3, 2026.
+
+What changed:
+
+- management-plane recovery behavior is documented in [`docs/ops.md`](../ops.md)
+- router fail2ban configuration exempts the management CIDR so recovery access
+  cannot self-ban
+- management IPs continue to derive from inventory rather than repeated
+  literals
+
+Follow-up work stays in separate items:
+
+- service dependency cleanup
+- router health model
+- automated management-plane smoke validation
 
 ## Do Not
 

--- a/docs/router-work-items/13-upstream-hotfix-pinning-policy.md
+++ b/docs/router-work-items/13-upstream-hotfix-pinning-policy.md
@@ -1,0 +1,39 @@
+# Upstream Hotfix Pinning Policy
+
+Status: `ready`
+Suggested branch: `docs/router-hotfix-pinning-policy`
+Priority: `medium`
+
+## Goal
+
+Document and standardize how this repo temporarily consumes upstream hotfixes
+for critical router paths, then returns to stable upstream refs.
+
+## Why This Matters
+
+The Technitium NTP sync fix required a short-lived upstream hotfix branch and a
+fast follow-up to repoint the input back to upstream `main`. That worked, but
+the process is currently implicit and easy to repeat inconsistently.
+
+## Tasks
+
+- write a short policy for temporary upstream hotfix consumption
+- specify what must appear in the PR description or commit message:
+  - reason for the ref move
+  - expected lockfile churn
+  - validation commands
+  - rollback path
+- clarify when to use:
+  - upstream branch
+  - immutable commit pin
+  - upstream `main` after merge
+
+## Deliverable
+
+- a concise policy note in docs
+- if appropriate, a short PR template/checklist snippet
+
+## Do Not
+
+- do not redesign the whole flake input strategy
+- do not treat all inputs as equally critical; focus on router/infra hotfixes

--- a/docs/router-work-items/14-management-plane-smoke-validation.md
+++ b/docs/router-work-items/14-management-plane-smoke-validation.md
@@ -1,0 +1,38 @@
+# Management Plane Smoke Validation
+
+Status: `ready`
+Suggested branch: `feat/router-management-plane-smoke-validation`
+Priority: `medium`
+
+## Goal
+
+Create a repeatable smoke-validation path for the management-plane recovery
+model instead of relying only on manual operator checks.
+
+## Why This Matters
+
+The current router design depends heavily on management-plane independence.
+Manual verification has been useful, but this should become a repeatable
+pre-merge or post-build check.
+
+## Tasks
+
+- identify the smallest useful automated smoke checks, for example:
+  - management IP present in rendered config
+  - key services bind to `0.0.0.0` or management-usable addresses
+  - router-dashboard links include management paths
+- choose whether the first version should be:
+  - a `just` recipe
+  - a Nix eval/check
+  - a small verification script
+- keep manual ops docs, but back them with one automated path
+
+## Deliverable
+
+- one repeatable smoke-validation mechanism
+- short docs explaining what it does and what it does not prove
+
+## Do Not
+
+- do not try to fully simulate WAN/LAN failure in the first version
+- do not block on a full VM/integration test harness

--- a/docs/router-work-items/14-upstream-hotfix-pinning-policy.md
+++ b/docs/router-work-items/14-upstream-hotfix-pinning-policy.md
@@ -1,0 +1,39 @@
+# Upstream Hotfix Pinning Policy
+
+Status: `ready`
+Suggested branch: `docs/router-hotfix-pinning-policy`
+Priority: `medium`
+
+## Goal
+
+Document and standardize how this repo temporarily consumes upstream hotfixes
+for critical router paths, then returns to stable upstream refs.
+
+## Why This Matters
+
+The Technitium NTP sync fix required a short-lived upstream hotfix branch and a
+fast follow-up to repoint the input back to upstream `main`. That worked, but
+the process is currently implicit and easy to repeat inconsistently.
+
+## Tasks
+
+- write a short policy for temporary upstream hotfix consumption
+- specify what must appear in the PR description or commit message:
+  - reason for the ref move
+  - expected lockfile churn
+  - validation commands
+  - rollback path
+- clarify when to use:
+  - upstream branch
+  - immutable commit pin
+  - upstream `main` after merge
+
+## Deliverable
+
+- a concise policy note in docs
+- if appropriate, a short PR template/checklist snippet
+
+## Do Not
+
+- do not redesign the whole flake input strategy
+- do not treat all inputs as equally critical; focus on router/infra hotfixes

--- a/docs/router-work-items/15-management-plane-smoke-validation.md
+++ b/docs/router-work-items/15-management-plane-smoke-validation.md
@@ -1,0 +1,38 @@
+# Management Plane Smoke Validation
+
+Status: `ready`
+Suggested branch: `feat/router-management-plane-smoke-validation`
+Priority: `medium`
+
+## Goal
+
+Create a repeatable smoke-validation path for the management-plane recovery
+model instead of relying only on manual operator checks.
+
+## Why This Matters
+
+The current router design depends heavily on management-plane independence.
+Manual verification has been useful, but this should become a repeatable
+pre-merge or post-build check.
+
+## Tasks
+
+- identify the smallest useful automated smoke checks, for example:
+  - management IP present in rendered config
+  - key services bind to `0.0.0.0` or management-usable addresses
+  - router-dashboard links include management paths
+- choose whether the first version should be:
+  - a `just` recipe
+  - a Nix eval/check
+  - a small verification script
+- keep manual ops docs, but back them with one automated path
+
+## Deliverable
+
+- one repeatable smoke-validation mechanism
+- short docs explaining what it does and what it does not prove
+
+## Do Not
+
+- do not try to fully simulate WAN/LAN failure in the first version
+- do not block on a full VM/integration test harness

--- a/docs/router-work-items/README.md
+++ b/docs/router-work-items/README.md
@@ -15,7 +15,10 @@ in parallel on separate worktrees.
 - Treat each file in this folder as one PR-sized work stream.
 - Prefer one agent per file/branch.
 - Mark the file as `in-progress` in its header once an agent starts it.
-- Delete the file when the work is fully merged and no longer needs tracking.
+- When work is fully merged, either delete the file or keep it briefly as
+  `done` if it records useful outcome notes for follow-up agents.
+- `done` items must not remain in the active ranking; archive or delete them
+  once their notes are no longer useful.
 - If the work changes shape materially, update the file instead of creating
   drift in chat history only.
 - Agents should also check whether the suggested branch/worktree already exists
@@ -27,7 +30,8 @@ in parallel on separate worktrees.
 - `blocked`: do not start yet
 - `ready`: can be started now
 - `in-progress`: owned by an active branch / agent
-- `done`: merged; file can be deleted
+- `done`: merged; may remain briefly for outcome notes, but should be archived
+  or deleted and removed from the active ranking
 
 ## Recommended Process
 
@@ -45,17 +49,18 @@ Highest value first:
 
 1. `01-router-recovery-invariants.md`
 2. `02-stable-interface-matching.md`
-3. `03-management-plane-independence.md`
-4. `04-service-dependency-cleanup.md`
-5. `05-router-health-model.md`
-6. `06-boot-and-recovery-hardening.md`
-7. `07-observability-and-flow-logging.md`
-8. `08-vlans-and-vpn-policy-routing.md`
-9. `09-kea-technitium-architecture.md`
-10. `10-router-kea-module-roadmap.md`
-11. `11-internal-admin-hostnames.md`
-12. `12-vpn-module-hardening-and-tests.md`
-13. `13-vyos-pattern-study.md`
+3. `04-service-dependency-cleanup.md`
+4. `05-router-health-model.md`
+5. `06-boot-and-recovery-hardening.md`
+6. `07-observability-and-flow-logging.md`
+7. `08-vlans-and-vpn-policy-routing.md`
+8. `09-kea-technitium-architecture.md`
+9. `10-router-kea-module-roadmap.md`
+10. `11-internal-admin-hostnames.md`
+11. `12-vpn-module-hardening-and-tests.md`
+12. `13-vyos-pattern-study.md`
+13. `14-upstream-hotfix-pinning-policy.md`
+14. `15-management-plane-smoke-validation.md`
 
 ## Why This Structure
 
@@ -68,4 +73,5 @@ single long roadmap because they:
 - are easy to delete once merged
 
 Keep GitHub issues for cross-cutting or discussion-heavy items. Keep concrete
-implementation plans here.
+implementation plans here. Keep the active ranking limited to `ready`,
+`blocked`, and `in-progress` work.

--- a/docs/router-work-items/agent-prompts.md
+++ b/docs/router-work-items/agent-prompts.md
@@ -337,3 +337,39 @@ Important constraints:
 Deliver:
 - branch commit(s)
 - short note listing patterns to borrow, defer, and reject
+## Prompt 14: Upstream Hotfix Pinning Policy
+
+Work on [`14-upstream-hotfix-pinning-policy.md`](./14-upstream-hotfix-pinning-policy.md).
+
+Create a branch named `docs/router-hotfix-pinning-policy`.
+
+Task:
+- document a repeatable policy for temporarily consuming upstream router/infra
+  hotfixes and then returning to stable refs
+- optimize for recent real examples like the Technitium NTP sync fix
+
+Important constraints:
+- keep it short and operational
+- focus on prod-critical inputs, not every flake input in the repo
+
+Deliver:
+- branch commit(s)
+- concise policy/checklist docs
+
+## Prompt 15: Management Plane Smoke Validation
+
+Work on [`15-management-plane-smoke-validation.md`](./15-management-plane-smoke-validation.md).
+
+Create a branch named `feat/router-management-plane-smoke-validation`.
+
+Task:
+- add one repeatable smoke-validation path for management-plane recovery
+- back the existing manual ops guidance with a lightweight automated check
+
+Important constraints:
+- do not require a full VM test harness in the first version
+- keep scope to the management-plane model, not all router behavior
+
+Deliver:
+- branch commit(s)
+- summary of what the smoke check proves and what it does not


### PR DESCRIPTION
Summary:
- remove the leftover merge marker from docs/ops.md
- mark management-plane-independence as done with outcome notes
- add follow-up work items for upstream hotfix pinning policy and management-plane smoke validation

Testing:
- not run (docs only)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
