### PR TITLE
fix: remove committed conflict markers from tool-aliases.nix

### DIFF
--- a/modules/home-manager/common/tool-aliases.nix
+++ b/modules/home-manager/common/tool-aliases.nix
@@ -40,7 +40,6 @@ let
 
   # Prefer explicit wrappers via aliases (raw remains available)
   wrappedToolAliases =
-<<<<<<< HEAD
     (lib.optionalAttrs (pkgs ? gh-fnox) { gh = "gh-fnox"; })
     // (lib.optionalAttrs (pkgs ? bw-fnox) { bw = "bw-fnox"; })
     // (lib.optionalAttrs (pkgs ? factory-droid-fnox) { droid = "factory-droid-fnox"; })
@@ -57,23 +56,6 @@ let
     // (lib.optionalAttrs (config.programs.fnox.enable or false) {
       opencode = "opencode-zai";
     });
-=======
-    let
-      ghAlias = if pkgs ? gh-fnox then { gh = "gh-fnox"; } else { };
-      bwAlias = if pkgs ? bw-fnox then { bw = "bw-fnox"; } else { };
-      atticAlias =
-        if (pkgs ? attic-fnox) && !(config.programs.attic-client.enable or false)
-        then { attic = "attic-fnox"; }
-        else { };
-      # When fnox is enabled, prefer the opencode-zai wrapper; keep opencode-raw
-      # as an escape hatch to the unwrapped binary.
-      opencodeFnoxAlias =
-        if config.programs.fnox.enable or false
-        then { opencode = "opencode-zai"; }
-        else { };
-    in
-    ghAlias // bwAlias // atticAlias // opencodeFnoxAlias;
->>>>>>> feat/tooling-agent-cli-fnox-wrappers
 in
 {
   options.custom.toolAliases = {


### PR DESCRIPTION
## **User description**
## Summary

A `git merge` conflict was accidentally committed (and pushed) into `main` in `modules/home-manager/common/tool-aliases.nix`. The conflict markers `<<<<<<< HEAD` / `=======` / `>>>>>>> feat/tooling-agent-cli-fnox-wrappers` were left in the file, breaking any Nix evaluation that imports Home Manager for any host.

## Resolution

Takes the HEAD side of the conflict (from commit `07547e27`), which is the more complete version — includes `gh`, `bw`, `droid` (factory-droid-fnox), `pbs` (proxmox-backup-client-fnox), `attic`, and `opencode` (via fnox) wrappers.

The `feat/tooling-agent-cli-fnox-wrappers` side used a `let…in` style and was missing the `droid` and `pbs` wrappers, so the HEAD side is strictly a superset.

## Test plan

- [ ] CI passes (module-loading-eval will catch any remaining syntax errors)
- [ ] No conflict markers remain in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Remove stray merge conflict text so Home Manager config loads again**

### What Changed
- Removed accidental conflict markers from the tool aliases file, which was breaking Nix evaluation
- Kept the fuller alias set, including `gh`, `bw`, `droid`, `pbs`, `attic`, and `opencode` wrappers

### Impact
`✅ Home Manager configs load successfully again`
`✅ Fewer setup failures on affected hosts`
`✅ Restored access to all expected tool aliases`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
