### PR TITLE
docs: add cpu-features aspect planning document

### DIFF
--- a/docs/cpu-features-aspect-plan.md
+++ b/docs/cpu-features-aspect-plan.md
@@ -1,0 +1,194 @@
+# CPU Features Aspect — Planning Document
+
+This document captures the design for a lightweight NixOS option that exposes
+per-host CPU capability flags so that modules can gate package installation
+without breaking the binary cache.
+
+**Status: Deferred.** The immediate problem (qmd/bun requiring AVX2) was solved
+by making `programs.qmd.enable` opt-in per capable host. Build this when the
+opt-in list becomes a maintenance burden (see trigger conditions below).
+
+---
+
+## Problem
+
+Some packages require CPU instructions (AVX2, AES-NI, etc.) that are not
+exposed by the default Proxmox KVM CPU type (`kvm64` / "Common KVM processor",
+which only provides SSE/SSE2/SSE3). These packages build successfully on the
+build machine but crash at runtime with `Illegal instruction` on under-equipped
+guests.
+
+**Observed case:** `qmd` uses `bun` to install its node modules. `bun` requires
+AVX2. The router and router-backup are KVM guests with `kvm64` CPU type — they
+lack AVX2, causing `bun install` to crash at build time.
+
+**Workaround in place:** `programs.qmd.enable = lib.mkDefault false` in
+`coding-agents.nix`; `workstation` and `macminim4` opt in explicitly.
+
+---
+
+## Community Patterns
+
+### `nixpkgs.hostPlatform` with `gcc.arch` (idiomatic but costly)
+
+```nix
+# In a host's NixOS config:
+nixpkgs.hostPlatform = {
+  system = "x86_64-linux";
+  gcc.arch = "skylake";   # or "haswell", "x86-64-v3", etc.
+  gcc.tune = "skylake";
+};
+```
+
+Setting `gcc.arch` causes nixpkgs to append `-march=skylake` to every gcc
+invocation, producing different store paths from the standard build. This
+**breaks binary cache compatibility** for the entire closure — all packages must
+be rebuilt locally rather than fetched from attic or cache.nixos.org.
+
+Nixpkgs exposes capability predicates derived from `gcc.arch`:
+
+```nix
+stdenv.hostPlatform.avx2Support   # bool
+stdenv.hostPlatform.aesSupport    # bool
+stdenv.hostPlatform.sse4_2Support # bool
+# ... defined in nixpkgs/lib/systems/architectures.nix
+```
+
+These predicates are idiomatic and used by `nixos-hardware` modules and
+packages inside nixpkgs. They are the right choice when you *want* CPU-tuned
+builds. They are the wrong choice when you only want to *gate* package
+installation.
+
+### Custom NixOS option (no binary cache impact)
+
+The alternative is a thin declarative option that records capability facts
+without affecting build flags:
+
+```nix
+options.host.cpu.avx2 = lib.mkEnableOption "AVX2 / x86-64-v3 CPU features";
+```
+
+Modules read `config.host.cpu.avx2` to decide whether to install a package.
+No derivation paths change; attic cache continues to work.
+
+---
+
+## Proposed Design
+
+### 1. New module: `modules/common/cpu-features.nix`
+
+```nix
+{ lib, ... }:
+{
+  options.host.cpu = {
+    avx2  = lib.mkEnableOption "AVX2 and x86-64-v3 feature set";
+    aesNi = lib.mkEnableOption "AES-NI hardware encryption";
+  };
+}
+```
+
+Import this from `modules/common/` (auto-imported for all hosts). All options
+default to `false` — safe for restricted KVM guests.
+
+### 2. Den inventory integration
+
+Add a `cpu` attrset to each host entry in `den/inventory/hosts.nix`:
+
+```nix
+workstation = {
+  aspectsList = [ "nixos-base" "home-manager-users" ... ];
+  cpu = { avx2 = true; aesNi = true; };
+};
+router = {
+  aspectsList = [ "nixos-base" "home-manager-users" "router-router" ];
+  # cpu omitted — both default to false
+};
+```
+
+### 3. Inventory aspect or den leaf wiring
+
+The inventory `cpu` values must be wired into `config.host.cpu.*`. Two options:
+
+**Option A — Per-host den leaf (explicit):**
+
+```nix
+# den/hosts/workstation/default.nix
+{ ... }: {
+  imports = [ (mkInventoryHostModule { name = "workstation"; }) ];
+  host.cpu.avx2  = true;
+  host.cpu.aesNi = true;
+}
+```
+
+**Option B — Inventory-driven aspect (DRY):**
+
+Create `den/aspects/cpu-features.nix` that reads the inventory entry and sets
+`config.host.cpu.*` automatically. This follows the existing pattern where
+aspects receive host-specific arguments from `mkHostModule`.
+
+Option B is cleaner but requires the aspect to receive the inventory `cpu`
+attrset — check whether the current `mkHostModule` / `mkInventoryHostModule`
+plumbing can pass arbitrary inventory fields through before choosing this path.
+
+### 4. Module usage
+
+```nix
+# modules/home-manager/common/coding-agents.nix
+programs.qmd.enable = lib.mkDefault config.host.cpu.avx2;
+```
+
+Any future module that installs an AVX2-dependent package follows the same
+pattern, with no per-host configuration required.
+
+---
+
+## CPU Type Reference
+
+| Proxmox CPU type | AVX2 | AES-NI | Notes |
+|---|---|---|---|
+| `kvm64` (default) | No | No | SSE/SSE2/SSE3 only |
+| `host` (i7-6770 / Skylake) | Yes | Yes | Full host passthrough |
+| `Haswell` (named model) | Yes | Yes | Portable across Haswell+ hosts |
+| `Skylake-Client` | Yes | Yes | Portable across Skylake+ hosts |
+| `aarch64` (Apple M-series) | N/A | Yes | ARM; bun AVX2 issue does not apply |
+
+Hosts currently running `cpu: host`:
+- `workstation` (physical; always had native CPU)
+- `router` — upgraded 2026-04-06 from `kvm64` to `host` (i7-6770 / Skylake)
+
+Hosts still on `kvm64` or equivalent:
+- `router-backup`, `homeserver`, `attic-cache`, `authentik-host`,
+  `nixos-lxc`, `inference-vm`, `rustdesk`, and others
+
+---
+
+## Trigger Conditions
+
+Build this when **two or more** of the following are true:
+
+- A second package beyond `qmd` requires an explicit per-host enable/disable
+  due to CPU capability constraints.
+- The opt-in host list for any single package grows beyond four entries.
+- A new host is added and the developer has to remember to check the capability
+  list for every relevant package.
+- A package is accidentally enabled on a limited-CPU host and causes a runtime
+  failure that reaches production.
+
+---
+
+## Implementation Checklist
+
+When the time comes:
+
+- [ ] Create `modules/common/cpu-features.nix` with `host.cpu.avx2` and
+      `host.cpu.aesNi` options
+- [ ] Decide Option A vs Option B for wiring inventory → NixOS option
+- [ ] Set `host.cpu.avx2 = true` for `workstation` and (via Home Manager)
+      `macminim4`; leave all other hosts at default `false`
+- [ ] Replace `programs.qmd.enable = true` in `workstation` and `macminim4`
+      host overlays with the module-driven default
+- [ ] Audit `coding-agents.nix` and other modules for any other packages
+      that should be gated similarly
+- [ ] Run `module-loading-eval` CI check and rebuild router to confirm it no
+      longer sees the qmd derivations
+- [ ] Update this document to `Status: Done` and record the final approach


