### PR TITLE
docs: link router work queue from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ Use `worktrunk` (`wt`) for parallel agent work in separate git worktrees.
 - List: `wt list`
 - Remove: `wt remove`
 
+## Agent Work Queue
+
+If you are assigning or running agents against this repo, start with:
+
+- [`docs/router-work-items/START-HERE.md`](./docs/router-work-items/START-HERE.md)
+
+The ranked router queue lives in:
+
+- [`docs/router-work-items/README.md`](./docs/router-work-items/README.md)
+
 ## Notes
 
 - Some operational repo clones on hosts may drift or become conflicted over time; rebuilding from a clean checkout is often safer than repairing in place.


### PR DESCRIPTION
Add a top-level README pointer to the router work queue so agents can discover the repo-local START-HERE flow from main.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
