### PR TITLE
refactor(router): harden boot and document recovery procedures

### DIFF
--- a/docs/ops.md
+++ b/docs/ops.md
@@ -79,6 +79,43 @@ recovery plane**. It is intentionally independent of WAN and LAN state.
 **Design rule:** any new service added to the router role must be reachable on
 the management interface. Do not bind router services exclusively to the LAN IP.
 
+## Proxmox Recovery Procedures
+
+If the router is unresponsive or the network is misconfigured, use these paths
+to regain control.
+
+### 1. Management SSH
+
+The management interface (`ens18`) is independent of the production LAN. If
+you can reach the management network (e.g., from a jump host or via a static
+route), SSH directly to the management IP:
+
+```bash
+ssh deepwatrcreatur@192.168.100.100  # Primary Router
+ssh deepwatrcreatur@192.168.100.99   # Backup Router
+```
+
+### 2. Proxmox Serial Console (`qm terminal`)
+
+If SSH is unavailable, use the serial console. This is hardened in NixOS and
+does not depend on the graphical stack or network.
+
+1.  Log in to the Proxmox host via SSH.
+2.  Identify the VM ID (e.g., 100).
+3.  Run the terminal command:
+    ```bash
+    qm terminal 100
+    ```
+4.  Press **Enter** to see the login prompt.
+5.  To exit the terminal, press **Ctrl+O**.
+
+### 3. Proxmox Web UI Console
+
+If `qm terminal` is not preferred, use the Web UI:
+- Navigate to the Router VM → **Console**.
+- Change the view to **Serial Terminal 0** if the default NoVNC console is
+  blank or unresponsive.
+
 ## Router Standby / Dev Mode
 
 Both `router` and `router-backup` are designed to boot into a debuggable state

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -104,7 +104,7 @@ does not depend on the graphical stack or network.
 2.  Identify the VM ID (e.g., 100).
 3.  Run the terminal command:
     ```bash
-    qm terminal 100
+    qm terminal <VM_ID>
     ```
 4.  Press **Enter** to see the login prompt.
 5.  To exit the terminal, press **Ctrl+O**.

--- a/docs/router-work-items/06-boot-and-recovery-hardening.md
+++ b/docs/router-work-items/06-boot-and-recovery-hardening.md
@@ -1,6 +1,6 @@
 # Boot And Recovery Hardening
 
-Status: `in-progress`
+Status: `done`
 Suggested branch: `refactor/router-boot-recovery`
 Priority: `medium-high`
 

--- a/docs/router-work-items/06-boot-and-recovery-hardening.md
+++ b/docs/router-work-items/06-boot-and-recovery-hardening.md
@@ -1,6 +1,6 @@
 # Boot And Recovery Hardening
 
-Status: `ready`
+Status: `in-progress`
 Suggested branch: `refactor/router-boot-recovery`
 Priority: `medium-high`
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -75,6 +75,13 @@ in
       '';
     }
     {
+      assertion = config.systemd.services."serial-getty@ttyS0".enable;
+      message = ''
+        Router invariant violated: systemd.services."serial-getty@ttyS0".enable must be true.
+        This provides the login prompt on the Proxmox serial terminal.
+      '';
+    }
+    {
       assertion =
         !builtins.elem "podman" (getAttrByPath [ "services" "router-dashboard" "services" ] [ ] config);
       message = ''


### PR DESCRIPTION
## Summary

- Adds a build-time assertion that `systemd.services."serial-getty@ttyS0".enable` is `true` — the serial console is the last-resort recovery path; this prevents it from being accidentally removed
- Adds a **Proxmox Recovery Procedures** section to `docs/ops.md` covering three recovery paths in order of preference:
  1. Management SSH (`192.168.100.100` / `.99`)
  2. `qm terminal <vmid>` from the Proxmox host
  3. Proxmox Web UI → Serial Terminal 0

Both `router` and `router-backup` share the same `role.nix`, so the assertion and the documented behavior apply to both.

Closes work item `06-boot-and-recovery-hardening`.

## Test plan

- [ ] `nix build .#nixosConfigurations.router.config.system.build.toplevel` passes
- [ ] `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel` passes
- [ ] Removing `systemd.services."serial-getty@ttyS0".enable = true` from `role.nix` causes a build assertion failure with the correct message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Proxmox Recovery Procedures documentation detailing three recovery paths: direct SSH access to the management interface, VM serial terminal access via command-line tools, and Web UI console fallback—essential guidance for troubleshooting unresponsive or misconfigured router deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->