### PR TITLE
docs(tooling): audit den inventory legacy entries and add explanatory comments

### DIFF
--- a/den/inventory/bootstrap.nix
+++ b/den/inventory/bootstrap.nix
@@ -1,13 +1,30 @@
+# Bootstrap template configurations for new LXC containers.
+#
+# These entries use kind = "special" which mkInventoryOutputs does NOT process.
+# The actual NixOS outputs are defined manually in outputs/nixos-lxc.nix because
+# the bootstrap sequence has unusual requirements (one deliberately omits
+# Determinate Nix for the initial container bring-up, then switches post-boot).
+#
+# mode = "legacy" here reflects that the outputs/nixos-lxc.nix path bypasses
+# the den pipeline by design, not due to a migration gap. There is no clear
+# den-native equivalent for kind = "special" entries at this time.
+#
+# Do not attempt to migrate these to aspect mode without first designing a
+# den framework path for bootstrap templates that skip Determinate Nix.
 {
   nixos_lxc_without_determinate = {
     kind = "special";
     name = "nixos_lxc_without_determinate";
+    # Intentionally legacy: actual output is in outputs/nixos-lxc.nix.
+    # Bootstrap step 1 - no Determinate Nix, used for initial container creation.
     mode = "legacy";
   };
 
   nixos_lxc_with_determinate = {
     kind = "special";
     name = "nixos_lxc_with_determinate";
+    # Intentionally legacy: actual output is in outputs/nixos-lxc.nix.
+    # Bootstrap step 2 - with Determinate Nix, used after initial boot succeeds.
     mode = "legacy";
   };
 }

--- a/den/inventory/darwin.nix
+++ b/den/inventory/darwin.nix
@@ -1,3 +1,20 @@
+# Darwin (macOS) host inventory.
+#
+# These entries are consumed by mkInventoryOutputs -> mkDarwinOutput, so they
+# do participate in the den output pipeline. However, they remain mode = "legacy"
+# because the den aspects system (den/aspects/) covers NixOS only. There are no
+# darwin-specific aspects for dock, finder, security, or macOS package management.
+#
+# Migration path: define darwin-specific aspects (e.g. darwin-base, darwin-dock)
+# and move macminim4's host modules into aspect files. This is blocked on the
+# darwin aspect infrastructure being designed first.
+#
+# hackintosh: NOT present in lib/hosts.nix. This is an archived/inactive system.
+# It has a hosts/hackintosh/ directory but is no longer deployed. Kept here so
+# its darwinConfiguration output continues to evaluate; delete if the host is
+# fully retired.
+#
+# macminim4: Active macOS machine. Intentionally legacy until darwin aspects exist.
 {
   hackintosh = {
     kind = "darwin";
@@ -5,6 +22,8 @@
     system = "x86_64-darwin";
     hostPath = ../../hosts/hackintosh;
     username = "deepwatrcreatur";
+    # Intentionally legacy: no darwin aspects exist yet. Also likely inactive —
+    # hackintosh is not in lib/hosts.nix and has no recent maintenance.
     mode = "legacy";
   };
 
@@ -14,6 +33,8 @@
     system = "aarch64-darwin";
     hostPath = ../../hosts/macminim4;
     username = "deepwatrcreatur";
+    # Intentionally legacy: no darwin aspects exist yet. Active machine;
+    # migrate to aspect mode once darwin-base and related aspects are defined.
     mode = "legacy";
   };
 }

--- a/den/inventory/homes.nix
+++ b/den/inventory/homes.nix
@@ -1,3 +1,18 @@
+# Home Manager configurations for the root user on each Proxmox node.
+#
+# These entries are consumed by mkInventoryOutputs -> mkHomeOutput, so they
+# do participate in the den output pipeline. They remain mode = "legacy" because
+# the den framework has no "home aspect" concept analogous to the NixOS
+# aspectsList. Home Manager configs are user-scoped rather than system-scoped
+# and do not map cleanly onto the current aspect model.
+#
+# Migration path: there is no current plan. The proxmox-root profile is small
+# and stable; defining a home-manager aspect layer for it would add complexity
+# without a clear benefit.
+#
+# The outputs/checks.nix consistency check verifies that every pve-* host in
+# lib/hosts.nix has a matching "-root" home entry here, so additions to
+# lib/hosts.nix are automatically reflected.
 let
   libHosts = (import ../../lib/hosts.nix).hosts;
   proxmoxHostNames =
