### PR TITLE
refactor(router): inline router-backup networking wrapper into den leaf

### DIFF
--- a/den/hosts/router-backup/default.nix
+++ b/den/hosts/router-backup/default.nix
@@ -1,20 +1,35 @@
 { lib, ... }:
 let
   den = import ../../lib.nix { inherit lib; };
+  base = den.mkInventoryHostModule {
+    name = "router-backup";
+    primaryUser = "deepwatrcreatur";
+    primaryUserImports = [
+      ../../../users/deepwatrcreatur/hosts/router-backup/default.nix
+    ];
+    extraImports = [
+      # hardware-configuration.nix — generated hardware config. Always keep separate.
+      ../../../hosts/nixos/router-backup/hardware-configuration.nix
+
+      # router/networking.nix — shared DNS/NAT config; imported directly now that
+      # the thin hosts/nixos/router-backup/networking.nix wrapper has been inlined
+      # here. The hostname override below replaces that wrapper.
+      ../../../hosts/nixos/router/networking.nix
+
+      # caddy.nix — Caddy config for router-backup. Keep separate (large, host-local).
+      ../../../hosts/nixos/router-backup/caddy.nix
+
+      # configuration.nix — main composition: imports role.nix with backup-specific
+      # args (wanDevice, lanDevice, managementIP, backup-specific Grafana/Prometheus
+      # paths, enableLogStorage=false). The authoritative router-backup wiring file.
+      ../../../hosts/nixos/router-backup/configuration.nix
+    ];
+  };
 in
-den.mkInventoryHostModule {
-  name = "router-backup";
-  primaryUser = "deepwatrcreatur";
-  primaryUserImports = [
-    ../../../users/deepwatrcreatur/hosts/router-backup/default.nix
-  ];
-  extraImports = [
-    # Transitional bridge: router-backup is exported through den, but still
-    # reuses legacy router-backup host files until the router migration is
-    # finished in smaller refactor PRs.
-    ../../../hosts/nixos/router-backup/hardware-configuration.nix
-    ../../../hosts/nixos/router-backup/networking.nix
-    ../../../hosts/nixos/router-backup/caddy.nix
-    ../../../hosts/nixos/router-backup/configuration.nix
-  ];
+# Merge base imports with the hostname override that was previously in the
+# now-deleted hosts/nixos/router-backup/networking.nix wrapper.
+{
+  inherit (base) imports;
+  # router/networking.nix sets hostName = "router"; override for this host.
+  networking.hostName = lib.mkForce "router-backup";
 }

--- a/den/hosts/router/default.nix
+++ b/den/hosts/router/default.nix
@@ -9,14 +9,26 @@ den.mkInventoryHostModule {
     ../../../users/deepwatrcreatur/hosts/router
   ];
   extraImports = [
-    # Transitional bridge: router outputs are exported through den, but the
-    # host still depends on legacy router-local modules for hardware,
-    # networking, Caddy, and role configuration. Keep this explicit until the
-    # router tree is migrated into den/aspects in reviewable pieces.
+    # hardware-configuration.nix — generated hardware config. Always keep as a
+    # separate import; never inline hardware-generated modules.
     ../../../hosts/nixos/router/hardware-configuration.nix
+
+    # networking.nix — small host-local module: hostname, DNS service (Technitium),
+    # NAT=false. Kept separate because it still uses topology config; candidate
+    # for inlining once router/configuration.nix is fully migrated.
     ../../../hosts/nixos/router/networking.nix
+
+    # caddy.nix — full Caddy configuration with virtualHosts, DDNS, ACME.
+    # Large and host-specific; should remain a separate file.
     ../../../hosts/nixos/router/caddy.nix
+
+    # disko.nix — declarative disk layout. Keep separate (hardware-adjacent).
     ../../../hosts/nixos/router/disko.nix
+
+    # configuration.nix — main composition: imports role.nix with host-specific
+    # args (wanDevice, lanDevice, IPs, domains), adds stable NIC link rules,
+    # and configures DNS zones. This is the active router role wiring file.
+    # Future work: split into a den aspect once the role.nix API stabilises.
     ../../../hosts/nixos/router/configuration.nix
   ];
 }

