### PR TITLE
docs(tooling): add fnox wrapper work queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ The ranked router queue lives in:
 
 - [`docs/router-work-items/README.md`](./docs/router-work-items/README.md)
 
+For repo-wide tooling and secret-wrapper follow-up, use:
+
+- [`docs/tooling-work-items/START-HERE.md`](./docs/tooling-work-items/START-HERE.md)
+
 ## Notes
 
 - Some operational repo clones on hosts may drift or become conflicted over time; rebuilding from a clean checkout is often safer than repairing in place.

--- a/docs/tooling-work-items/01-agent-cli-fnox-wrappers.md
+++ b/docs/tooling-work-items/01-agent-cli-fnox-wrappers.md
@@ -1,0 +1,32 @@
+# 01 Agent CLI Fnox Wrappers
+
+Status: `ready`
+
+Suggested branch: `feat/tooling-agent-cli-fnox-wrappers`
+
+## Goal
+
+Wrap the agent CLIs that regularly need API-key injection from `fnox` while
+keeping the current repo conventions around canonical names and fallbacks.
+
+## Scope
+
+- audit existing `fnox` wrapped commands and agent packages
+- identify which of `opencode`, `claude-code`, `gemini-cli`, and `droid`
+  already have wrapped command specs available
+- wire the high-value ones into the repo’s alias/package path using the same
+  fallback style already used for `gh` and `bw`
+- keep raw commands available if the wrapper is a convenience layer rather than
+  a true replacement
+
+## Non-Goals
+
+- wrapping generic build tools like `nixos-rebuild`, `nh`, or `just`
+- broad shell refactors unrelated to `fnox`
+
+## Validation
+
+- affected Home Manager modules evaluate cleanly
+- wrapped command aliases or package selections resolve correctly when
+  `<tool>-fnox` exists and fall back cleanly when it does not
+- docs/comments make the policy obvious to future maintainers

--- a/docs/tooling-work-items/02-api-and-proxmox-wrapper-candidates.md
+++ b/docs/tooling-work-items/02-api-and-proxmox-wrapper-candidates.md
@@ -1,0 +1,30 @@
+# 02 API And Proxmox Wrapper Candidates
+
+Status: `ready`
+
+Suggested branch: `feat/tooling-api-proxmox-wrappers`
+
+## Goal
+
+Decide whether this repo should expose dedicated secret-aware wrappers for API
+calls and Proxmox operations, and implement only the ones that clearly improve
+operator ergonomics.
+
+## Scope
+
+- evaluate a dedicated API helper wrapper such as `curl-api` or `xh-api`
+- evaluate whether there is a stable Proxmox helper command worth wrapping
+- prefer dedicated helper commands over overriding raw `curl`
+- make the secret sources and intended usage clear in docs or comments
+
+## Non-Goals
+
+- replacing raw `curl` globally
+- wrapping every command that could theoretically use a token
+
+## Validation
+
+- chosen helper commands evaluate cleanly on hosts that import the relevant
+  modules
+- helpers are clearly documented as intentional wrappers, not silent
+  replacements for unrelated tools

--- a/docs/tooling-work-items/03-wrapper-policy-and-rollout.md
+++ b/docs/tooling-work-items/03-wrapper-policy-and-rollout.md
@@ -1,0 +1,27 @@
+# 03 Wrapper Policy And Rollout
+
+Status: `ready`
+
+Suggested branch: `docs/tooling-wrapper-policy`
+
+## Goal
+
+Write down a repo-wide policy for when commands should be wrapped with `fnox`
+and align the existing implementation with that policy where low-risk cleanup is
+needed.
+
+## Scope
+
+- document the rule that commands should be wrapped only when they regularly
+  need secrets or stable policy defaults
+- explicitly document which command categories should stay unwrapped
+- note the canonical-name preference and fallback pattern already used in this
+  repo
+- leave concise follow-up notes if the current implementation deviates from the
+  policy in ways that should be fixed later
+
+## Validation
+
+- README or queue docs make the wrapping rule easy to discover
+- the policy is specific enough that a future agent can decide whether a new
+  wrapper belongs in scope without reopening the whole debate

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -1,0 +1,42 @@
+# Tooling Work Items
+
+Start here if you are assigning another agent:
+
+- [`START-HERE.md`](./START-HERE.md)
+
+This folder is the working queue for repo-wide tooling follow-up that does not
+belong in the router backlog.
+
+Use this for small PR-sized improvements to developer tooling, command
+wrappers, shell defaults, and related repo operations.
+
+## How To Use
+
+- Treat each file in this folder as one PR-sized work stream.
+- Prefer one agent per file/branch.
+- Mark the file as `in-progress` in its header once an agent starts it.
+- When work is fully merged, either delete the file or keep it briefly as
+  `done` if it records useful outcome notes for follow-up agents.
+- `done` items must not remain in the active ranking; archive or delete them
+  once their notes are no longer useful.
+- If the work changes shape materially, update the file instead of creating
+  drift in chat history only.
+- Agents should also check whether the suggested branch/worktree already exists
+  before claiming a `ready` item, but treat that only as a hint.
+
+## Current Ranked Queue
+
+1. `01-agent-cli-fnox-wrappers.md`
+2. `02-api-and-proxmox-wrapper-candidates.md`
+3. `03-wrapper-policy-and-rollout.md`
+
+## Why This Structure
+
+This repo already has a router-specific queue. Keeping tooling work separate:
+
+- avoids mixing unrelated work into router planning
+- lets agents take shell/tooling tasks without router context
+- keeps wrapper policy changes reviewable as small PRs
+
+Keep GitHub issues for discussion-heavy or cross-repo topics. Keep concrete
+implementation plans here.

