### PR TITLE
fix(router): disable utmp activation noise

### DIFF
--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -234,6 +234,7 @@ in
   # Proxmox recovery path: keep a serial console available even when SSH or the
   # graphical console path is broken.
   systemd.services."serial-getty@ttyS0".enable = true;
+  systemd.services.systemd-update-utmp.enable = false;
 
   services.openssh = {
     enable = true;


### PR DESCRIPTION
Disable the legacy systemd-update-utmp service in the shared router role so router and router-backup no longer report switch failure from harmless UTMP write errors during activation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted system service configuration in router systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->