### PR TITLE
workstation: review amd gfxoff and linuxbrew switch fixes

### DIFF
--- a/hosts/nixos/workstation/profile.nix
+++ b/hosts/nixos/workstation/profile.nix
@@ -72,6 +72,9 @@
   boot.loader.systemd-boot.consoleMode = "auto";
 
   boot.kernelModules = [ "amdgpu" ];
+  # Disable GFX power gating — prevents the amdgpu SMU gfxoff hang that causes
+  # "GPU reset failed: device lost from bus" and a black screen requiring reboot.
+  boot.kernelParams = [ "amdgpu.gfxoff=0" ];
   boot.blacklistedKernelModules = [
     "virtio_gpu"
     "bochs_drm"

--- a/hosts/nixos/workstation/profile.nix
+++ b/hosts/nixos/workstation/profile.nix
@@ -53,7 +53,10 @@
   };
 
   programs.linuxbrew = {
-    enableSystemSetup = true;
+    # The generated setup hook recursively chowns the entire Linuxbrew prefix
+    # on every activation, which causes workstation switches to time out.
+    # The prefix already exists with the correct ownership on this host.
+    enableSystemSetup = false;
     owner = "deepwatrcreatur";
   };
 

--- a/hosts/nixos/workstation/profile.nix
+++ b/hosts/nixos/workstation/profile.nix
@@ -57,7 +57,6 @@
     # on every activation, which causes workstation switches to time out.
     # The prefix already exists with the correct ownership on this host.
     enableSystemSetup = false;
-    owner = "deepwatrcreatur";
   };
 
   programs.wezterm.extraConfig = lib.mkAfter ''


### PR DESCRIPTION
## **User description**
## Summary
- disable amdgpu gfxoff on workstation to avoid black-screen GPU hangs
- stop running the Linuxbrew system-setup hook on each workstation switch
- keep this PR based on the commit before the AMD change so review bots can comment on both fixes

## Testing
- nix build .#nixosConfigurations.workstation.config.system.build.toplevel -L
- /run/wrappers/bin/sudo nixos-rebuild build --flake .#workstation
- direct switch-to-configuration activation on workstation

<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
Stop workstation black-screen GPU hangs and speed up workstation switches

### What Changed
- Workstation graphics power saving is now disabled to avoid GPU reset failures that could leave the screen black and require a reboot
- Linuxbrew no longer runs its full setup on every workstation switch, removing the repeated prefix-wide ownership check that was slowing activations
- The workstation keeps the same Linuxbrew install and shell setup without redoing setup work each time

### Impact
`✅ Fewer black-screen GPU crashes`
`✅ Faster workstation switches`
`✅ Fewer switch timeouts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
