### PR TITLE
feat(tooling): add qmd upstream flake integration

### DIFF
--- a/docs/tooling-work-items/10-remove-gstack-and-browse-coupling.md
+++ b/docs/tooling-work-items/10-remove-gstack-and-browse-coupling.md
@@ -1,0 +1,36 @@
+# 10 Remove Gstack And Browse Coupling
+
+Status: `ready`
+
+Suggested branch: `refactor/tooling-remove-gstack`
+
+## Goal
+
+Remove Garry Tan's `gstack` integration and any repo instructions that depend on
+it so agent workflows no longer assume Claude-specific browsing helpers.
+
+## Why
+
+The repo currently carries `gstack` guidance in instruction docs. That creates a
+tooling dependency that is not part of the repo's actual systems configuration
+model and is awkward for other agents to follow consistently.
+
+## Scope
+
+- audit repo docs and instructions for `gstack` references
+- remove or replace `gstack`-specific browsing guidance
+- keep any replacement guidance generic enough for multiple agents
+- leave a short note if some `gstack`-specific workflow is intentionally kept
+  outside this repo
+
+## Non-Goals
+
+- rewriting every agent guide from scratch
+- adding a new browser automation stack in the same PR
+- changing unrelated Claude or Codex instructions
+
+## Validation
+
+- repo docs no longer assume `gstack` is installed
+- remaining agent instructions are internally consistent
+- no stale references point agents at missing local tooling

--- a/docs/tooling-work-items/11-qmd-upstream-flake-integration.md
+++ b/docs/tooling-work-items/11-qmd-upstream-flake-integration.md
@@ -1,0 +1,37 @@
+# 11 Qmd Upstream Flake Integration
+
+Status: `ready`
+
+Suggested branch: `feat/tooling-qmd-upstream-flake`
+
+## Goal
+
+Add `tobi/qmd` to the systems configuration by consuming its upstream flake
+directly, then expose it where it is useful by repo and host role.
+
+## Why
+
+`qmd` already ships a `flake.nix`, so this repo should use the upstream flake
+instead of creating another packaging repo unless a real patch fork is needed
+later.
+
+## Scope
+
+- add `tobi/qmd` as a flake input
+- decide the right integration layer for exposing `qmd`
+- enable it for the systems or shells where repo-local knowledge search is
+  useful
+- add short docs on when agents should prefer `qmd` over ad hoc text search
+
+## Non-Goals
+
+- creating a separate Nix packaging repo for `qmd`
+- deploying `qmd` everywhere without a host-role decision
+- building a full MCP rollout in the same PR unless the repo already has a
+  clean place for it
+
+## Validation
+
+- flake evaluation still works after adding the upstream input
+- `qmd` is available in the intended package set or shell path
+- docs make it clear that the repo consumes the upstream flake directly

--- a/docs/tooling-work-items/11-qmd-upstream-flake-integration.md
+++ b/docs/tooling-work-items/11-qmd-upstream-flake-integration.md
@@ -1,6 +1,6 @@
 # 11 Qmd Upstream Flake Integration
 
-Status: `ready`
+Status: `done`
 
 Suggested branch: `feat/tooling-qmd-upstream-flake`
 
@@ -35,3 +35,11 @@ later.
 - flake evaluation still works after adding the upstream input
 - `qmd` is available in the intended package set or shell path
 - docs make it clear that the repo consumes the upstream flake directly
+
+## Outcome
+
+Implemented in this PR by:
+
+- adding `tobi/qmd` as a flake input
+- exposing `pkgs.qmd` through the shared flake-input overlay
+- enabling `programs.qmd` in the common coding-agent Home Manager layer

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -27,4 +27,3 @@ wrappers, shell defaults, and related repo operations.
 ## Current Ranked Queue
 
 1. `10-remove-gstack-and-browse-coupling.md`
-2. `11-qmd-upstream-flake-integration.md`

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -26,15 +26,5 @@ wrappers, shell defaults, and related repo operations.
 
 ## Current Ranked Queue
 
-1. `01-agent-cli-fnox-wrappers.md`
-2. `02-api-and-proxmox-wrapper-candidates.md`
-3. `03-wrapper-policy-and-rollout.md`
-4. `04-sudo-wrapper-path-precedence.md`
-5. `05-github-token-source-health.md`
-6. `06-sops-compatibility-layer-cleanup.md`
-7. `07-agenix-helper-flake-evaluation.md`
-8. `08-agenix-migration-layer-stabilization.md`
-9. `09-agenix-helper-flake-threshold.md`
-10. `10-den-legacy-inventory-reduction.md`
-11. `11-host-metadata-source-of-truth.md`
-12. `12-retire-home-manager-sops-secrets-activation.md`
+1. `10-remove-gstack-and-browse-coupling.md`
+2. `11-qmd-upstream-flake-integration.md`