--- a/docs/router-work-items/21-router-leaf-inline-migration.md
+++ b/docs/router-work-items/21-router-leaf-inline-migration.md
@@ -1,6 +1,6 @@
 # Router Leaf Inline Migration
 
-Status: `ready`
+Status: `done`
 Priority: `medium`
 Branch: `refactor/router-leaf-inline-migration`
 
@@ -51,3 +51,17 @@ The desired outcome is:
 - confirm resulting router output is equivalent at a high level
 - ensure comments explain any remaining legacy imports that are still
   intentional
+
+## Outcome
+
+- Added per-import comments to `den/hosts/router/default.nix` explaining
+  why each legacy file is kept separate (hardware-adjacent, large host-local,
+  or still uses topology config).
+- Inlined `hosts/nixos/router-backup/networking.nix` into
+  `den/hosts/router-backup/default.nix`. That file was a 7-line thin wrapper
+  that set `networking.hostName = "router-backup"` and imported
+  `router/networking.nix`. The hostname override is now inline; the wrapper
+  is deleted.
+- Validated: `nix eval .#nixosConfigurations.router.config.networking.hostName`
+  → `"router"` and `.#nixosConfigurations.router-backup.config.networking.hostName`
+  → `"router-backup"`.

--- a/hosts/nixos/router-backup/networking.nix
+++ b/hosts/nixos/router-backup/networking.nix
@@ -1,7 +1,0 @@
-{ lib, ... }:
-{
-  imports = [ ../router/networking.nix ];
-
-  # Only differ in hostname; DNS and NAT settings are shared with primary router.
-  networking.hostName = lib.mkForce "router-backup";
-}


### PR DESCRIPTION
## **User description**
## Summary

- Deleted `hosts/nixos/router-backup/networking.nix` (7-line thin wrapper that only imported `router/networking.nix` and set `networking.hostName`)
- Inlined the hostname override (`lib.mkForce "router-backup"`) directly into `den/hosts/router-backup/default.nix`; now imports `router/networking.nix` directly
- Added per-import comments to `den/hosts/router/default.nix` explaining why each remaining legacy file stays separate (hardware-adjacent, large host-local, uses topology config)

Closes work item `docs/router-work-items/21-router-leaf-inline-migration.md`.

## Test plan

- [x] `nix eval .#nixosConfigurations.router.config.networking.hostName` → `"router"`
- [x] `nix eval .#nixosConfigurations.router-backup.config.networking.hostName` → `"router-backup"`
- [ ] Full build validation via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
Keep router and router-backup network setup consistent while removing a duplicate wrapper

### What Changed
- router-backup now uses the shared router networking setup directly, with its hostname set inline to `router-backup`
- The old router-backup networking wrapper file was removed
- Router configuration notes now explain why the remaining host-specific files stay separate

### Impact
`✅ Same router-backup hostname setup`
`✅ Fewer duplicate host files`
`✅ Clearer router migration path`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated router-backup networking configuration into the main module definition for improved maintainability.
  * Updated router configuration documentation with granular per-module comments for clarity.

* **Documentation**
  * Marked router configuration migration task as complete with validation details and outcome summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR refactors router networking configuration by eliminating a duplicate wrapper file and inlining the hostname override directly into the den host module. The changes remove the 7-line hosts/nixos/router-backup/networking.nix wrapper that only imported shared router networking and set the hostname, instead moving the hostname override into den/hosts/router-backup/default.nix. Enhanced documentation comments were also added to den/hosts/router/default.nix to explain the purpose of each remaining legacy import, supporting the ongoing router migration effort.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>removes duplicate networking wrapper file in hosts/nixos/router-backup/networking.nix</li>

<li>inlines hostname override directly into den/hosts/router-backup/default.nix using lib.mkForce</li>

<li>adds detailed per-import comments to den/hosts/router/default.nix explaining migration rationale</li>

</ul>
</details>

</div>