### PR TITLE
fix(checks): include internal admin caddy hosts in router inventory

### DIFF
--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -135,6 +135,9 @@ let
   allLibHostNames = names libHosts;
   publicIngressServicesFor =
     hostName: libHosts.${hostName}.publicIngressServices or libHosts.${hostName}.services or [ ];
+  internalAdminServicesFor =
+    hostName:
+    builtins.attrNames (libHosts.${hostName}.internalAdminServices or { });
 
   serviceNameCollisions =
     builtins.concatLists (
@@ -145,6 +148,8 @@ let
     );
 
   routerPublicIngressServices = publicIngressServicesFor "router";
+  routerInternalAdminServices = internalAdminServicesFor "router";
+  routerExpectedCaddyVirtualHostNames = routerPublicIngressServices ++ routerInternalAdminServices;
   routerDdnsServices = libHosts.router.ddnsServices or [ ];
 
   routerDdnsOutsideIngress =
@@ -186,10 +191,10 @@ let
     );
 
   routerIngressMissingInCaddy =
-    builtins.filter (name: !(builtins.elem name routerCaddyVirtualHostNames)) routerPublicIngressServices;
+    builtins.filter (name: !(builtins.elem name routerCaddyVirtualHostNames)) routerExpectedCaddyVirtualHostNames;
 
   routerCaddyHostsMissingInInventory =
-    builtins.filter (name: !(builtins.elem name routerPublicIngressServices)) routerCaddyVirtualHostNames;
+    builtins.filter (name: !(builtins.elem name routerExpectedCaddyVirtualHostNames)) routerCaddyVirtualHostNames;
 
   routerPrimaryHost = libHosts.router;
   routerBackupHost = libHosts.router-backup;


### PR DESCRIPTION
Account for router internal admin Caddy hosts declared via internalAdminServices when validating hosts/nixos/router/caddy.nix against lib/hosts.nix. This fixes the current CI regression for netdata, prometheus, and technitium.

Validation:
- nix build .#checks.x86_64-linux.inventory-consistency
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