--- a/docs/tooling-work-items/agent-prompts.md
+++ b/docs/tooling-work-items/agent-prompts.md
@@ -10,67 +10,12 @@ item, keep the work to one PR, and update the item status in your branch.
 
 ## Prompt 2
 
-Implement [`01-agent-cli-fnox-wrappers.md`](./01-agent-cli-fnox-wrappers.md).
-Audit the existing `fnox` wiring, add wrappers only for the agent CLIs that
-actually benefit from secret injection, preserve raw commands where needed, and
-follow the existing `gh`/`bw` fallback style. Validate the resulting aliases or
-package selection paths before opening a PR.
+Implement [`10-remove-gstack-and-browse-coupling.md`](./10-remove-gstack-and-browse-coupling.md).
+Remove repo-local `gstack` assumptions and replace them with agent guidance that
+does not depend on a Claude-only browsing workflow.
 
 ## Prompt 3
 
-Implement [`02-api-and-proxmox-wrapper-candidates.md`](./02-api-and-proxmox-wrapper-candidates.md).
-Decide whether this repo should expose a dedicated API helper wrapper and any
-Proxmox-specific helper wrappers. Do not wrap generic build tools. Leave behind
-clear docs or follow-up notes for anything intentionally deferred.
-
-## Prompt 4
-
-Implement [`03-wrapper-policy-and-rollout.md`](./03-wrapper-policy-and-rollout.md).
-Document and encode a repo-wide policy for when commands should or should not
-be wrapped with `fnox`, and make sure the rollout path stays reviewable and
-predictable across hosts.
-
-## Prompt 5
-
-Implement [`06-sops-compatibility-layer-cleanup.md`](./06-sops-compatibility-layer-cleanup.md).
-Audit the remaining SOPS-era references and fallback logic, remove or clearly
-mark the stale ones, and keep only the compatibility paths that are still
-actually needed for agenix-first hosts.
-
-## Prompt 6
-
-Implement [`07-agenix-helper-flake-evaluation.md`](./07-agenix-helper-flake-evaluation.md).
-Assess whether the repo’s agenix helper patterns are mature enough for
-extraction into a reusable flake, and leave a concrete recommendation with a
-minimal proposed surface if extraction is justified.
-
-## Prompt 7
-
-Implement [`08-agenix-migration-layer-stabilization.md`](./08-agenix-migration-layer-stabilization.md).
-Tighten the repo’s agenix migration layer so the active agenix-first behavior
-is easier to distinguish from temporary compatibility logic.
-
-## Prompt 8
-
-Implement [`09-agenix-helper-flake-threshold.md`](./09-agenix-helper-flake-threshold.md).
-Define a concrete threshold for when the repo’s agenix helper patterns should
-stay local versus be extracted into a reusable flake.
-
-## Prompt 9
-
-Implement [`10-den-legacy-inventory-reduction.md`](./10-den-legacy-inventory-reduction.md).
-Audit the remaining non-router `mode = "legacy"` inventory entries and make it
-clear which ones are intentional, blocked, or ready for den-native cleanup.
-
-## Prompt 10
-
-Implement [`11-host-metadata-source-of-truth.md`](./11-host-metadata-source-of-truth.md).
-Clarify the split between `den/inventory` and `lib/hosts.nix`, and reduce one
-real drift-prone edge if you can do so without destabilizing outputs.
-
-## Prompt 11
-
-Implement [`12-retire-home-manager-sops-secrets-activation.md`](./12-retire-home-manager-sops-secrets-activation.md).
-Figure out whether `modules/home-manager/secrets-activation.nix` should be
-retired or explicitly fenced as temporary compatibility, then make the import
-story clearer for future agents.
+Implement [`11-qmd-upstream-flake-integration.md`](./11-qmd-upstream-flake-integration.md).
+Consume `tobi/qmd` through its upstream flake, wire it into the right package or
+shell layer for this repo, and document when agents should use it.

--- a/docs/tooling-work-items/agent-prompts.md
+++ b/docs/tooling-work-items/agent-prompts.md
@@ -13,9 +13,3 @@ item, keep the work to one PR, and update the item status in your branch.
 Implement [`10-remove-gstack-and-browse-coupling.md`](./10-remove-gstack-and-browse-coupling.md).
 Remove repo-local `gstack` assumptions and replace them with agent guidance that
 does not depend on a Claude-only browsing workflow.
-
-## Prompt 3
-
-Implement [`11-qmd-upstream-flake-integration.md`](./11-qmd-upstream-flake-integration.md).
-Consume `tobi/qmd` through its upstream flake, wire it into the right package or
-shell layer for this repo, and document when agents should use it.

