### PR TITLE
fix(router): remove duplicate systemd.network.links blocks

### DIFF
--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -50,17 +50,6 @@ in
   # Pin the physical passthrough NICs to stable names via PCI path-based udev
   # rules. Unlike the primary router (where we use MAC matching), the backup
   # router's PCIe slot layout is the primary stable identifier.
-  # The management virtio NIC (ens18) is already stable and does not need a rule.
-  systemd.network.links = {
-    "10-router-backup-lan-stable" = {
-      matchConfig.Path = "pci-0000:03:00.0";
-      linkConfig.Name = "enp3s0";
-    };
-    "10-router-backup-wan-stable" = {
-      matchConfig.Path = "pci-0000:02:00.0";
-      linkConfig.Name = "enp2s0";
-    };
-  };
 
 
 }

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -81,17 +81,6 @@ in
   # Pin the physical passthrough NICs to stable names via MAC-based udev rules.
   # The igc NICs on pve-z170 have stable MACs assigned by Proxmox; using them
   # here ensures the names survive PCIe slot changes or kernel renaming changes.
-  # The management virtio NIC (ens18) is already stable and does not need a rule.
-  systemd.network.links = {
-    "10-router-lan-stable" = {
-      matchConfig.MACAddress = "02:76:c6:01:2a:af";
-      linkConfig.Name = "enp6s16";
-    };
-    "10-router-wan-stable" = {
-      matchConfig.MACAddress = "02:76:c6:01:2a:b0";
-      linkConfig.Name = "enp6s17";
-    };
-  };
 
 
 }


### PR DESCRIPTION
## Problem

PR #64 appended `.link` file entries that were already present in the file from an earlier squash-merge, causing a build failure on `main`:

```
error: attribute 'systemd.network.links."10-router-lan-stable".matchConfig.MACAddress' already defined
```

Both `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` had duplicate `systemd.network.links` blocks.

## Fix

Remove the second (trailing) copy of each block. The first (correct) definitions remain unchanged.

## Test plan

- [ ] `nix build .#nixosConfigurations.router.config.system.build.toplevel` passes
- [ ] `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed static network interface naming rules from router configuration files. PCI-path and MAC-based link mappings for passthrough NICs were removed from both primary and backup router configs, and duplicated comments were cleaned up. No other behavioral interfaces or public configuration signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->