### PR TITLE
router docs: VyOS study and PBR design

### DIFF
--- a/docs/router-firewall-roles.md
+++ b/docs/router-firewall-roles.md
@@ -50,8 +50,8 @@ services.router-firewall = {
   trustedTcpPorts = [ 80 443 ];
   hairpinNat.enable = true;
   trustedUdpPorts = [ ];
-  extraInputRules = ''
-    iifname {"${lanDevice}"} tcp dport 5201 accept comment "iperf3 from LAN"
+  extraLanLocalRules = ''
+    tcp dport 5201 accept comment "iperf3 from LAN"
   '';
 };
 ```
@@ -61,7 +61,7 @@ explicitly:
 
 - allowing HTTP/HTTPS from trusted interfaces
 - enabling IPv4 hairpin NAT for routed LAN/management CIDRs
-- exposing iperf3 on LAN for testing
+- exposing iperf3 on LAN for testing using the role-specific `extraLanLocalRules`
 
 ## How To Extend Safely
 
@@ -70,6 +70,10 @@ When adding new firewall behavior:
 - prefer adjusting role-aware options (`wanTcpPorts`, `wanUdpPorts`,
   `trustedTcpPorts`, `trustedUdpPorts`, `dnsInterfaces`) over hand-written
   nftables in `extra*Rules`
+- use role-specific extension points for custom nftables:
+  - `extraWanLocalRules` / `extraWanInRules`
+  - `extraLanLocalRules` / `extraLanInRules`
+  - `extraMgmtLocalRules` / `extraMgmtInRules`
 - keep WAN exposure explicit and minimal; use LAN/management for admin access
 - update this doc and the router work-items queue if you introduce new
   role-specific behavior

--- a/docs/router-work-items/16-role-based-firewall-boundaries.md
+++ b/docs/router-work-items/16-role-based-firewall-boundaries.md
@@ -16,10 +16,10 @@ Clear role-to-policy mapping makes it easier to reason about router behavior, re
 
 ## Tasks
 
-- Inventory current firewall rules and how they relate to WAN/LAN/management roles.
-- Propose a role-oriented grouping (e.g., LAN_IN, WAN_LOCAL, MGMT_IN) that matches existing behavior.
-- Update router modules/config to make the role-to-rule-set mapping explicit without large behavior changes.
-- Document the new mapping for operators, including how to extend it safely.
+- [x] Inventory current firewall rules and how they relate to WAN/LAN/management roles.
+- [x] Propose a role-oriented grouping (e.g., LAN_IN, WAN_LOCAL, MGMT_IN) that matches existing behavior.
+- [x] Update router modules/config to make the role-to-rule-set mapping explicit without large behavior changes.
+- [x] Document the new mapping for operators, including how to extend it safely.
 
 ## Validation
 
@@ -29,10 +29,8 @@ Clear role-to-policy mapping makes it easier to reason about router behavior, re
 
 ## Outcome Notes
 
-- `services.router-optimizations.interfaces` already models WAN / LAN /
-  management roles and devices for the router.
-- `services.router-firewall` automatically derives interface lists from those
-  roles when explicit lists are not set, so the firewall is already
-  role-aware.
-- `docs/router-firewall-roles.md` explains how these pieces fit together and
-  how to extend the router firewall safely.
+- `nix-router-optimized` has been refactored to use role-based chains (`WAN_LOCAL`, `LAN_LOCAL`, `MGMT_LOCAL`, `WAN_IN`, `LAN_IN`, `MGMT_IN`) internally.
+- New role-specific extension options (`extraWanLocalRules`, `extraLanLocalRules`, etc.) have been added to the `router-firewall` module.
+- `hosts/nixos/router/role.nix` now uses `extraLanLocalRules` for iperf3, making the role-to-rule mapping explicit.
+- `docs/router-firewall-roles.md` provides comprehensive documentation on the new role-based firewall structure.
+

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -255,8 +255,8 @@ in
     trustedTcpPorts = [ 80 443 ];
     hairpinNat.enable = true;
     trustedUdpPorts = [ ];
-    extraInputRules = ''
-      iifname {"${lanDevice}"} tcp dport 5201 accept comment "iperf3 from LAN"
+    extraLanLocalRules = ''
+      tcp dport 5201 accept comment "iperf3 from LAN"
     '';
     flowLogging.enable = true;
   };


### PR DESCRIPTION
## **User description**
- Record VyOS router pattern study outcomes in the work-item doc.
- Add docs/policy-routing-pbr.md describing tables, RoutingPolicyRule usage, and guardrails.
- Mark related router work-items as done and point them at the new PBR design doc.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Make router firewall rules role-specific and document the new setup**

### What Changed
- Router firewall rules are now split by network role, so LAN, WAN, and management access are handled through separate rule paths.
- The LAN iperf3 exception now uses the LAN-specific rule hook, making its scope match the intended network role.
- The router firewall guide now explains the new role-based rule points and how to extend them safely.

### Impact
`✅ Clearer router access boundaries`
`✅ Safer LAN-only exceptions`
`✅ Easier firewall setup changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This pull request records the outcomes of the VyOS router pattern study in the work-item documentation, adds comprehensive documentation for Policy-Based Routing (PBR) design using systemd-networkd, marks related router work-items as completed, and updates the router firewall configuration to use appropriate rule categories for LAN traffic.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Records VyOS router pattern study outcomes in the work-item documentation.</li>

<li>Adds new documentation docs/policy-routing-pbr.md describing routing tables, RoutingPolicyRule usage, recommended patterns, and guardrails for Policy-Based Routing.</li>

<li>Marks related router work-items (08-vlans-and-vpn-policy-routing.md and 17-policy-routing-vpn-and-multiwan.md) as completed and references the new PBR design document.</li>

<li>Updates router firewall configuration in hosts/nixos/router/role.nix to use extraLanLocalRules for LAN-specific traffic, simplifying rules by removing interface conditions.</li>

</ul>
</details>

</div>