### PR TITLE
fix: start qemu guest agent on boot for Proxmox VMs

### DIFF
--- a/hosts/nixos/inference-vm/modules/configuration.nix
+++ b/hosts/nixos/inference-vm/modules/configuration.nix
@@ -71,6 +71,10 @@
   systemd.services."serial-getty@ttyS0".enable = true;
 
   services.fstrim.enable = true;
+  # Proxmox expects qemu-ga to be running continuously for IP reporting,
+  # shutdown, and filesystem freeze support. The upstream qemuGuest module is
+  # only udev-triggered, so start it explicitly on inference VMs as well.
+  systemd.services.qemu-guest-agent.wantedBy = [ "multi-user.target" ];
 
   # Time zone
   time.timeZone = "America/Toronto";

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -341,6 +341,11 @@ in
 
   services.qemuGuest.enable = true;
   services.fstrim.enable = true;
+  # NixOS's qemuGuest module only wires qemu-ga to a udev-triggered virtio-port
+  # event. On Proxmox VMs that can leave the agent installed but never started,
+  # so Proxmox reports the guest agent as missing after boot. Start it
+  # explicitly as part of the normal boot target on router-class VMs.
+  systemd.services.qemu-guest-agent.wantedBy = [ "multi-user.target" ];
 
   # Proxmox recovery path: keep a serial console available even when SSH or the
   # graphical console path is broken.


### PR DESCRIPTION
## Summary
- start qemu-guest-agent from multi-user.target for router-class and inference VM roles
- keep the upstream qemuGuest udev trigger, but stop depending on it as the only startup path
- document why this is needed for Proxmox visibility

## Why
NixOS's qemuGuest module installs a udev-triggered service but does not pull qemu-guest-agent into boot by default. On the router, that left the agent installed but inactive, so Proxmox reported it as missing.

## Validation
- nix build .#nixosConfigurations.router.config.system.build.toplevel
- nix build .#nixosConfigurations.router-backup.config.system.build.toplevel
- live router check showed qemu-guest-agent had WantedBy= and remained inactive despite being configured

## Note
 currently has a separate pre-existing NIX_CONFIG conflict in the repo that prevented a full system build validation there; this PR does not touch that path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated system service startup configuration to ensure QEMU guest agent properly initializes and runs continuously on system boot across all deployment environments. These enhancements improve system management capabilities, strengthen VM monitoring functionality, and overall system reliability by guaranteeing essential services automatically start reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->