### PR TITLE
feat(router): explicit health model for interfaces

### DIFF
--- a/docs/router-work-items/05-router-health-model.md
+++ b/docs/router-work-items/05-router-health-model.md
@@ -1,6 +1,6 @@
 # Router Health Model
 
-Status: `in-progress`
+Status: `done`
 Suggested branch: `feat/router-health-model`
 Priority: `high`
 

--- a/docs/router-work-items/05-router-health-model.md
+++ b/docs/router-work-items/05-router-health-model.md
@@ -1,6 +1,6 @@
 # Router Health Model
 
-Status: `ready`
+Status: `in-progress`
 Suggested branch: `feat/router-health-model`
 Priority: `high`
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -178,6 +178,12 @@ in
   services.router-homelab.listenAddress = "0.0.0.0";
 
   services.router-dashboard = {
+    services = lib.mkAfter [
+      "health-mgmt-ip"
+      "health-lan-ip"
+      "health-wan-carrier"
+      "health-wan-ip"
+    ];
     links = [
       {
         label = "Tech Logs";

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -20,6 +20,7 @@ let
   optSec = import ../../../modules/helpers/optional-secrets.nix { inherit lib; };
   getAttrByPath = lib.attrByPath;
   managementListenAddress = builtins.head (lib.splitString "/" managementIpv4Address);
+  managementDevice = config.services.router-optimizations.interfaces.management.device;
 
   secrets = optSec.mkSecrets {
     cloudflare-api-key = {
@@ -122,7 +123,7 @@ in
         ];
       };
       management = {
-        device = "ens18";
+        device = managementDevice;
         ipv4Address = managementIpv4Address;
         prefixDelegationMode = "managed";
       };
@@ -144,7 +145,7 @@ in
         label = "LAN";
       };
       management = {
-        device = "ens18";
+        device = managementDevice;
         role = "management";
         label = "Management";
       };
@@ -301,7 +302,7 @@ in
       description = "Health Check: Management IP Present";
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${pkgs.bash}/bin/bash -c 'while true; do ip -4 addr show dev ens18 | grep -q \"inet \" || exit 1; sleep 15; done'";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'while true; do ip -4 addr show dev ${managementDevice} | grep -q \"inet \" || exit 1; sleep 15; done'";
         Restart = "always";
         RestartSec = "15s";
       };

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -287,6 +287,52 @@ in
 
   services.router-log-storage.enable = lib.mkForce enableLogStorage;
 
+  # Explicit Health Model Services
+  # These services exit with failure if the health invariant is violated,
+  # allowing the dashboard's service monitor to surface interface-level health.
+  systemd.services = {
+    health-mgmt-ip = {
+      description = "Health Check: Management IP Present";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'while true; do ip -4 addr show dev ens18 | grep -q \"inet \" || exit 1; sleep 15; done'";
+        Restart = "always";
+        RestartSec = "15s";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+    health-lan-ip = {
+      description = "Health Check: Production LAN IP Present";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'while true; do ip -4 addr show dev ${lanDevice} | grep -q \"inet \" || exit 1; sleep 15; done'";
+        Restart = "always";
+        RestartSec = "15s";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+    health-wan-carrier = {
+      description = "Health Check: WAN Carrier Active";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'while true; do cat /sys/class/net/${wanDevice}/operstate | grep -q \"up\" || exit 1; sleep 15; done'";
+        Restart = "always";
+        RestartSec = "15s";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+    health-wan-ip = {
+      description = "Health Check: WAN IP Present";
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.bash}/bin/bash -c 'while true; do ip -4 addr show dev ${wanDevice} | grep -q \"inet \" || exit 1; sleep 15; done'";
+        Restart = "always";
+        RestartSec = "15s";
+      };
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+
   nixpkgs.hostPlatform = "x86_64-linux";
   system.stateVersion = "25.05";
 }


### PR DESCRIPTION
## Summary

- Adds four `systemd` health check services: `health-mgmt-ip`, `health-lan-ip`, `health-wan-carrier`, `health-wan-ip`
- Each service polls its condition every 15 s and exits with failure when the invariant breaks — making the failure domain directly visible in the dashboard status panel
- Adds the four services to `services.router-dashboard.services` via `lib.mkAfter` so they appear alongside the other monitored units
- Cleans up stale merge conflict markers left in `docs/ops.md`

Closes work item `05-router-health-model`.

## Test plan

- [ ] `nix build .#nixosConfigurations.router.config.system.build.toplevel` passes
- [ ] `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel` passes
- [ ] Dashboard shows `health-mgmt-ip`, `health-lan-ip`, `health-wan-carrier`, `health-wan-ip` in the service monitor panel
- [ ] On a standby router with LAN cable unplugged: `health-lan-ip` and `health-wan-*` show red; `health-mgmt-ip` stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic health monitoring for router network connectivity, continuously verifying management IP, LAN IP, WAN carrier, and WAN IP status with automatic recovery.
  * Made management network device configuration flexible and dynamic instead of hardcoded.

* **Documentation**
  * Updated work-item status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->