### PR TITLE
fix(inference1): move ollama overrides to active den aspect

### DIFF
--- a/den/aspects/inference1-ollama.nix
+++ b/den/aspects/inference1-ollama.nix
@@ -51,6 +51,13 @@ _context:
 
     host = "0.0.0.0";
     port = 11434;
+    # The upstream NixOS module only emits User=/Group= when these options are
+    # non-null. Leaving them unset while forcing DynamicUser=false makes the
+    # service silently run as root.
+    user = "ollama";
+    group = "ollama";
+    home = "/models/ollama";
+    models = "/models/ollama/models";
     environmentVariables = {
       CUDA_VISIBLE_DEVICES = "0";
       OLLAMA_GPU_OVERHEAD = "0";
@@ -73,9 +80,22 @@ _context:
     serviceConfig = {
       StateDirectory = lib.mkForce "";
       DynamicUser = lib.mkForce false;
+      # Virtiofs exposes host UIDs/GIDs directly; user namespaces can make the
+      # shared mount appear mismatched even when ownership is correct.
+      PrivateUsers = lib.mkForce false;
       ReadWritePaths = lib.mkForce [ "/models/ollama" ];
       WorkingDirectory = lib.mkForce "/models/ollama";
-      DeviceAllow = [ "/dev/nvidia0" ];
+      DeviceAllow = [
+        "char-nvidiactl"
+        "char-nvidia-caps"
+        "char-nvidia-frontend"
+        "char-nvidia-uvm"
+        "char-drm"
+        "char-fb"
+        "char-kfd"
+        "/dev/dxg"
+        "/dev/nvidia0"
+      ];
     };
   };
 


### PR DESCRIPTION
## Summary
- fix the active inference1 config in den/aspects/inference1-ollama.nix
- set services.ollama user/group/home/models at the upstream option layer
- keep PrivateUsers disabled for the virtiofs-backed models path

## Validation
- nix eval .#nixosConfigurations.inference1.config.services.ollama.user --json
- nix eval .#nixosConfigurations.inference1.config.systemd.services.ollama.serviceConfig --json
- nix build .#nixosConfigurations.inference1.config.system.build.toplevel
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
