### PR TITLE
fix(inference1): run ollama as ollama user again

### DIFF
--- a/hosts/nixos/inference-vm/hosts/inference1/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference1/default.nix
@@ -82,8 +82,16 @@
       HOME = lib.mkForce "/models/ollama";
     };
     serviceConfig = {
+      # Keep Ollama running as the dedicated service user. If User= is omitted
+      # while DynamicUser=false, systemd falls back to root, which has proven
+      # brittle with this hardened unit and the virtiofs-backed model store.
+      User = lib.mkForce "ollama";
+      Group = lib.mkForce "ollama";
       StateDirectory = lib.mkForce "";
       DynamicUser = lib.mkForce false;
+      # Virtiofs exposes host UIDs/GIDs directly; user namespaces can make the
+      # shared mount appear mismatched even when the on-disk ownership is right.
+      PrivateUsers = lib.mkForce false;
       ReadWritePaths = lib.mkForce [ "/models/ollama" ];
       WorkingDirectory = lib.mkForce "/models/ollama";
       # Allow access to the actual GPU device


### PR DESCRIPTION
Restore the earlier inference1 Ollama service invariant: run as the dedicated ollama user, not root, and keep PrivateUsers disabled for the virtiofs-backed models mount.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