@@ -27,6 +42,10 @@ let
     userPath = ../../users/root;
     modules = [ ../../profiles/home-manager/proxmox-root.nix ];
     isDesktop = false;
+    # Intentionally legacy: no home-manager aspect concept exists in den.
+    # These configs are user-scoped (root on Proxmox) and do not fit the
+    # NixOS aspectsList model. Keep legacy until a home-manager aspect
+    # layer is explicitly designed.
     mode = "legacy";
   };
 in

--- a/docs/tooling-work-items/10-den-legacy-inventory-reduction.md
+++ b/docs/tooling-work-items/10-den-legacy-inventory-reduction.md
@@ -1,6 +1,6 @@
 # 10 Den Legacy Inventory Reduction
 
-Status: `in-progress`
+Status: `done`
 
 Suggested branch: `refactor/tooling-den-legacy-inventory`
 
@@ -43,3 +43,25 @@ intentionally legacy or simply not migrated yet.
 - den docs and inventory make the remaining legacy boundaries easier to follow
 - any changed outputs still evaluate cleanly
 - future agents can tell which legacy inventory entries are intentional
+
+## Outcome
+
+Audited all three non-router legacy inventory files. All are **intentionally
+legacy** for different structural reasons:
+
+- `bootstrap.nix` (`nixos_lxc_without_determinate`, `nixos_lxc_with_determinate`):
+  `kind = "special"` — these are NOT processed by `mkInventoryOutputs`. Their
+  actual NixOS outputs live in `outputs/nixos-lxc.nix`. Legacy by design because
+  the bootstrap sequence deliberately omits Determinate Nix in step 1.
+
+- `darwin.nix` (`hackintosh`, `macminim4`): consumed by `mkDarwinOutput` but
+  legacy because no darwin aspects exist in `den/aspects/`. `hackintosh` is also
+  absent from `lib/hosts.nix` (likely inactive). `macminim4` is active; can be
+  migrated once darwin-specific aspects are defined.
+
+- `homes.nix` (proxmox-root homes): consumed by `mkHomeOutput` but legacy
+  because the den framework has no home-manager aspect concept. The proxmox-root
+  profile is stable and small; no migration planned.
+
+Added explanatory comments to each file making the intentional/blocked status
+explicit so future agents stop debating whether to migrate them.


### PR DESCRIPTION
## **User description**
## Summary

Re-opens the work from closed PR #79 (auto-closed when its base branch was merged).

- Audits `den/inventory/bootstrap.nix`, `darwin.nix`, and `homes.nix`
- Adds explanatory comments to each file documenting *why* each entry remains `mode = "legacy"`:
  - `bootstrap.nix`: `kind = "special"` bypasses `mkInventoryOutputs`; actual outputs are in `outputs/nixos-lxc.nix`
  - `darwin.nix`: no darwin aspects exist yet; hackintosh is also likely inactive
  - `homes.nix`: no home-manager aspect concept in den
- Marks tooling work item 10 as done

## Test plan

- [ ] CI passes (inventory consistency + module eval checks)
- [ ] `den/inventory/*.nix` files still evaluate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Document why legacy inventory entries stay as-is**

### What Changed
- Added clear notes to the bootstrap, Darwin, and Home Manager inventory files explaining why each entry remains legacy
- Clarified which entries are intentionally kept outside the normal migration path and which ones are blocked until matching support exists
- Marked the tooling work item as complete

### Impact
`✅ Clearer inventory maintenance`
`✅ Fewer false migration attempts`
`✅ Easier handoff for future cleanup work`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR re-opens work from a previously closed PR to audit den inventory legacy entries and add explanatory comments documenting why each entry remains in legacy mode rather than being migrated to aspect mode. The changes focus on three inventory files and provide detailed reasoning for the current architectural decisions.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds comprehensive header comments to den/inventory/bootstrap.nix explaining why kind="special" entries bypass mkInventoryOutputs and remain in legacy mode due to bootstrap sequence requirements</li>

<li>Documents in den/inventory/darwin.nix that entries remain legacy due to lack of darwin-specific aspects, with notes about active vs inactive systems</li>

<li>Explains in den/inventory/homes.nix why Home Manager configurations remain legacy due to absence of home-manager aspect concepts in the den framework</li>

</ul>
</details>

</div>