### PR TITLE
fix(tooling): align cache trust and fallback behavior

### DIFF
--- a/modules/common/nix-settings.nix
+++ b/modules/common/nix-settings.nix
@@ -105,10 +105,12 @@ in
       ];
 
     trusted-public-keys =
-      # When Attic is disabled, fall back to the full set of official keys so
-      # cache.nixos.org remains usable.
+      # Keep the trusted key set aligned with the substituters we enable by
+      # default. Otherwise Nix still queries public caches like garnix and
+      # nix-community but then ignores their results as untrusted noise.
       (if enableAttic then
         atticCache.defaultTrustedPublicKeys { includeNixCi = enableNixCi; }
+        ++ cacheTrust.official
       else
         cacheTrust.official);
 

--- a/modules/home-manager/common/nix-user-config.md
+++ b/modules/home-manager/common/nix-user-config.md
@@ -9,10 +9,12 @@ On systems using Determinate Nix, the system-level `nix.settings` configuration 
 ## Default Configuration
 
 By default, this module:
-- Enables Attic cache at `http://cache-build-server:5001/cache-local`
+- Enables the local Attic cache at `http://attic-cache:5001/cache-local`
 - Falls back to `cache.nixos.org`
 - Configures authentication via a managed Determinate Nix netrc block
 - Enables common experimental features (flakes, nix-command, etc.)
+- prefers the repo-managed GitHub token file over `fnox` when writing
+  `access-tokens` into `~/.config/nix/nix.conf`
 
 ## Per-Host Customization
 
@@ -67,6 +69,23 @@ To customize for a specific host, add to your user's host configuration:
 
 - `~/.config/nix/nix.conf` - Nix configuration (substituters, keys, features)
 - `/nix/var/determinate/netrc` - managed netrc block for private cache authentication
+
+## Degraded Cache Path
+
+When `attic-cache` is unhealthy or misaddressed, agent builds should still be
+able to run against `cache.nixos.org` and any explicitly trusted public caches.
+
+For one-off degraded-mode builds, prefer passing a narrowed substituter set such
+as:
+
+```bash
+nix build .#someTarget \
+  --option substituters https://cache.nixos.org/ \
+  --option trusted-public-keys cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+```
+
+That avoids waiting on a broken local Attic endpoint while still keeping the
+build path explicit and reproducible.
 
 ## Integration with Attic
 

--- a/modules/home-manager/common/nix-user-config.nix
+++ b/modules/home-manager/common/nix-user-config.nix
@@ -130,14 +130,15 @@ in
           token_path="${tokenPath}"
 
           token=""
-          # Try fnox if available
-          if command -v fnox &> /dev/null && [ -f "$HOME/.config/sops/age/keys.txt" ]; then
-            export FNOX_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
-            token=$(fnox get GITHUB_TOKEN 2>/dev/null || echo "")
+          # Prefer the repo-managed token file first. fnox may still have a
+          # stale cached value even when agenix has already rotated the file.
+          if [[ -f "$token_path" ]]; then
+            token=$(cat "$token_path")
           fi
 
-          if [[ -z "$token" && -f "$token_path" ]]; then
-            token=$(cat "$token_path")
+          if [[ -z "$token" ]] && command -v fnox &> /dev/null && [ -f "$HOME/.config/sops/age/keys.txt" ]; then
+            export FNOX_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
+            token=$(fnox get GITHUB_TOKEN 2>/dev/null || echo "")
           fi
 
           if [[ -n "$token" ]]; then

