### PR TITLE
docs(den): clarify active and legacy host paths

### DIFF
--- a/den/README.md
+++ b/den/README.md
@@ -38,3 +38,14 @@ outputs should be treated as `den/inventory`, not `inventory/legacy`.
 - Some `den` leaves still import legacy host-local files for hardware and networking.
 - Some exported leaves remain `mode = "legacy"` while their inventory is already under `den/`.
 - Support metadata such as SSH and DNS still lives in [`lib/hosts.nix`](/home/deepwatrcreatur/flakes/unified-nix-configuration/lib/hosts.nix), so checks must keep `den/inventory` and `lib/hosts.nix` aligned.
+
+## Active vs Legacy Paths
+
+- Inference VMs now use `den/hosts/<name>/default.nix` plus den aspects as the
+  active source of truth for exported `.#inference*` outputs.
+- The old `hosts/nixos/inference-vm/hosts/*/default.nix` files are legacy and
+  should not receive active fixes unless they are being migrated or deleted.
+- Router leaves are still intentionally hybrid: den owns the exported leaf,
+  while `den/hosts/router*.nix` still import legacy router host-local files for
+  hardware, networking, Caddy, and configuration until that migration is split
+  into reviewable PRs.

--- a/den/hosts/router-backup/default.nix
+++ b/den/hosts/router-backup/default.nix
@@ -9,6 +9,9 @@ den.mkInventoryHostModule {
     ../../../users/deepwatrcreatur/hosts/router-backup/default.nix
   ];
   extraImports = [
+    # Transitional bridge: router-backup is exported through den, but still
+    # reuses legacy router-backup host files until the router migration is
+    # finished in smaller refactor PRs.
     ../../../hosts/nixos/router-backup/hardware-configuration.nix
     ../../../hosts/nixos/router-backup/networking.nix
     ../../../hosts/nixos/router-backup/caddy.nix

--- a/den/hosts/router/default.nix
+++ b/den/hosts/router/default.nix
@@ -9,6 +9,10 @@ den.mkInventoryHostModule {
     ../../../users/deepwatrcreatur/hosts/router
   ];
   extraImports = [
+    # Transitional bridge: router outputs are exported through den, but the
+    # host still depends on legacy router-local modules for hardware,
+    # networking, Caddy, and role configuration. Keep this explicit until the
+    # router tree is migrated into den/aspects in reviewable pieces.
     ../../../hosts/nixos/router/hardware-configuration.nix
     ../../../hosts/nixos/router/networking.nix
     ../../../hosts/nixos/router/caddy.nix

--- a/docs/inference-vm-models-virtiofs.md
+++ b/docs/inference-vm-models-virtiofs.md
@@ -85,7 +85,15 @@ Because VirtioFS does not virtualise permissions, any persistent "permission den
 
 ### 1. VirtioFS mount
 
-In the NixOS host config (e.g. `hosts/nixos/inference-vm/hosts/inference1/default.nix` in this repo):
+For the active `.#inference1` output, the source of truth is the den layer:
+
+- `den/hosts/inference1/default.nix`
+- `den/aspects/inference1-ollama.nix`
+
+The old `hosts/nixos/inference-vm/hosts/inference1/default.nix` path is legacy
+and is no longer the active place to land fixes for `.#inference1`.
+
+Example from the active inference1 config:
 
 ```nix
 fileSystems."/models/ollama" = {
@@ -106,9 +114,10 @@ mount | grep models
 
 ### 2. Ollama layout and tmpfiles
 
-On the guest we treat `/models/ollama` as Ollama's "home" and ensure its layout is created with the right owner/mode.
+On the guest we treat `/models/ollama` as Ollama's "home" and ensure its layout
+is created with the right owner/mode.
 
-Example (in `hosts/nixos/inference-vm/hosts/inference1/default.nix`):
+Example (in `den/aspects/inference1-ollama.nix`):
 
 ```nix
 users.users.ollama = {
@@ -146,8 +155,10 @@ systemd.tmpfiles.rules = [
 
 Notes:
 
-- We currently use `0777` for the shared `models` subdirs while iterating on virtiofs id‑mapping; this is intentionally permissive. Once UID/GID mapping is nailed down, we can tighten this to `0770` or a more conservative mode.
-- The **generic** version of these rules lives in `tesla-inference-flake` as a module option; here we override them specifically for inference VMs.
+- The active inference1 logic now lives in the den aspect layer, not the old
+  host-specific file tree.
+- The **generic** version of these rules lives in `tesla-inference-flake` as a
+  module option; here we override them specifically for inference VMs.
 
 ### 3. End‑to‑end check
 

--- a/docs/router-work-items/19-router-den-migration-boundary.md
+++ b/docs/router-work-items/19-router-den-migration-boundary.md
@@ -31,17 +31,14 @@ repository harder for agents to navigate.
 
 ## Suggested Scope
 
-Do this in one reviewable PR only if the split stays small. Otherwise, break it
-into follow-up tasks.
+This item is now the umbrella note for the more concrete follow-up tasks:
 
-Good first target:
+- `20-router-den-import-audit.md`
+- `21-router-leaf-inline-migration.md`
+- `22-router-backup-den-parity.md`
 
-- move non-hardware composition out of `den/hosts/router*.nix` legacy imports
-- keep `hardware-configuration.nix` as the last host-local import if needed
-- decide whether `networking.nix`, `caddy.nix`, and `configuration.nix` should
-  become:
-  - den aspects, or
-  - inlined host-leaf imports inside `den/hosts/router*.nix`
+Use those files for implementation work. Keep this file as the high-level
+problem statement and rationale.
 
 ## Constraints
 
@@ -54,7 +51,8 @@ Good first target:
 
 - `nix build .#nixosConfigurations.router.config.system.build.toplevel`
 - `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel`
-- confirm `den/hosts/router*.nix` import graph is simpler after the change
+- confirm the active router source-of-truth is easier to follow after the
+  follow-up tasks land
 
 ## Notes
 

--- a/docs/router-work-items/19-router-den-migration-boundary.md
+++ b/docs/router-work-items/19-router-den-migration-boundary.md
@@ -51,7 +51,7 @@ problem statement and rationale.
 
 - `nix build .#nixosConfigurations.router.config.system.build.toplevel`
 - `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel`
-- confirm the active router source-of-truth is easier to follow after the
+- confirm the active router source-of-truth is easier to follow once the
   follow-up tasks land
 
 ## Notes

--- a/docs/router-work-items/19-router-den-migration-boundary.md
+++ b/docs/router-work-items/19-router-den-migration-boundary.md
@@ -1,0 +1,63 @@
+# Router Den Migration Boundary
+
+Status: `ready`
+Priority: `medium`
+Branch: `refactor/router-den-boundary`
+
+## Goal
+
+Reduce the hybrid den/legacy split for router hosts so the active source of
+truth is easier to follow and future fixes stop landing in the wrong file tree.
+
+## Why
+
+Today `den/hosts/router/default.nix` and
+`den/hosts/router-backup/default.nix` still import multiple legacy host-local
+files:
+
+- `hosts/nixos/router/{hardware-configuration,networking,caddy,disko,configuration}.nix`
+- `hosts/nixos/router-backup/{hardware-configuration,networking,caddy,configuration}.nix`
+
+That works, but it hides which paths are still authoritative and makes the
+repository harder for agents to navigate.
+
+## Desired Outcome
+
+- The den leaves clearly own host composition.
+- Legacy router files are either:
+  - folded into den aspects / host leaves, or
+  - explicitly limited to hardware-only imports with the rest moved into den.
+- Documentation describes the resulting ownership boundary.
+
+## Suggested Scope
+
+Do this in one reviewable PR only if the split stays small. Otherwise, break it
+into follow-up tasks.
+
+Good first target:
+
+- move non-hardware composition out of `den/hosts/router*.nix` legacy imports
+- keep `hardware-configuration.nix` as the last host-local import if needed
+- decide whether `networking.nix`, `caddy.nix`, and `configuration.nix` should
+  become:
+  - den aspects, or
+  - inlined host-leaf imports inside `den/hosts/router*.nix`
+
+## Constraints
+
+- Do not change router behavior as part of a “cleanup only” refactor.
+- Preserve current router and router-backup outputs exactly.
+- Keep PRs small enough that review bots and humans can verify the ownership
+  change without re-auditing the entire router stack.
+
+## Validation
+
+- `nix build .#nixosConfigurations.router.config.system.build.toplevel`
+- `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel`
+- confirm `den/hosts/router*.nix` import graph is simpler after the change
+
+## Notes
+
+This is organizational debt, not an emergency runtime fix. It matters because
+recent inference work showed how easy it is to patch a dead legacy path when den
+is the real source of truth.

--- a/docs/router-work-items/20-router-den-import-audit.md
+++ b/docs/router-work-items/20-router-den-import-audit.md
@@ -1,0 +1,57 @@
+# Router Den Import Audit
+
+Status: `ready`
+Priority: `medium`
+Branch: `docs/router-den-import-audit`
+
+## Goal
+
+Produce a precise map of which router files are still authoritative for the
+active den outputs and which ones are now only legacy helpers.
+
+## Why
+
+`den/hosts/router/default.nix` and `den/hosts/router-backup/default.nix` still
+pull in a mix of:
+
+- den aspects
+- legacy host-local files
+- user host overlays
+
+That makes it easy to patch the wrong file first, especially for agents.
+
+## Deliverable
+
+One documentation-focused PR that adds a short source-of-truth map for:
+
+- router
+- router-backup
+
+The map should identify, for each major concern, the active file(s):
+
+- hardware
+- networking
+- Caddy / ingress
+- shared router role
+- user host overlays
+- den aspects
+
+## Suggested Output
+
+Add or update one doc under `docs/` or `den/README.md` with:
+
+- current import graph summary
+- which legacy files are still active
+- which files are legacy-only / migration candidates
+- explicit guidance for where new fixes should land first
+
+## Constraints
+
+- no behavior changes
+- no large refactor in this PR
+- optimize for navigation clarity, not architectural perfection
+
+## Validation
+
+- verify the documented import graph matches `den/hosts/router*.nix`
+- verify the doc names the current active router role and Caddy paths correctly

--- a/docs/router-work-items/21-router-leaf-inline-migration.md
+++ b/docs/router-work-items/21-router-leaf-inline-migration.md
@@ -1,0 +1,53 @@
+# Router Leaf Inline Migration
+
+Status: `ready`
+Priority: `medium`
+Branch: `refactor/router-leaf-inline-migration`
+
+## Goal
+
+Reduce the number of legacy router file imports in `den/hosts/router/default.nix`
+by moving simple host-local composition directly into the den leaf.
+
+## Why
+
+Right now the router den leaf still imports several legacy files:
+
+- `hardware-configuration.nix`
+- `networking.nix`
+- `caddy.nix`
+- `disko.nix`
+- `configuration.nix`
+
+Some of these may still make sense as imports, but some are only thin
+composition wrappers and can likely be inlined or split more cleanly.
+
+## Target Scope
+
+Start with the non-hardware pieces only.
+
+Good candidates:
+
+- identify whether `configuration.nix` is mostly wiring around
+  `hosts/nixos/router/role.nix`
+- identify whether `networking.nix` is host-local data or reusable logic
+- identify whether `caddy.nix` is truly host-local enough to stay separate
+
+The desired outcome is:
+
+- `den/hosts/router/default.nix` remains the obvious active leaf
+- thin legacy wrapper files are reduced
+- large behavioral modules stay where they belong
+
+## Constraints
+
+- keep `hardware-configuration.nix` imported as-is
+- do not change router behavior
+- prefer moving only one or two imports per PR if the diff grows
+
+## Validation
+
+- `nix build .#nixosConfigurations.router.config.system.build.toplevel`
+- confirm resulting router output is equivalent at a high level
+- ensure comments explain any remaining legacy imports that are still
+  intentional

--- a/docs/router-work-items/22-router-backup-den-parity.md
+++ b/docs/router-work-items/22-router-backup-den-parity.md
@@ -1,0 +1,40 @@
+# Router-Backup Den Parity
+
+Status: `ready`
+Priority: `medium`
+Branch: `refactor/router-backup-den-parity`
+
+## Goal
+
+Apply the same den/legacy boundary cleanup to `router-backup` after the main
+router leaf is better understood.
+
+## Why
+
+`router-backup` is still a hybrid den leaf with imports from:
+
+- `hosts/nixos/router-backup/hardware-configuration.nix`
+- `hosts/nixos/router-backup/networking.nix`
+- `hosts/nixos/router-backup/caddy.nix`
+- `hosts/nixos/router-backup/configuration.nix`
+
+It should not drift into a different organizational model than `router`.
+
+## Scope
+
+- compare `den/hosts/router/default.nix` and `den/hosts/router-backup/default.nix`
+- keep only the differences that are truly backup-specific
+- mirror any den-boundary cleanup already done for `router`
+- add comments if any remaining legacy imports are intentionally kept
+
+## Constraints
+
+- preserve `router-backup` behavior exactly
+- do not merge this before understanding the active `router` boundary
+- keep the PR focused on parity and ownership, not new router features
+
+## Validation
+
+- `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel`
+- compare active import structure against `router`
+- confirm the remaining differences are host-specific and not accidental drift

--- a/docs/router-work-items/README.md
+++ b/docs/router-work-items/README.md
@@ -61,6 +61,7 @@ Highest value first:
 12. `13-vyos-pattern-study.md`
 13. `14-upstream-hotfix-pinning-policy.md`
 14. `15-management-plane-smoke-validation.md`
+15. `19-router-den-migration-boundary.md`
 
 ## Why This Structure
 

--- a/docs/router-work-items/README.md
+++ b/docs/router-work-items/README.md
@@ -62,6 +62,9 @@ Highest value first:
 13. `14-upstream-hotfix-pinning-policy.md`
 14. `15-management-plane-smoke-validation.md`
 15. `19-router-den-migration-boundary.md`
+16. `20-router-den-import-audit.md`
+17. `21-router-leaf-inline-migration.md`
+18. `22-router-backup-den-parity.md`
 
 ## Why This Structure
 

--- a/hosts/nixos/inference-vm/hosts/inference-fresh/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference-fresh/default.nix
@@ -6,6 +6,9 @@
 }:
 
 {
+  # Legacy path: inference VM outputs are moving to den leaves and aspects.
+  # Keep this file only while the fresh-host experiment still depends on the
+  # older tree layout.
   imports = [
     # Hardware configuration
     ./hardware-configuration.nix

--- a/hosts/nixos/inference-vm/hosts/inference-fresh/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference-fresh/default.nix
@@ -6,9 +6,10 @@
 }:
 
 {
-  # Legacy path: inference VM outputs are moving to den leaves and aspects.
-  # Keep this file only while the fresh-host experiment still depends on the
-  # older tree layout.
+  # Legacy path: the active `.#inference-fresh` output is built from
+  # `den/hosts` and den aspects. Keep this file only while the fresh-host
+  # experiment still depends on the older tree layout. Do not land active
+  # inference-fresh fixes here first.
   imports = [
     # Hardware configuration
     ./hardware-configuration.nix

--- a/hosts/nixos/inference-vm/hosts/inference1/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference1/default.nix
@@ -7,6 +7,10 @@
 }:
 
 {
+  # Legacy path: `.#inference1` is now composed from `den/hosts/inference1`
+  # plus `den/aspects/inference1-ollama.nix`. Keep this file only as migration
+  # context until the old inference host tree is deleted or folded fully into
+  # den. Do not land active inference1 fixes here first.
   imports = [
     ./hardware-configuration.nix
     ../..

--- a/hosts/nixos/inference-vm/hosts/inference2/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference2/default.nix
@@ -6,6 +6,9 @@
 }:
 
 {
+  # Legacy path: the active `.#inference2` output is built from `den/hosts`
+  # and den aspects. Keep this file only as migration context while the old
+  # inference host tree still exists.
   imports = [
     ./hardware-configuration.nix
 

--- a/hosts/nixos/inference-vm/hosts/inference2/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference2/default.nix
@@ -8,7 +8,8 @@
 {
   # Legacy path: the active `.#inference2` output is built from `den/hosts`
   # and den aspects. Keep this file only as migration context while the old
-  # inference host tree still exists.
+  # inference host tree still exists. Do not land active inference2 fixes here
+  # first.
   imports = [
     ./hardware-configuration.nix
 

--- a/hosts/nixos/inference-vm/hosts/inference3/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference3/default.nix
@@ -6,6 +6,9 @@
 }:
 
 {
+  # Legacy path: the active `.#inference3` output is built from `den/hosts`
+  # and den aspects. Keep this file only as migration context while the old
+  # inference host tree still exists.
   imports = [
     # Hardware configuration (you'll need to copy this from your VM)
     ./hardware-configuration.nix

--- a/hosts/nixos/inference-vm/hosts/inference3/default.nix
+++ b/hosts/nixos/inference-vm/hosts/inference3/default.nix
@@ -8,7 +8,8 @@
 {
   # Legacy path: the active `.#inference3` output is built from `den/hosts`
   # and den aspects. Keep this file only as migration context while the old
-  # inference host tree still exists.
+  # inference host tree still exists. Do not land active inference3 fixes here
+  # first.
   imports = [
     # Hardware configuration (you'll need to copy this from your VM)
     ./hardware-configuration.nix


### PR DESCRIPTION
## **User description**
## Summary
- mark legacy inference host files as non-authoritative for active den outputs
- update the inference virtiofs doc to point at the den host/aspect source of truth
- document the router den/legacy bridge and add a router migration work item

## Why
Recent inference1 fixes landed in a dead legacy path before we traced the active output back to den/aspects. This PR makes the boundary explicit so future work lands in the right files first.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural clarification defining authoritative configuration paths and migration boundaries for inference VM and router systems.
  * Updated references to identify legacy versus active configuration sources.
  * Documented transition context and work items to guide ongoing system organization efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Clarify which files are active for inference VMs and router hosts**

### What Changed
- Marked the den-based inference VM outputs as the active source of truth and labeled the old `hosts/nixos/inference-vm/hosts/*` files as legacy
- Updated the inference model storage guide to point to the current den host and aspect files instead of the old host-specific path
- Added clear notes in the router and router-backup leaves that they still use a mixed den/legacy setup while migration is completed in smaller steps
- Added router migration work items and a readme index so the follow-up cleanup tasks are easier to find and track

### Impact
`✅ Fewer fixes landing in the wrong inference VM files`
`✅ Clearer guidance for router host maintenance`
`✅ Easier migration tracking for den-based host cleanup`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR clarifies active and legacy host paths by marking legacy inference VM files as non-authoritative, updating documentation to reference den sources, and documenting router migration bridges to guide future development and prevent changes in outdated files.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds comments in inference VM host files under hosts/nixos/inference-vm/hosts/ marking them as legacy paths and directing active fixes to den/hosts and den/aspects.</li>

<li>Adds comments in den/hosts/router/ and den/hosts/router-backup/ files documenting transitional bridges that use den for outputs but still import legacy router-local modules.</li>

<li>Updates inference model storage guide to point to current den host and aspect files instead of old paths.</li>

</ul>
</details>

</div>