### PR TITLE
docs(tooling): add sudo and token health work items

### DIFF
--- a/docs/tooling-work-items/04-sudo-wrapper-path-precedence.md
+++ b/docs/tooling-work-items/04-sudo-wrapper-path-precedence.md
@@ -1,0 +1,49 @@
+# 04 Sudo Wrapper Path Precedence
+
+Status: `ready`
+
+Suggested branch: `fix/tooling-sudo-wrapper-path`
+
+## Goal
+
+Make `sudo` resolve to `/run/wrappers/bin/sudo` reliably on NixOS hosts,
+including non-interactive execution paths used by `nixos-rebuild`, SSH command
+execution, and agent automation.
+
+## Why This Exists
+
+On `inference1`, `sudo` currently resolves to
+`/run/current-system/sw/bin/sudo`, while the working setuid wrapper is
+`/run/wrappers/bin/sudo`. That breaks operational commands in exactly the
+contexts where shell aliases are not applied.
+
+The short-term workaround is to call `/run/wrappers/bin/sudo` explicitly. This
+work item is about making that workaround unnecessary, or at least documenting
+the remaining edge cases precisely.
+
+## Scope
+
+- audit how PATH is assembled for interactive shells, non-interactive shells,
+  SSH remote commands, Home Manager shells, and system-level command runners
+- identify why `/run/current-system/sw/bin` is winning over `/run/wrappers/bin`
+  on affected hosts
+- implement the smallest reliable fix that improves default command resolution
+  without breaking current shell behavior on workstation-class systems
+- keep explicit-path usage for truly critical operational docs if that remains
+  the safer invariant
+- add comments explaining why aliases are insufficient for `sudo`
+
+## Non-Goals
+
+- replacing `sudo` with a wrapper alias only
+- redesigning privilege escalation across the repo
+- changing unrelated PATH ordering just for stylistic consistency
+
+## Validation
+
+- on at least one affected NixOS VM, `command -v sudo` resolves to the working
+  wrapper path in the execution contexts that matter for rebuilds
+- `sudo -n true` succeeds where it already should
+- repo docs clearly state when `/run/wrappers/bin/sudo` must still be used
+- comments make it obvious why future agents should not "simplify" this back to
+  an alias-only fix

--- a/docs/tooling-work-items/05-github-token-source-health.md
+++ b/docs/tooling-work-items/05-github-token-source-health.md
@@ -1,0 +1,55 @@
+# 05 GitHub Token Source Health
+
+Status: `ready`
+
+Suggested branch: `fix/tooling-github-token-health`
+
+## Goal
+
+Make GitHub token sourcing fail safe and observable, so hosts do not silently
+write decryption error text into `~/.config/git/github-token` and then use that
+garbage as if it were a valid token.
+
+## Why This Exists
+
+On `inference1`, `~/.config/git/github-token` contained a SOPS decryption error
+message rather than a token. That broke authenticated GitHub API access during
+`nixos-rebuild`, while making the failure mode look like a normal token file.
+
+The repo currently mixes several token paths:
+
+- user token files under `~/.config/git/github-token`
+- agenix-managed paths
+- shell-exported `GITHUB_TOKEN`
+- `fnox` seed sources
+
+This needs a clearer health model and safer fallback behavior.
+
+## Scope
+
+- audit the current GitHub token write path in Home Manager and any system-side
+  secret provisioning used by flake operations
+- prevent obvious non-token content from being installed as
+  `~/.config/git/github-token`
+- make secret bootstrap prefer valid agenix/system sources over best-effort
+  decrypt attempts that can leave misleading files behind
+- add clear warnings for missing or unreadable token sources
+- document the short-term rebuild escape hatch:
+  passing a real token explicitly to `nixos-rebuild` when host-local token files
+  are unhealthy
+
+## Non-Goals
+
+- fully completing the wrapper-first migration away from shell-exported
+  `GITHUB_TOKEN`
+- redesigning every secret in the repo
+- adding provider-specific token validation beyond basic sanity checks
+
+## Validation
+
+- unhealthy decrypt output is not written to `~/.config/git/github-token`
+- a host with broken user secret decryption does not masquerade as having a
+  valid GitHub token
+- flake operations still work when valid agenix/system token sources are
+  available
+- docs leave future operators with a clear recovery path for one-off rebuilds

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -29,6 +29,8 @@ wrappers, shell defaults, and related repo operations.
 1. `01-agent-cli-fnox-wrappers.md`
 2. `02-api-and-proxmox-wrapper-candidates.md`
 3. `03-wrapper-policy-and-rollout.md`
+4. `04-sudo-wrapper-path-precedence.md`
+5. `05-github-token-source-health.md`
 
 ## Why This Structure
 


### PR DESCRIPTION
Add tooling queue items for sudo wrapper path precedence and GitHub token source health based on the recent inference1 failures.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
