### PR TITLE
fix(secrets): reject invalid github token files

### DIFF
--- a/modules/home-manager/git.nix
+++ b/modules/home-manager/git.nix
@@ -164,8 +164,13 @@ in
   config = {
     # Shell configurations that merge with existing configs from other modules
     programs.bash.initExtra = lib.mkAfter ''
-      # Set GITHUB_TOKEN directly for all shells from sops decrypted file
-      if [ -f ~/.config/git/github-token ]; then
+      # Only export a token that looks like an actual single-line secret. This
+      # keeps failed decrypt output from poisoning interactive shells until the
+      # wrapper-first migration is complete.
+      if [ -f ~/.config/git/github-token ] \
+        && [ -s ~/.config/git/github-token ] \
+        && [ "$(${pkgs.coreutils}/bin/wc -l < ~/.config/git/github-token)" -le 1 ] \
+        && ! ${pkgs.gnugrep}/bin/grep -q '[[:space:]]' ~/.config/git/github-token; then
         export GITHUB_TOKEN="$(cat ~/.config/git/github-token)"
       fi
 
@@ -185,8 +190,13 @@ in
     '';
 
     programs.zsh.initContent = lib.mkAfter ''
-      # Set GITHUB_TOKEN directly for all shells from sops decrypted file
-      if [ -f ~/.config/git/github-token ]; then
+      # Only export a token that looks like an actual single-line secret. This
+      # keeps failed decrypt output from poisoning interactive shells until the
+      # wrapper-first migration is complete.
+      if [ -f ~/.config/git/github-token ] \
+        && [ -s ~/.config/git/github-token ] \
+        && [ "$(${pkgs.coreutils}/bin/wc -l < ~/.config/git/github-token)" -le 1 ] \
+        && ! ${pkgs.gnugrep}/bin/grep -q '[[:space:]]' ~/.config/git/github-token; then
         export GITHUB_TOKEN="$(cat ~/.config/git/github-token)"
       fi
 
@@ -206,8 +216,10 @@ in
     '';
 
     programs.fish.interactiveShellInit = lib.mkAfter ''
-      # Set GITHUB_TOKEN directly for all shells from sops decrypted file
-      if test -f ~/.config/git/github-token
+      # Only export a token that looks like an actual single-line secret. This
+      # keeps failed decrypt output from poisoning interactive shells until the
+      # wrapper-first migration is complete.
+      if test -f ~/.config/git/github-token; and test -s ~/.config/git/github-token; and test (${pkgs.coreutils}/bin/wc -l < ~/.config/git/github-token) -le 1; and not ${pkgs.gnugrep}/bin/grep -q '[[:space:]]' ~/.config/git/github-token
         set -gx GITHUB_TOKEN (cat ~/.config/git/github-token)
       end
 
@@ -227,8 +239,13 @@ in
     '';
 
     programs.nushell.extraConfig = lib.mkAfter ''
-      # Set GITHUB_TOKEN directly for all shells from sops decrypted file
-      if ("~/.config/git/github-token" | path exists) {
+      # Only export a token that looks like an actual single-line secret. This
+      # keeps failed decrypt output from poisoning interactive shells until the
+      # wrapper-first migration is complete.
+      if ("~/.config/git/github-token" | path exists)
+        and ((open ~/.config/git/github-token | lines | length) <= 1)
+        and (((open ~/.config/git/github-token | str trim) | str contains " ") == false)
+        and (((open ~/.config/git/github-token | str trim) | is-not-empty)) {
         $env.GITHUB_TOKEN = (open ~/.config/git/github-token | str trim)
       }
 

--- a/modules/home-manager/user-secrets.nix
+++ b/modules/home-manager/user-secrets.nix
@@ -43,6 +43,35 @@ in {
       AGENIX_GITHUB_TOKEN="${cfg.agenixGithubTokenPath}"
       SYSTEM_GITHUB_TOKEN="/run/secrets/github-token"
       SYSTEM_ATTIC_TOKEN="${cfg.systemAtticTokenPath}"
+      USER_GITHUB_TOKEN="$HOME/.config/git/github-token"
+
+      token_file_is_sane() {
+        local token_file="$1"
+        local line_count
+
+        [ -f "$token_file" ] || return 1
+        [ -r "$token_file" ] || return 1
+
+        # Refuse empty, multiline, or whitespace-containing content so failed
+        # decrypt output does not masquerade as a usable GitHub token.
+        [ -s "$token_file" ] || return 1
+        line_count="$(${pkgs.coreutils}/bin/wc -l < "$token_file")"
+        [ "$line_count" -le 1 ] || return 1
+        ${pkgs.gnugrep}/bin/grep -q '[[:space:]]' "$token_file" && return 1
+
+        return 0
+      }
+
+      install_github_token_if_sane() {
+        local source_file="$1"
+
+        if token_file_is_sane "$source_file"; then
+          install -m 600 "$source_file" "$USER_GITHUB_TOKEN"
+          return 0
+        fi
+
+        return 1
+      }
 
       if [ -f "$SYSTEM_ATTIC_TOKEN" ] && [ -r "$SYSTEM_ATTIC_TOKEN" ]; then
         install -m 600 "$SYSTEM_ATTIC_TOKEN" "$HOME/.config/sops/attic-client-token"
@@ -65,14 +94,17 @@ in {
       # Prefer agenix GitHub token for nix flake operations, otherwise fall back
       # to the legacy SOPS-encrypted user secret.
       if [ -f "$AGENIX_GITHUB_TOKEN" ]; then
-        install -m 600 "$AGENIX_GITHUB_TOKEN" "$HOME/.config/git/github-token"
+        install_github_token_if_sane "$AGENIX_GITHUB_TOKEN" || \
+          echo "Warning: refusing invalid agenix GitHub token at $AGENIX_GITHUB_TOKEN" >&2
       elif [ -f "$SYSTEM_GITHUB_TOKEN" ] && [ -r "$SYSTEM_GITHUB_TOKEN" ]; then
-        install -m 600 "$SYSTEM_GITHUB_TOKEN" "$HOME/.config/git/github-token"
+        install_github_token_if_sane "$SYSTEM_GITHUB_TOKEN" || \
+          echo "Warning: refusing invalid system GitHub token at $SYSTEM_GITHUB_TOKEN" >&2
       elif [ -f "$GITHUB_TOKEN_ENC" ]; then
         if [ -f "$SOPS_AGE_KEY_FILE" ]; then
           tmp_github_token="$(mktemp)"
           if sops -d "$GITHUB_TOKEN_ENC" > "$tmp_github_token" 2>/dev/null; then
-            install -m 600 "$tmp_github_token" "$HOME/.config/git/github-token"
+            install_github_token_if_sane "$tmp_github_token" || \
+              echo "Warning: refusing invalid decrypted GitHub token from $GITHUB_TOKEN_ENC" >&2
           fi
           rm -f "$tmp_github_token"
         else
@@ -82,6 +114,13 @@ in {
       else
         # echo "Warning: no agenix or SOPS GitHub token found; leaving existing github-token in place"
         true
+      fi
+
+      # If no valid source was installed this run, drop obviously invalid stale
+      # content so shells and flake operations do not keep exporting garbage.
+      if [ -f "$USER_GITHUB_TOKEN" ] && ! token_file_is_sane "$USER_GITHUB_TOKEN"; then
+        rm -f "$USER_GITHUB_TOKEN"
+        echo "Warning: removed invalid GitHub token file at $USER_GITHUB_TOKEN" >&2
       fi
     '';
   };

--- a/modules/home-manager/user-secrets.nix
+++ b/modules/home-manager/user-secrets.nix
@@ -67,7 +67,7 @@ in {
 
         if token_file_is_sane "$source_file"; then
           install -m 600 "$source_file" "$USER_GITHUB_TOKEN"
-          return 0
+          return $?
         fi
 
         return 1
@@ -91,20 +91,36 @@ in {
         true
       fi
 
-      # Prefer agenix GitHub token for nix flake operations, otherwise fall back
-      # to the legacy SOPS-encrypted user secret.
+      # Prefer agenix GitHub token for nix flake operations, then fall back to
+      # system and finally the legacy SOPS-encrypted user secret. Invalid
+      # higher-priority sources must not block lower-priority fallbacks.
+      github_token_installed=0
+
       if [ -f "$AGENIX_GITHUB_TOKEN" ]; then
-        install_github_token_if_sane "$AGENIX_GITHUB_TOKEN" || \
+        if install_github_token_if_sane "$AGENIX_GITHUB_TOKEN"; then
+          github_token_installed=1
+        else
           echo "Warning: refusing invalid agenix GitHub token at $AGENIX_GITHUB_TOKEN" >&2
-      elif [ -f "$SYSTEM_GITHUB_TOKEN" ] && [ -r "$SYSTEM_GITHUB_TOKEN" ]; then
-        install_github_token_if_sane "$SYSTEM_GITHUB_TOKEN" || \
+        fi
+      fi
+
+      if [ "$github_token_installed" -eq 0 ] && [ -f "$SYSTEM_GITHUB_TOKEN" ] && [ -r "$SYSTEM_GITHUB_TOKEN" ]; then
+        if install_github_token_if_sane "$SYSTEM_GITHUB_TOKEN"; then
+          github_token_installed=1
+        else
           echo "Warning: refusing invalid system GitHub token at $SYSTEM_GITHUB_TOKEN" >&2
-      elif [ -f "$GITHUB_TOKEN_ENC" ]; then
+        fi
+      fi
+
+      if [ "$github_token_installed" -eq 0 ] && [ -f "$GITHUB_TOKEN_ENC" ]; then
         if [ -f "$SOPS_AGE_KEY_FILE" ]; then
           tmp_github_token="$(mktemp)"
           if sops -d "$GITHUB_TOKEN_ENC" > "$tmp_github_token" 2>/dev/null; then
-            install_github_token_if_sane "$tmp_github_token" || \
+            if install_github_token_if_sane "$tmp_github_token"; then
+              github_token_installed=1
+            else
               echo "Warning: refusing invalid decrypted GitHub token from $GITHUB_TOKEN_ENC" >&2
+            fi
           fi
           rm -f "$tmp_github_token"
         else


### PR DESCRIPTION
Refuse poisoned GitHub token files in Home Manager activation and shell export paths so hosts do not keep exporting failed decrypt output as GITHUB_TOKEN.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced GitHub token validation with stricter format checks across all shell environments
  - Invalid or malformed tokens are now rejected and automatically cleaned up

<!-- end of auto-generated comment: release notes by coderabbit.ai -->