### PR TITLE
fix: disable qmd by default, opt-in on capable hosts

### DIFF
--- a/modules/home-manager/common/coding-agents.nix
+++ b/modules/home-manager/common/coding-agents.nix
@@ -22,7 +22,7 @@
   };
 
   programs.qmd = {
-    enable = lib.mkDefault true;
+    enable = lib.mkDefault false;
     package = lib.mkDefault pkgs.qmd;
   };
 

--- a/users/deepwatrcreatur/hosts/macminim4/default.nix
+++ b/users/deepwatrcreatur/hosts/macminim4/default.nix
@@ -21,6 +21,8 @@
     ../../rbw.nix
   ];
 
+  programs.qmd.enable = true;
+
   home.packages = with pkgs; [
     bitwarden-desktop
     cyberduck

--- a/users/deepwatrcreatur/hosts/workstation/default.nix
+++ b/users/deepwatrcreatur/hosts/workstation/default.nix
@@ -20,6 +20,7 @@
   ];
 
   programs.dmux.enable = true;
+  programs.qmd.enable = true;
 
   programs.rtk-hooks.integrations = {
     claude.enable = true;


### PR DESCRIPTION
## **User description**
## Summary

- `programs.qmd.enable` default changed from `mkDefault true` → `mkDefault false` in `coding-agents.nix`
- Enabled explicitly on `workstation` and `macminim4` (modern CPUs with AVX2)
- Router and router-backup now skip the qmd build automatically

## Root cause

`qmd` uses `bun` to build its node modules. `bun` requires AVX2 (or newer SIMD) instructions. The router and router-backup are KVM guests configured as `"Common KVM processor"` which only exposes SSE/SSE2/SSE3, causing `bun install` to crash with `Illegal instruction` at build time.

## Test plan
- [ ] CI `module-loading-eval` passes
- [ ] Router build no longer includes `qmd-node-modules` derivation
- [ ] Workstation and macminim4 still get qmd

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Stop building qmd on hosts that cannot run it**

### What Changed
- qmd is no longer enabled by default, so it is skipped on hosts without the required CPU support
- qmd is still enabled on workstation and macminim4, where the hardware can run it
- This avoids build crashes on older or minimal KVM guests that do not expose the needed instructions

### Impact
`✅ Fewer host build failures`
`✅ Reliable builds on KVM guests`
`✅ qmd still available on capable machines`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Changed QMD (Quarto Markdown) from enabled-by-default to disabled-by-default across configurations.
  * Explicitly enabled QMD for two specific host configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->