--- a/scripts/router-dashboard-api-wrapper.py
+++ b/scripts/router-dashboard-api-wrapper.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import os
+
+UPSTREAM_SERVER = os.environ["DASHBOARD_UPSTREAM_SERVER"]
+FAIL2BAN_STATUS_FILE = os.environ.get("DASHBOARD_FAIL2BAN_STATUS_FILE", "")
+CLOUDFLARE_TOKEN_FILE = os.environ.get("DASHBOARD_CLOUDFLARE_TOKEN_FILE", "")
+
+if CLOUDFLARE_TOKEN_FILE and os.path.exists(CLOUDFLARE_TOKEN_FILE):
+    try:
+        with open(CLOUDFLARE_TOKEN_FILE, "r", encoding="utf-8") as handle:
+            os.environ["CLOUDFLARE_API_TOKEN"] = handle.read().strip()
+    except Exception:
+        pass
+
+spec = importlib.util.spec_from_file_location("router_dashboard_upstream", UPSTREAM_SERVER)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+try:
+    dashboard_interfaces = json.loads(os.environ.get("DASHBOARD_INTERFACES", "[]"))
+except json.JSONDecodeError:
+    dashboard_interfaces = []
+
+interface_role_map = {}
+for interface in dashboard_interfaces:
+    if not isinstance(interface, dict):
+        continue
+    device = interface.get("device")
+    role = interface.get("role") or device
+    if device:
+        interface_role_map[device] = role
+
+original_handle_fail2ban_status = module.RouterAPIHandler.handle_fail2ban_status
+
+
+def handle_interface_stats(self):
+    try:
+        interfaces = {}
+        net_path = module.Path("/sys/class/net")
+
+        for iface_path in net_path.iterdir():
+            name = iface_path.name
+            if name.startswith(("lo", "docker", "veth", "br-", "virbr")):
+                continue
+
+            stats_path = iface_path / "statistics"
+            if not stats_path.exists():
+                continue
+
+            rx_bytes = int(self.read_file(stats_path / "rx_bytes") or 0)
+            tx_bytes = int(self.read_file(stats_path / "tx_bytes") or 0)
+            rx_rate, tx_rate = self.calculate_rates(name, rx_bytes, tx_bytes)
+            ipv4 = self.get_ipv4(name)
+            ipv6_list = self.get_ipv6(name)
+            key = interface_role_map.get(name, name)
+
+            interfaces[key] = {
+                "device": name,
+                "state": (self.read_file(iface_path / "operstate") or "").strip().upper() or "UNKNOWN",
+                "ipv4": ipv4,
+                "ipv6": ipv6_list,
+                "rx_bytes": rx_bytes,
+                "tx_bytes": tx_bytes,
+                "rx_rate": rx_rate,
+                "tx_rate": tx_rate,
+                "rx_packets": int(self.read_file(stats_path / "rx_packets") or 0),
+                "tx_packets": int(self.read_file(stats_path / "tx_packets") or 0),
+                "rx_errors": int(self.read_file(stats_path / "rx_errors") or 0),
+                "tx_errors": int(self.read_file(stats_path / "tx_errors") or 0),
+            }
+
+        self.send_json(interfaces)
+    except Exception as exc:
+        self.send_error_json(500, str(exc))
+
+
+def handle_fail2ban_status(self):
+    if FAIL2BAN_STATUS_FILE:
+        try:
+            with open(FAIL2BAN_STATUS_FILE, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            self.send_json(payload)
+            return
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
+
+    return original_handle_fail2ban_status(self)
+
+
+module.RouterAPIHandler.handle_interface_stats = handle_interface_stats
+module.RouterAPIHandler.handle_fail2ban_status = handle_fail2ban_status
+
+if __name__ == "__main__":
+    module.run_server()

--- a/scripts/validate-router-cutover.sh
+++ b/scripts/validate-router-cutover.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# scripts/validate-router-cutover.sh — Post-cutover validation for homelab router
+set -euo pipefail
+
+ROUTER_IP="10.10.10.1"
+DOMAIN="deepwatercreature.com"
+SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new"
+BLOCKING_FAILED=0
+
+# Critical hosts from lib/hosts.nix that depend on reserved leases
+declare -A CRITICAL_HOSTS=(
+  ["attic-cache"]="10.10.11.39"
+  ["authentik-host"]="10.10.11.70"
+  ["inference1"]="10.10.11.131"
+  ["homeserver"]="10.10.11.69"
+  ["ap-ruqayya"]="10.10.11.20"
+  ["ap-nosheen-living"]="10.10.11.21"
+  ["ap-nosheen-bedroom"]="10.10.11.22"
+)
+
+echo "=== Router Post-Cutover Validation ==="
+
+# 1. Connectivity to Router
+echo -n "Checking router reachability ($ROUTER_IP)... "
+if ping -c 1 -W 2 "$ROUTER_IP" >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAILED"
+  exit 1
+fi
+
+# 2. WAN Connectivity
+echo -n "Checking Internet connectivity (1.1.1.1)... "
+if ping -c 1 -W 2 1.1.1.1 >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAILED (Advisory)"
+fi
+
+# 3. Technitium Service Status
+echo -n "Checking Technitium DNS Server service... "
+# shellcheck disable=SC2086
+TECH_STATUS=$(ssh $SSH_OPTS "$ROUTER_IP" "systemctl is-active technitium-dns-server" 2>/dev/null || echo "unknown")
+if [ "$TECH_STATUS" = "active" ]; then
+  echo "OK"
+else
+  echo "FAILED: $TECH_STATUS"
+  BLOCKING_FAILED=1
+fi
+
+# 4. Technitium DHCP Scope Name
+echo -n "Checking DHCP scope 'LAN' presence... "
+# shellcheck disable=SC2086
+if ssh $SSH_OPTS "$ROUTER_IP" "/run/wrappers/bin/sudo ls /var/lib/technitium-dns-server/scopes/LAN.scope" >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAILED (Check if scope is named 'Default' instead)"
+  BLOCKING_FAILED=1
+fi
+
+# 5. Critical Host Reachability (Reserved IPs)
+echo "Checking critical host reachability (reserved IPs):"
+for host in "${!CRITICAL_HOSTS[@]}"; do
+  expected_ip="${CRITICAL_HOSTS[$host]}"
+  echo -n "  - $host ($expected_ip)... "
+  if ping -c 1 -W 1 "$expected_ip" >/dev/null 2>&1; then
+    echo "OK"
+  else
+    # Try to find current IP if wrong
+    # shellcheck disable=SC2086
+    actual_ip=$(ssh $SSH_OPTS "$ROUTER_IP" "/run/wrappers/bin/sudo grep -i \"leased IP address .* to .*$host\" /var/lib/technitium-dns-server/logs/\$(date +%Y-%m-%d).log | tail -n 1 | grep -oE 'leased IP address \[[0-9.]+' | grep -oE '[0-9.]+' | head -n 1" 2>/dev/null || echo "unknown")
+    if [ -n "$actual_ip" ] && [ "$actual_ip" != "unknown" ]; then
+      echo "FAILED (Advisory: Actually at $actual_ip)"
+    else
+      echo "FAILED (Advisory: Unreachable)"
+    fi
+  fi
+done
+
+# 6. Dashboard Reachability (Management Plane)
+MGMT_IP="192.168.100.100"
+echo -n "Checking Dashboard on Management Plane ($MGMT_IP:8888)... "
+if curl -s -m 2 "http://$MGMT_IP:8888" >/dev/null 2>&1; then
+  echo "OK"
+else
+  echo "FAILED (Advisory)"
+fi
+
+echo "=== Validation Complete ==="
+exit "$BLOCKING_FAILED"


### PR DESCRIPTION
## **User description**
## Summary
- align trusted public keys with the public substituters this repo already enables
- stop querying garnix/nix-community/hyprland/cuda/numtide caches as untrusted noise
- make user-level nix token wiring prefer the managed GitHub token file before fnox
- document the explicit cache.nixos.org-only degraded build path

## Validation
- module syntax checks passed for system and user nix config modules
- verified the new trust set matches the enabled public caches
- documented the emergency narrowed-substituter build command
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added router dashboard wrapper with interface statistics and fail2ban status monitoring.
  * Added post-router cutover validation tool for connectivity and service health checks.

* **Documentation**
  * Updated cache configuration documentation with degraded mode fallback guidance.

* **Configuration**
  * Improved cache key management to support multiple trusted sources simultaneously.
  * Adjusted GitHub token sourcing priority in configuration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Align cache trust, token lookup, and router validation behavior**

### What Changed
- Nix now trusts the same public cache keys it already uses by default, which avoids repeated untrusted-cache lookups while still keeping cache.nixos.org available when Attic is off.
- GitHub token setup now reads the managed token file first, then falls back to `fnox`, so token rotation is picked up without using a stale cached value.
- Added a router cutover check script that verifies router reachability, DNS and DHCP status, and management dashboard access, while failing only on the issues that block the cutover.
- Router dashboard responses now show the correct interface names and can load fail2ban status from a saved snapshot file when available.
- Documentation now reflects the local Attic cache address and includes a one-off degraded build command for cache.nixos.org-only runs.

### Impact
`✅ Fewer ignored cache lookups`
`✅ Reliable GitHub token refresh`
`✅ Clearer router cutover checks`
`✅ Safer fallback builds when the local cache is down`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
