### PR TITLE
refactor(tooling): remove gstack browsing coupling from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,13 +178,13 @@ If you're fixing a package installation error:
 **Problem**: git commit opens password dialog that is difficult to handle in TUI
 **Solution**: use --no-gpg-sign option
 
-## gstack
+## Web Browsing and External Resources
 
-Use /browse from gstack for all web browsing. Never use mcp__claude-in-chrome__* tools.
-
-Available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade.
-
-If gstack skills aren't working, run `cd ~/.claude/skills/gstack && ./setup` to build the binary and register skills.
+For web browsing and external resource lookups, use whatever browser or fetch
+tooling is available in the current agent environment. Do not assume any
+specific browser automation stack is installed. Prefer reading documentation
+from local files or fetching URLs directly over any agent-specific GUI browsing
+workflow.
 
 ## Agent Instructions
 

--- a/docs/tooling-work-items/10-remove-gstack-and-browse-coupling.md
+++ b/docs/tooling-work-items/10-remove-gstack-and-browse-coupling.md
@@ -1,6 +1,6 @@
 # 10 Remove Gstack And Browse Coupling
 
-Status: `ready`
+Status: `done`
 
 Suggested branch: `refactor/tooling-remove-gstack`
 
@@ -34,3 +34,14 @@ model and is awkward for other agents to follow consistently.
 - repo docs no longer assume `gstack` is installed
 - remaining agent instructions are internally consistent
 - no stale references point agents at missing local tooling
+
+## Implementation
+
+- Audited all repo docs, agent guides, and CLAUDE.md for `gstack` and `/browse`
+  references. Only CLAUDE.md carried a live gstack-specific instruction block.
+- Replaced the `## gstack` section in CLAUDE.md with a generic `## Web Browsing
+  and External Resources` section that does not assume any specific browser
+  automation stack is installed.
+- The `.claude/skills/gstack/` tooling installation is intentionally left
+  outside this PR's scope — it lives in a gitignored local config path and is
+  not part of the repo's systems configuration model.


### PR DESCRIPTION
## **User description**
## Summary

- Audited all repo docs, agent guides, and CLAUDE.md for `gstack`/`/browse` references
- Only `CLAUDE.md` had an active gstack-specific instruction block
- Replaced `## gstack` section with a generic `## Web Browsing and External Resources` section that works for any agent environment
- Marks tooling work item 10 as done

## What changed

**CLAUDE.md** — removed:
```
## gstack
Use /browse from gstack for all web browsing. Never use mcp__claude-in-chrome__* tools.
Available skills: /office-hours, /plan-ceo-review, ...
If gstack skills aren't working, run `cd ~/.claude/skills/gstack && ./setup` ...
```

**CLAUDE.md** — replaced with:
```
## Web Browsing and External Resources
For web browsing and external resource lookups, use whatever browser or fetch
tooling is available in the current agent environment. ...
```

The `.claude/skills/gstack/` installation is intentionally out of scope — it is a local config path, not part of the repo's systems configuration.

## Test plan

- [ ] CI passes
- [ ] No remaining `gstack` or `/browse` references in repo docs or agent guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Remove gstack-specific browsing instructions from repo guidance**

### What Changed
- Replaced the CLAUDE.md section that required gstack browsing tools with guidance that works in any agent environment
- Browsing instructions now tell agents to use whatever browser or fetch tool is available, instead of assuming a specific setup
- Marked the tooling work item as done and recorded the completed guidance update

### Impact
`✅ Fewer failed browsing instructions for non-gstack agents`
`✅ Clearer repo guidance for web lookups`
`✅ Less dependence on local agent-specific tooling`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
