### PR TITLE
refactor(router-backup): inline caddy passthrough wrapper into den leaf

### DIFF
--- a/den/hosts/router-backup/default.nix
+++ b/den/hosts/router-backup/default.nix
@@ -16,8 +16,10 @@ let
       # here. The hostname override below replaces that wrapper.
       ../../../hosts/nixos/router/networking.nix
 
-      # caddy.nix — Caddy config for router-backup. Keep separate (large, host-local).
-      ../../../hosts/nixos/router-backup/caddy.nix
+      # router/caddy.nix — full Caddy config (194 lines); shared with router directly
+      # now that the single-line hosts/nixos/router-backup/caddy.nix wrapper has been
+      # inlined here. Large and host-local; keep as a separate file.
+      ../../../hosts/nixos/router/caddy.nix
 
       # configuration.nix — main composition: imports role.nix with backup-specific
       # args (wanDevice, lanDevice, managementIP, backup-specific Grafana/Prometheus

--- a/docs/router-work-items/22-router-backup-den-parity.md
+++ b/docs/router-work-items/22-router-backup-den-parity.md
@@ -1,6 +1,6 @@
 # Router-Backup Den Parity
 
-Status: `ready`
+Status: `done`
 Priority: `medium`
 Branch: `refactor/router-backup-den-parity`
 
@@ -38,3 +38,22 @@ It should not drift into a different organizational model than `router`.
 - `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel`
 - compare active import structure against `router`
 - confirm the remaining differences are host-specific and not accidental drift
+
+## Outcome
+
+Building on item 21 (which inlined `networking.nix` and added per-import comments),
+this PR removes the remaining single-line passthrough wrapper:
+
+- Deleted `hosts/nixos/router-backup/caddy.nix` (`import ../router/caddy.nix`)
+- Updated `den/hosts/router-backup/default.nix` to import `router/caddy.nix` directly
+- Fixed the comment (was "large, host-local"; clarified it's the shared Caddy config)
+
+Remaining `extraImports` that differ from `router` are all intentionally backup-specific:
+- `hardware-configuration.nix` — different physical hardware
+- `router/networking.nix` — shared config with hostname override inline in den leaf
+- `router/caddy.nix` — same shared Caddy config, now imported directly
+- `configuration.nix` — backup-specific args: different WAN/LAN devices, separate
+  Grafana/Prometheus paths, `enableLogStorage=false`
+
+Validated: `nix eval .#nixosConfigurations.router-backup.config.networking.hostName`
+→ `"router-backup"` and `.config.services.caddy.enable` → `true`.

--- a/hosts/nixos/router-backup/caddy.nix
+++ b/hosts/nixos/router-backup/caddy.nix
@@ -1,1 +1,0 @@
-import ../router/caddy.nix


### PR DESCRIPTION
## **User description**
## Summary

Follows #83. Removes the last thin passthrough wrapper from `router-backup`:

- Deleted `hosts/nixos/router-backup/caddy.nix` (single-line file: `import ../router/caddy.nix`)
- Updated `den/hosts/router-backup/default.nix` to import `hosts/nixos/router/caddy.nix` directly
- Fixed misleading comment (was "large, host-local"; clarified it is the shared Caddy config)

After this PR, all remaining `extraImports` differences between `router` and `router-backup` are intentionally backup-specific:
- different `hardware-configuration.nix` (different hardware)
- `networking.nix` shared, hostname override inlined in den leaf
- `caddy.nix` now shared directly (no wrapper)
- `configuration.nix` backup-specific: different WAN/LAN devices, separate Grafana/Prometheus paths, `enableLogStorage=false`

Closes work item `docs/router-work-items/22-router-backup-den-parity.md`.

## Test plan

- [x] `nix eval .#nixosConfigurations.router-backup.config.networking.hostName` → `"router-backup"`
- [x] `nix eval .#nixosConfigurations.router-backup.config.services.caddy.enable` → `true`
- [ ] Full build via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
Router-backup now uses the shared Caddy setup directly, with no change to its enabled services.

### What Changed
- router-backup now imports the shared Caddy configuration directly instead of going through a separate wrapper file
- The extra wrapper file for router-backup Caddy config was removed
- Comments were updated to reflect that this is shared Caddy config, not a separate host-only copy

### Impact
`✅ Fewer router-backup config files to maintain`
`✅ Lower drift between router and router-backup`
`✅ Same Caddy behavior on router-backup`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR continues the effort to eliminate thin passthrough wrappers from router-backup configuration, following PR #83. It removes the last remaining wrapper for Caddy configuration by deleting the single-line hosts/nixos/router-backup/caddy.nix file and inlining its import directly into the den leaf configuration. This achieves better parity between router and router-backup setups while maintaining identical Caddy functionality.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes hosts/nixos/router-backup/caddy.nix wrapper file that contained only a single import statement</li>

<li>Updates den/hosts/router-backup/default.nix to directly import the shared Caddy configuration from hosts/nixos/router/caddy.nix</li>

<li>Clarifies the comment to indicate the imported file contains the full 194-line shared Caddy config and notes the wrapper inlining</li>

</ul>
</details>

</div>