### PR TITLE
fix(inference1): set upstream ollama user options

### DIFF
--- a/hosts/nixos/inference-vm/hosts/inference1/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference1/default.nix
@@ -62,6 +62,13 @@
 
     host = "0.0.0.0";
     port = 11434;
+    # The upstream NixOS module only sets User=/Group= when these options are
+    # non-null. Leaving them unset while forcing DynamicUser=false makes the
+    # service silently run as root.
+    user = "ollama";
+    group = "ollama";
+    home = "/models/ollama";
+    models = "/models/ollama/models";
     environmentVariables = {
       CUDA_VISIBLE_DEVICES = "0";
       OLLAMA_GPU_OVERHEAD = "0";
@@ -82,11 +89,6 @@
       HOME = lib.mkForce "/models/ollama";
     };
     serviceConfig = {
-      # Keep Ollama running as the dedicated service user. If User= is omitted
-      # while DynamicUser=false, systemd falls back to root, which has proven
-      # brittle with this hardened unit and the virtiofs-backed model store.
-      User = lib.mkForce "ollama";
-      Group = lib.mkForce "ollama";
       StateDirectory = lib.mkForce "";
       DynamicUser = lib.mkForce false;
       # Virtiofs exposes host UIDs/GIDs directly; user namespaces can make the
@@ -94,8 +96,19 @@
       PrivateUsers = lib.mkForce false;
       ReadWritePaths = lib.mkForce [ "/models/ollama" ];
       WorkingDirectory = lib.mkForce "/models/ollama";
-      # Allow access to the actual GPU device
-      DeviceAllow = [ "/dev/nvidia0" ];
+      # Preserve the upstream GPU device allowances and add the actual NVIDIA
+      # device node used on this VM.
+      DeviceAllow = [
+        "char-nvidiactl"
+        "char-nvidia-caps"
+        "char-nvidia-frontend"
+        "char-nvidia-uvm"
+        "char-drm"
+        "char-fb"
+        "char-kfd"
+        "/dev/dxg"
+        "/dev/nvidia0"
+      ];
     };
   };
 


### PR DESCRIPTION
## Summary
- set services.ollama.user/group/home/models explicitly for inference1
- keep PrivateUsers disabled for the virtiofs-backed models path
- preserve the upstream GPU device allowances while adding /dev/nvidia0

## Validation
- nix build .#nixosConfigurations.inference1.config.system.build.toplevel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded GPU device access configuration to support broader NVIDIA compute interfaces and improved device compatibility
  * Reorganized service configuration for enhanced reliability and explicit resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->