### PR TITLE
feat(router): pin passthrough NIC names via systemd .link files

### DIFF
--- a/docs/router-work-items/02-stable-interface-matching.md
+++ b/docs/router-work-items/02-stable-interface-matching.md
@@ -1,6 +1,6 @@
 # Stable Interface Matching
 
-Status: `done`
+Status: `in-progress`
 Suggested branch: `refactor/router-stable-interface-matching`
 Priority: `very high`
 

--- a/docs/router-work-items/02-stable-interface-matching.md
+++ b/docs/router-work-items/02-stable-interface-matching.md
@@ -1,6 +1,6 @@
 # Stable Interface Matching
 
-Status: `ready`
+Status: `done`
 Suggested branch: `refactor/router-stable-interface-matching`
 Priority: `very high`
 

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -32,4 +32,20 @@ in
   ];
 
   home-manager.extraSpecialArgs.hostName = lib.mkForce "router-backup";
+  # Pin the physical passthrough NICs to stable names via PCI path-based udev
+  # rules. Unlike the primary router (where we use MAC matching), the backup
+  # router's PCIe slot layout is the primary stable identifier.
+  # The management virtio NIC (ens18) is already stable and does not need a rule.
+  systemd.network.links = {
+    "10-router-backup-lan-stable" = {
+      matchConfig.Path = "pci-0000:03:00.0";
+      linkConfig.Name = "enp3s0";
+    };
+    "10-router-backup-wan-stable" = {
+      matchConfig.Path = "pci-0000:02:00.0";
+      linkConfig.Name = "enp2s0";
+    };
+  };
+
+
 }

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -155,4 +155,20 @@ in
       {
         "${dnsConfig.domain}" = mkZone dnsConfig;
       };
+  # Pin the physical passthrough NICs to stable names via MAC-based udev rules.
+  # The igc NICs on pve-z170 have stable MACs assigned by Proxmox; using them
+  # here ensures the names survive PCIe slot changes or kernel renaming changes.
+  # The management virtio NIC (ens18) is already stable and does not need a rule.
+  systemd.network.links = {
+    "10-router-lan-stable" = {
+      matchConfig.MACAddress = "02:76:c6:01:2a:af";
+      linkConfig.Name = "enp6s16";
+    };
+    "10-router-wan-stable" = {
+      matchConfig.MACAddress = "02:76:c6:01:2a:b0";
+      linkConfig.Name = "enp6s17";
+    };
+  };
+
+
 }


### PR DESCRIPTION
## Summary

Adds `systemd.network.links` entries to both router hosts so that udev pins the physical passthrough NICs to predictable names at link-init time, before networkd processes `.network` files.

**Router** (pve-z170, Intel igc NICs — matched by MAC):
| Rule | MAC | Name |
|------|-----|------|
| `10-router-lan-stable` | `02:76:c6:01:2a:af` | `enp6s16` |
| `10-router-wan-stable` | `02:76:c6:01:2a:b0` | `enp6s17` |

**Router-backup** (passthrough NICs — matched by PCI slot):
| Rule | PCI path | Name |
|------|----------|------|
| `10-router-backup-lan-stable` | `pci-0000:03:00.0` | `enp3s0` |
| `10-router-backup-wan-stable` | `pci-0000:02:00.0` | `enp2s0` |

The management virtio NIC (`ens18`) is stable by Proxmox assignment; no rule needed.

Closes work item `02-stable-interface-matching`.

## Test plan

- [ ] `nix build .#nixosConfigurations.router.config.system.build.toplevel` passes
- [ ] `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel` passes
- [ ] After a router rebuild: `ip link show enp6s16` and `ip link show enp6s17` list the correct NICs
- [ ] `ls /etc/systemd/network/` shows the generated `.link` files with the correct MAC / path match rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated router work item documentation status.

* **Chores**
  * Configured stable network interface naming for router and backup router configurations to ensure predictable device identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->