### PR DESCRIPTION
## **User description**
## Summary

- Adds `docs/cpu-features-aspect-plan.md` — a deferred design document for a `host.cpu.avx2` / `host.cpu.aesNi` NixOS option
- Documents why `nixpkgs.hostPlatform.gcc.arch` (the community-idiomatic approach) is unsuitable for this repo (breaks attic binary cache)
- Captures the lightweight custom-option alternative, inventory integration options, and a trigger-condition checklist for when to actually build it

## Context

`qmd` build failed on router (KVM guest with `kvm64` CPU, no AVX2) because `bun` requires AVX2. Short-term fix: `programs.qmd.enable = lib.mkDefault false`, opt-in on workstation and macminim4. This doc preserves the full design so it can be implemented later if the opt-in list becomes a burden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
Document a plan for per-host CPU feature flags without breaking cache sharing

### What Changed
- Adds a planning document for a future `host.cpu.avx2` and `host.cpu.aesNi` setting
- Explains why tuning the whole build for a specific CPU would stop shared binary cache reuse
- Records the current workaround: keep `qmd` off by default on limited-CPU hosts and enable it only where the CPU supports it
- Lists when this design should be built and the steps needed to implement it later

### Impact
`✅ Clearer CPU compatibility planning`
`✅ Fewer accidental AVX2 runtime failures`
`✅ Safer use of shared binary caches`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning documentation for managing per-host CPU capability flags, including design approaches, integration strategies, and implementation checklist for addressing CPU-instruction compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->