--- a/docs/tooling-work-items/START-HERE.md
+++ b/docs/tooling-work-items/START-HERE.md
@@ -1,0 +1,58 @@
+# Tooling Agent Start Here
+
+If you are a coding agent starting repo-tooling work in this repo, follow this
+file and it should be enough to begin contributing.
+
+## Objective
+
+Pick the next highest-value tooling work item that is not already in progress,
+do it in its own worktree/branch, and keep the work scoped to one PR.
+
+## Where The Work Queue Lives
+
+Read first:
+
+- [`README.md`](./README.md)
+- [`agent-prompts.md`](./agent-prompts.md)
+
+The authoritative work queue is the ordered list in [`README.md`](./README.md).
+
+## How To Choose Work
+
+0. Refresh remote state first if multiple agents may be active (`git fetch origin`).
+1. Start with the ordered list in [`README.md`](./README.md).
+2. Find the first item whose header says `Status: ready`.
+3. Before taking it, check whether the suggested branch/worktree already exists.
+4. If a branch/worktree exists but there is no sign of active ownership
+   (recent commits, open PR, or file already marked `in-progress`), treat it as
+   stale and proceed.
+5. Mark the item `in-progress` in your branch as part of the same PR.
+
+## Invariants
+
+- Do not wrap build/orchestration commands just because wrapping is possible.
+- Prefer wrapping commands that regularly need secrets or policy defaults.
+- Preserve canonical command names only when the wrapped variant is already
+  established as the better default.
+- Keep raw tools available when the wrapped command is a convenience layer, not
+  a true replacement.
+- Follow the existing fallback pattern where possible:
+  `if pkgs ? <tool>-fnox then <tool>-fnox else <tool>`.
+
+## PR Workflow
+
+1. Validate locally as appropriate.
+2. Push your branch and open a PR.
+3. Wait briefly for CI and bot review.
+4. Read comments and fix substantive issues.
+5. Merge only after checks are green or remaining comments are intentionally
+   judged non-blocking.
+
+## Completion Rules
+
+When your PR merges:
+
+- update the work-item file to `done` or delete it if the work is fully
+  complete and no longer useful
+- if partial work remains, leave a smaller follow-up file behind instead of
+  keeping stale completed text

--- a/docs/tooling-work-items/agent-prompts.md
+++ b/docs/tooling-work-items/agent-prompts.md
@@ -1,0 +1,31 @@
+# Tooling Agent Prompts
+
+Use these prompts to dispatch other agents onto the tooling queue.
+
+## Prompt 1
+
+Read [`docs/tooling-work-items/START-HERE.md`](./START-HERE.md) and take the
+highest-priority item still marked `Status: \`ready\``. Focus only on that one
+item, keep the work to one PR, and update the item status in your branch.
+
+## Prompt 2
+
+Implement [`01-agent-cli-fnox-wrappers.md`](./01-agent-cli-fnox-wrappers.md).
+Audit the existing `fnox` wiring, add wrappers only for the agent CLIs that
+actually benefit from secret injection, preserve raw commands where needed, and
+follow the existing `gh`/`bw` fallback style. Validate the resulting aliases or
+package selection paths before opening a PR.
+
+## Prompt 3
+
+Implement [`02-api-and-proxmox-wrapper-candidates.md`](./02-api-and-proxmox-wrapper-candidates.md).
+Decide whether this repo should expose a dedicated API helper wrapper and any
+Proxmox-specific helper wrappers. Do not wrap generic build tools. Leave behind
+clear docs or follow-up notes for anything intentionally deferred.
+
+## Prompt 4
+
+Implement [`03-wrapper-policy-and-rollout.md`](./03-wrapper-policy-and-rollout.md).
+Document and encode a repo-wide policy for when commands should or should not
+be wrapped with `fnox`, and make sure the rollout path stays reviewable and
+predictable across hosts.


### PR DESCRIPTION
Add a small repo-wide tooling queue for fnox-backed wrapper follow-up, separate from the router backlog. This seeds targeted work items for agent CLI wrappers, API/Proxmox wrapper candidates, and wrapper policy rollout.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
