### PR TITLE
docs(tooling): document host metadata authority split

### DIFF
--- a/den/inventory/hosts.nix
+++ b/den/inventory/hosts.nix
@@ -1,3 +1,9 @@
+# den/inventory/hosts.nix
+# Authority: NixOS build composition — system architecture, hostPath, and the
+# aspectsList that assembles each host's NixOS configuration. Operational and
+# network metadata (IPs, SSH config, DNS, DHCP, ingress) belongs in
+# lib/hosts.nix. Host names must be kept in sync across both files; the
+# alignment checks in outputs/checks.nix enforce this.
 {
   authentik-host = {
     kind = "nixos";

--- a/docs/host-metadata-boundary.md
+++ b/docs/host-metadata-boundary.md
@@ -39,12 +39,16 @@ not carry any network or SSH metadata.
 
 outputs/checks.nix enforces consistency between the two files:
 
-- Every host in den/inventory/hosts.nix (except an explicit allowlist) must
-  also appear in lib/hosts.nix.
-- If a host is present in inventory but missing from lib/hosts.nix, the check
-  outputs a failing derivation with a descriptive error.
-- Legacy mode hosts are tracked separately and must be on an allowlist to
-  avoid blocking the build.
+- Every host in den/inventory/hosts.nix is expected to appear in lib/hosts.nix,
+  except explicitly excluded transitional cases and any separately allowlisted
+  legacy-mode entries. Two distinct exception mechanisms exist:
+  - **hardcoded exclusion list**: for permanently excluded host entries (e.g.,
+    bootstrap nodes that have no operational metadata)
+  - **legacy allowlist**: for legacy-mode hosts that are permitted to bypass
+    the check without blocking the build
+- If a host is present in inventory but missing from lib/hosts.nix (and not on
+  either exception list), the check outputs a failing derivation with a
+  descriptive error.
 
 These checks are the primary drift-detection mechanism. They do not prevent
 drift in the other direction (a host in lib/hosts.nix with no inventory
@@ -69,8 +73,10 @@ validated and must be updated manually.
 **Adding a new host:**
 1. Add the entry to den/inventory/hosts.nix with kind, system, hostPath, mode,
    and aspectsList.
-2. Add a corresponding entry to lib/hosts.nix with at minimum an ip and
-   description. Set includeDns/includeSsh as appropriate.
+2. Add a corresponding entry to lib/hosts.nix with at minimum an ip (or, for
+   bootstrap/external hosts that use DNS-only addressing, explicit non-IP
+   metadata such as ip = null with a dns/address field) and a description.
+   Set includeDns/includeSsh as appropriate.
 3. Create the host directory at the path referenced by hostPath.
 
 **Adding metadata to an existing host:**

--- a/docs/host-metadata-boundary.md
+++ b/docs/host-metadata-boundary.md
@@ -1,0 +1,83 @@
+# Host Metadata Boundary: lib/hosts.nix vs den/inventory
+
+This document describes the intentional authority split between the two host
+metadata files in this repo and gives guidance for keeping them in sync.
+
+## Authority Split
+
+### lib/hosts.nix
+
+Owns **operational and network-layer metadata**:
+
+- IPv4/IPv6 addresses and DHCP reservations (MAC address, scope)
+- SSH access configuration (sshHostname, sshUser, includeSsh)
+- DNS registration (includeDns, aliases)
+- Public ingress routing (publicIngressServices, ddnsServices)
+- Internal admin service ports (internalAdminServices)
+- Human-readable descriptions
+- Shared network CIDR definitions (networks.lan, networks.management)
+
+This file is consumed by DNS zone generation, SSH config templating, and
+Ansible inventory tooling. It does not control what NixOS configuration is
+built for a host.
+
+### den/inventory/hosts.nix
+
+Owns **NixOS build composition metadata**:
+
+- system architecture (x86_64-linux, aarch64-linux)
+- hostPath — path to the host's NixOS configuration directory
+- mode — composition strategy ("aspect" or "legacy")
+- aspectsList — ordered list of aspects assembled into the NixOS config
+- kind — output type ("nixos", "darwin", "home")
+
+This file is consumed by lib/flake/inventory-outputs.nix to produce
+nixosConfigurations (and homeConfigurations/darwinConfigurations). It does
+not carry any network or SSH metadata.
+
+## Alignment Checks
+
+outputs/checks.nix enforces consistency between the two files:
+
+- Every host in den/inventory/hosts.nix (except an explicit allowlist) must
+  also appear in lib/hosts.nix.
+- If a host is present in inventory but missing from lib/hosts.nix, the check
+  outputs a failing derivation with a descriptive error.
+- Legacy mode hosts are tracked separately and must be on an allowlist to
+  avoid blocking the build.
+
+These checks are the primary drift-detection mechanism. They do not prevent
+drift in the other direction (a host in lib/hosts.nix with no inventory
+entry), but such hosts are harmlessly ignored by the build system.
+
+## Drift-Prone Edge: Host Renaming
+
+The most common source of drift is renaming a host. Because the hostname is
+the key in both files, a rename requires updating:
+
+1. The attribute name in den/inventory/hosts.nix
+2. The `name` field inside that attribute
+3. The attribute name in lib/hosts.nix
+4. The hostPath directory name (hosts/<name>)
+
+The alignment check in outputs/checks.nix will catch a mismatch between
+steps 1 and 3 at evaluation time. Steps 2 and 4 are not automatically
+validated and must be updated manually.
+
+## Guidance for Future Agents
+
+**Adding a new host:**
+1. Add the entry to den/inventory/hosts.nix with kind, system, hostPath, mode,
+   and aspectsList.
+2. Add a corresponding entry to lib/hosts.nix with at minimum an ip and
+   description. Set includeDns/includeSsh as appropriate.
+3. Create the host directory at the path referenced by hostPath.
+
+**Adding metadata to an existing host:**
+- Network/SSH/DNS/ingress metadata -> lib/hosts.nix
+- NixOS composition changes (new aspect, architecture change) -> den/inventory/hosts.nix
+
+**Do not add** NixOS build fields (hostPath, aspectsList, system) to
+lib/hosts.nix, and do not add networking fields (ip, sshUser, aliases) to
+den/inventory/hosts.nix. Keeping the boundary clean avoids requiring consumers
+of each file to parse fields they do not understand.

--- a/docs/tooling-work-items/11-host-metadata-source-of-truth.md
+++ b/docs/tooling-work-items/11-host-metadata-source-of-truth.md
@@ -1,6 +1,6 @@
 # 11 Host Metadata Source Of Truth
 
-Status: `ready`
+Status: `done`
 
 Suggested branch: `refactor/tooling-host-metadata-boundary`
 
@@ -42,3 +42,12 @@ easy to get wrong.
 - docs/comments make the boundary clear
 - inventory-related checks still pass
 - one concrete drift-prone edge is improved or explicitly documented
+
+## Outcome
+
+- Added authority-scope comments to `lib/hosts.nix` and `den/inventory/hosts.nix`
+  explaining what each file owns and cross-referencing the other.
+- Created `docs/host-metadata-boundary.md` with the full boundary description,
+  drift-prone edge documentation, and guidance for future agents.
+- No Nix behaviour was changed; alignment checks in `outputs/checks.nix` remain
+  the enforcement mechanism.

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -1,4 +1,11 @@
 # lib/hosts.nix
+# Authority: operational/network-layer metadata — SSH access, DNS names, IP
+# addresses, DHCP reservations, public ingress routing, and DDNS labels.
+# This file does NOT own NixOS build composition (system type, hostPath,
+# aspects); that lives in den/inventory/hosts.nix. The two files are kept in
+# sync by the alignment checks in outputs/checks.nix. If you rename a host,
+# update both files.
+#
 # Single source of truth for all homelab hosts
 # Used by: DNS zone config, SSH config, Ansible inventory
 {


### PR DESCRIPTION
## **User description**
## Summary

- Added authority-scope comments to `lib/hosts.nix` and `den/inventory/hosts.nix` explaining what each file owns and cross-referencing the other
- Created `docs/host-metadata-boundary.md` documenting the full boundary, drift-prone edges (host renaming), and guidance for future agents
- Marked tooling work item 11 as done with outcome notes

## What Changed

`lib/hosts.nix` now declares at the top that it owns operational/network-layer metadata (SSH, DNS, IPs, DHCP, ingress) and explicitly points to `den/inventory/hosts.nix` for build composition.

`den/inventory/hosts.nix` now declares at the top that it owns NixOS build composition (system, hostPath, aspectsList) and cross-references `lib/hosts.nix`.

No Nix behaviour was changed. The alignment checks in `outputs/checks.nix` remain the enforcement mechanism.

## Test plan

- [ ] `nix flake check` passes (alignment checks still present and passing)
- [ ] Comments in both modified files correctly describe the authority boundary
- [ ] `docs/host-metadata-boundary.md` is readable and actionable

Work item: `docs/tooling-work-items/11-host-metadata-source-of-truth.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified authority boundaries between build composition and operational/network metadata to reduce confusion.
  * Added step-by-step guidance for adding or renaming hosts and maintaining consistency across related configurations.
  * Recorded the completion and outcomes of the metadata management work, including documented edge cases and validation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request adds documentation and comments to clarify the boundary between host metadata files in the NixOS configuration repository, establishing clear ownership of operational/network metadata versus NixOS build composition without changing any runtime behavior.</p>

<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added authority comments to lib/hosts.nix and den/inventory/hosts.nix clarifying ownership boundaries and cross-referencing each other</li>

<li>Created docs/host-metadata-boundary.md documenting the complete authority split, alignment mechanisms, and guidance for future development</li>

<li>Marked tooling work item 11 as completed with outcome notes</li>

</ul>
</details>

</div>


___

## **CodeAnt-AI Description**
**Clarify which file owns host metadata and build composition**

### What Changed
- Added ownership notes to `lib/hosts.nix` and `den/inventory/hosts.nix` so it is clear where to update network and SSH details versus NixOS build settings
- Added a guide that explains the split, the main drift risk when renaming hosts, and where to make future changes
- Marked the tooling work item as done; no host behavior changed

### Impact
`✅ Clearer host edits`
`✅ Fewer misplaced metadata changes`
`✅ Safer host renames`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