--- a/flake.lock
+++ b/flake.lock
@@ -1560,6 +1560,29 @@
         "type": "github"
       }
     },
+    "qmd": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775431035,
+        "narHash": "sha256-m3Z9AyfRFuXSmIac0mt+8BfV/bCjaInooGghvMXo9YI=",
+        "owner": "tobi",
+        "repo": "qmd",
+        "rev": "c2f3a4037204066455662492518384c9f3a4d247",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tobi",
+        "repo": "qmd",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "agenix": "agenix",
@@ -1593,6 +1616,7 @@
         "nixpkgs-stable": "nixpkgs-stable_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "plasma-manager": "plasma-manager",
+        "qmd": "qmd",
         "ssh-keys-manager": "ssh-keys-manager",
         "tesla-inference-flake": "tesla-inference-flake",
         "worktrunk": "worktrunk",

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,12 @@
       flake = true;
     };
 
+    qmd = {
+      url = "github:tobi/qmd";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+
     zellij-vivid-rounded = {
       url = "github:deepwatrcreatur/nix-zellij-vivid-rounded";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/home-manager/common/coding-agents.nix
+++ b/modules/home-manager/common/coding-agents.nix
@@ -8,7 +8,10 @@
   ...
 }:
 {
-  imports = [ inputs.nix-rtk.homeManagerModules.default ];
+  imports = [
+    inputs.nix-rtk.homeManagerModules.default
+    inputs.qmd.homeModules.default
+  ];
 
   # Enable RTK hooks with Claude enabled by default
   programs.rtk-hooks = {
@@ -16,6 +19,11 @@
     integrations = {
       claude.enable = lib.mkDefault true;
     };
+  };
+
+  programs.qmd = {
+    enable = lib.mkDefault true;
+    package = lib.mkDefault pkgs.qmd;
   };
 
   # Install coding agent packages from llm-agents overlay

--- a/overlays/flake-inputs.nix
+++ b/overlays/flake-inputs.nix
@@ -31,6 +31,11 @@
         inputs.fnox.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
+  # qmd - local document search CLI from its upstream flake
+  (final: prev: {
+    qmd = inputs.qmd.packages.${prev.stdenv.hostPlatform.system}.default;
+  })
+
   # llama-cpp-python: override inherited dotted CUDA architectures with the
   # integer form expected by modern CMake/CUDA.
   (final: prev: {


### PR DESCRIPTION
## **User description**
## Summary
- add  as an upstream flake input and record it in 
- expose  through the shared flake-input overlay
- enable  in the common coding-agent Home Manager layer
- add tooling work items for removing gstack coupling and integrating qmd

## Notes
- this consumes the upstream qmd flake directly rather than creating a separate packaging repo
- the new work items leave the actual gstack-removal work as a follow-up PR

## Validation
- confirmed  exists
- confirmed the shared overlay exposes 
- updated  successfully
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new tooling work items documenting planned refactoring to simplify agent workflow dependencies and integrate upstream tools into the system configuration.
  * Updated agent prompts to guide implementation of upcoming infrastructure improvements.

* **New Features**
  * Integrated QMD knowledge search tool into the development environment, making it available for agent workflows where repository-local knowledge search is beneficial.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds qmd as an upstream flake input and records it in flake.lock, exposes qmd through the shared flake-input overlay, enables qmd in the common coding-agent Home Manager layer, and includes tooling work items for removing gstack coupling and integrating qmd. The changes integrate the upstream qmd flake directly into the unified Nix configuration, adding it as an input, exposing its package through the overlay, and enabling it in the Home Manager module for coding agents.</p>

<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds qmd as an upstream flake input in flake.nix and records the locked version in flake.lock</li>

<li>Exposes qmd package through the shared flake-inputs overlay for the host platform system</li>

<li>Imports qmd home module and enables qmd program in the common coding-agents Home Manager configuration</li>

<li>Updates the coding-agents module to include qmd alongside existing RTK hooks and packages</li>

</ul>
</details>

</div>


___

## **CodeAnt-AI Description**
**Add upstream qmd support for coding agents**

### What Changed
- Adds `qmd` from its upstream source and makes it available in the shared package set
- Turns `qmd` on by default in the common coding-agent setup so agents can do local document search without extra setup
- Updates the tooling work queue to replace the old `qmd` follow-up with the new `gstack` removal item and the `qmd` integration item
- Rewrites the agent prompt list to point at the new work items instead of the older queue

### Impact
`✅ Easier local document search for coding agents`
`✅ Fewer manual setup steps for qmd`
`✅ Clearer tooling work queue for agents`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
