### PR TITLE
feat: add iVentoy PXE service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1181,11 +1181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775737941,
-        "narHash": "sha256-Qdib9b3KgYMhFq2hfJ+EFtttEzFUoJSq2KmcO5fEoJ0=",
+        "lastModified": 1776031257,
+        "narHash": "sha256-Id2LCO/PXIfjQh3iJUnZd6kyjTWNYh5McE0zrm/69Rk=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "a8d8d666259fc2255edea7859db27278a86a94bf",
+        "rev": "0eccfa36921ad50b2a80608d6cc97f22031573ca",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -60,6 +60,23 @@ in
     '';
   };
 
+  services.iventoy = {
+    enable = true;
+    isoDir = "/srv/pxe/images";
+    openFirewall = false;
+  };
+
+  services.router-firewall = {
+    trustedTcpPorts = [
+      16000
+      26000
+    ];
+    trustedUdpPorts = [
+      69
+      4011
+    ];
+  };
+
   # Stable NIC identity via systemd .link files.
   #
   # Physical passthrough NICs are pinned by MAC so that PCI slot renumbering

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -35,8 +35,15 @@ in
       routerAddress = routerHost.ip;
       domainName = topology.domain;
       domainSearchList = [ topology.domain ];
+      # iVentoy External mode: clients fetch this virtual loader from the
+      # router, and iVentoy selects the real BIOS/UEFI loader after snooping
+      # the DHCP request. Keep this aligned with iVentoy's HTTP port.
+      serverAddress = routerHost.ip;
+      serverHostName = "router.${topology.domain}";
+      bootFileName = "iventoy_loader_16000";
       useThisDnsServer = true;
       ntpServers = [ routerHost.ip ];
+      tftpServerAddresses = [ routerHost.ip ];
       # Many Wi-Fi and mobile clients now use locally administered/randomized
       # MACs; blocking them causes silent "no lease" failures.
       blockLocallyAdministeredMacAddresses = false;

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -5,6 +5,7 @@
 let
   topology = config.router.topology;
   routerHost = topology.routerHost;
+  iventoy = config.services.iventoy;
 in
 {
   networking.hostName = "router";
@@ -37,10 +38,10 @@ in
       domainSearchList = [ topology.domain ];
       # iVentoy External mode: clients fetch this virtual loader from the
       # router, and iVentoy selects the real BIOS/UEFI loader after snooping
-      # the DHCP request. Keep this aligned with iVentoy's HTTP port.
+      # the DHCP request.
       serverAddress = routerHost.ip;
       serverHostName = "router.${topology.domain}";
-      bootFileName = "iventoy_loader_16000";
+      bootFileName = "iventoy_loader_${toString iventoy.httpPort}";
       useThisDnsServer = true;
       ntpServers = [ routerHost.ip ];
       tftpServerAddresses = [ routerHost.ip ];

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -23,6 +23,10 @@ let
   lanListenAddress = builtins.head (lib.splitString "/" lanIpv4Address);
   managementListenAddress = builtins.head (lib.splitString "/" managementIpv4Address);
   managementDevice = "ens18";
+  managementNetwork = topology.networks.management;
+  operatorStableSshKey = lib.strings.trim (
+    builtins.readFile ../../../ssh-keys/deepwatrcreatur-stable-identity.pub
+  );
 
   secrets = optSec.mkSecrets {
     cloudflare-api-key = {
@@ -47,18 +51,24 @@ let
   ) topology.hosts;
 in
 {
-  imports = [ ../../../modules/nixos/router/common.nix ];
+  imports = [
+    ../../../modules/nixos/router/common.nix
+    ../../../modules/nixos/services/iventoy.nix
+  ];
 
   # Recovery invariants: these assertions fail the build if the properties
   # that make the router usable in standby/dev mode are ever regressed.
   assertions = [
     {
       assertion =
-        getAttrByPath
-          [ "systemd" "network" "networks" "20-router-lan" "networkConfig" "ConfigureWithoutCarrier" ]
-          false
-          config
-        == true;
+        getAttrByPath [
+          "systemd"
+          "network"
+          "networks"
+          "20-router-lan"
+          "networkConfig"
+          "ConfigureWithoutCarrier"
+        ] false config == true;
       message = ''
         Router invariant violated: 20-router-lan must have ConfigureWithoutCarrier = true.
         Without this, the LAN static IP disappears when the data-plane cable is unplugged,
@@ -241,20 +251,21 @@ in
   };
 
   services.router-technitium = {
-    dhcpReservations = lib.mapAttrs (
-      name: host: {
-        scope = host.dhcpReservation.scope or "LAN";
-        macAddress = host.dhcpReservation.macAddress;
-        ipAddress = host.ip;
-        hostName = name;
-        comments = host.description or "";
-      }
-    ) reservableHosts;
+    dhcpReservations = lib.mapAttrs (name: host: {
+      scope = host.dhcpReservation.scope or "LAN";
+      macAddress = host.dhcpReservation.macAddress;
+      ipAddress = host.ip;
+      hostName = name;
+      comments = host.description or "";
+    }) reservableHosts;
   };
 
   services.router-firewall = {
     enable = true;
-    trustedTcpPorts = [ 80 443 ];
+    trustedTcpPorts = [
+      80
+      443
+    ];
     hairpinNat.enable = true;
     trustedUdpPorts = [ ];
     extraLanLocalRules = ''
@@ -270,12 +281,10 @@ in
 
   services.router-dashboard = {
     refreshInterval = lib.mkDefault 10;
-    interfaces = map
-      (iface: {
-        inherit (iface) device label;
-        role = if iface.role == "management" then "mgmt" else iface.role;
-      })
-      (lib.attrValues config.services.router-optimizations.interfaces);
+    interfaces = map (iface: {
+      inherit (iface) device label;
+      role = if iface.role == "management" then "mgmt" else iface.role;
+    }) (lib.attrValues config.services.router-optimizations.interfaces);
     services = [
       "systemd-networkd"
       "sshd"
@@ -443,12 +452,14 @@ in
 
   services.openssh = {
     enable = true;
-    settings.PermitRootLogin = "prohibit-password";
+    settings.PermitRootLogin = "no";
     extraConfig = ''
-      Match Address ${lanNetwork.cidr}
-        PermitRootLogin yes
+      Match Address ${lanNetwork.cidr},${managementNetwork.cidr}
+        PermitRootLogin prohibit-password
     '';
   };
+
+  users.users.root.openssh.authorizedKeys.keys = [ operatorStableSshKey ];
 
   services.fail2ban = {
     enable = true;

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -23,7 +23,6 @@ let
   lanListenAddress = builtins.head (lib.splitString "/" lanIpv4Address);
   managementListenAddress = builtins.head (lib.splitString "/" managementIpv4Address);
   managementDevice = "ens18";
-  managementNetwork = topology.networks.management;
   operatorStableSshKey = lib.strings.trim (
     builtins.readFile ../../../ssh-keys/deepwatrcreatur-stable-identity.pub
   );
@@ -45,6 +44,7 @@ let
 
   topology = config.router.topology;
   lanNetwork = topology.networks.lan;
+  managementNetwork = topology.networks.management;
   mkFqdn = label: "${label}.${topology.domain}";
   reservableHosts = lib.filterAttrs (
     _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null

--- a/modules/nixos/services/default.nix
+++ b/modules/nixos/services/default.nix
@@ -2,6 +2,7 @@
 
 {
   imports = [
+    ./iventoy.nix
     ./iperf3.nix
   ];
 }

--- a/modules/nixos/services/iventoy.nix
+++ b/modules/nixos/services/iventoy.nix
@@ -84,32 +84,32 @@ in
       preStart = ''
         set -euo pipefail
 
-        install -d -m 0755 ${cfg.stateDir}
-        install -d -m 0755 ${cfg.stateDir}/data ${cfg.stateDir}/log/history ${cfg.isoDir}
+        install -d -m 0755 "${cfg.stateDir}"
+        install -d -m 0755 "${cfg.stateDir}/data" "${cfg.stateDir}/log/history"
 
-        rm -rf ${cfg.stateDir}/lib ${cfg.stateDir}/doc
-        cp -a ${cfg.package}/share/iventoy/lib ${cfg.stateDir}/lib
-        cp -a ${cfg.package}/share/iventoy/doc ${cfg.stateDir}/doc
-        cp -a ${cfg.package}/share/iventoy/iventoy.sh ${cfg.stateDir}/iventoy.sh
+        rm -rf "${cfg.stateDir}/lib" "${cfg.stateDir}/doc"
+        cp -a "${cfg.package}/share/iventoy/lib" "${cfg.stateDir}/lib"
+        cp -a "${cfg.package}/share/iventoy/doc" "${cfg.stateDir}/doc"
+        cp -a "${cfg.package}/share/iventoy/iventoy.sh" "${cfg.stateDir}/iventoy.sh"
 
-        if [ ! -e ${cfg.stateDir}/user ]; then
-          cp -a ${cfg.package}/share/iventoy/user ${cfg.stateDir}/user
+        if [ ! -e "${cfg.stateDir}/user" ]; then
+          cp -a "${cfg.package}/share/iventoy/user" "${cfg.stateDir}/user"
         fi
-        if [ ! -e ${cfg.stateDir}/data/iventoy.dat ]; then
-          cp -a ${cfg.package}/share/iventoy/data/iventoy.dat ${cfg.stateDir}/data/iventoy.dat
+        if [ ! -e "${cfg.stateDir}/data/iventoy.dat" ]; then
+          cp -a "${cfg.package}/share/iventoy/data/iventoy.dat" "${cfg.stateDir}/data/iventoy.dat"
         fi
-        if [ ! -e ${cfg.stateDir}/data/mac.db ]; then
-          cp -a ${cfg.package}/share/iventoy/data/mac.db ${cfg.stateDir}/data/mac.db
+        if [ ! -e "${cfg.stateDir}/data/mac.db" ]; then
+          cp -a "${cfg.package}/share/iventoy/data/mac.db" "${cfg.stateDir}/data/mac.db"
         fi
 
-        rm -rf ${cfg.stateDir}/iso
-        ln -s ${cfg.isoDir} ${cfg.stateDir}/iso
+        rm -rf "${cfg.stateDir}/iso"
+        ln -s "${cfg.isoDir}" "${cfg.stateDir}/iso"
       '';
 
       serviceConfig = {
         Type = "forking";
         WorkingDirectory = cfg.stateDir;
-        PIDFile = "/run/iventoy.pid";
+        PIDFile = "/var/run/iventoy.pid";
         ExecStart = "${pkgs.bash}/bin/bash ${cfg.stateDir}/iventoy.sh -R start";
         ExecStop = "${pkgs.bash}/bin/bash ${cfg.stateDir}/iventoy.sh stop";
         Restart = "on-failure";

--- a/modules/nixos/services/iventoy.nix
+++ b/modules/nixos/services/iventoy.nix
@@ -1,0 +1,130 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.iventoy;
+  defaultPackage = pkgs.callPackage ../../../pkgs/iventoy-free.nix { };
+in
+{
+  options.services.iventoy = {
+    enable = lib.mkEnableOption "iVentoy PXE ISO menu server";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = defaultPackage;
+      description = "iVentoy package to run.";
+    };
+
+    stateDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/iventoy";
+      description = "Writable iVentoy runtime directory.";
+    };
+
+    isoDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/srv/pxe/images";
+      description = "Directory containing ISO files shown in the iVentoy boot menu.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Open iVentoy HTTP, web UI, TFTP, and PXE proxy ports in the NixOS firewall.";
+    };
+
+    httpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 16000;
+      description = "iVentoy HTTP boot content port.";
+    };
+
+    webUiPort = lib.mkOption {
+      type = lib.types.port;
+      default = 26000;
+      description = "iVentoy web UI port.";
+    };
+
+    tftpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 69;
+      description = "iVentoy TFTP port.";
+    };
+
+    proxyDhcpPort = lib.mkOption {
+      type = lib.types.port;
+      default = 4011;
+      description = "iVentoy PXE proxy DHCP port.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d ${cfg.stateDir} 0755 root root -"
+      "d ${cfg.isoDir} 0755 root root -"
+    ];
+
+    systemd.services.iventoy = {
+      description = "iVentoy PXE ISO menu server";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+      unitConfig.RequiresMountsFor = cfg.isoDir;
+
+      path = with pkgs; [
+        bash
+        coreutils
+        gnugrep
+        procps
+      ];
+
+      preStart = ''
+        set -euo pipefail
+
+        install -d -m 0755 ${cfg.stateDir}
+        install -d -m 0755 ${cfg.stateDir}/data ${cfg.stateDir}/log/history ${cfg.isoDir}
+
+        rm -rf ${cfg.stateDir}/lib ${cfg.stateDir}/doc
+        cp -a ${cfg.package}/share/iventoy/lib ${cfg.stateDir}/lib
+        cp -a ${cfg.package}/share/iventoy/doc ${cfg.stateDir}/doc
+        cp -a ${cfg.package}/share/iventoy/iventoy.sh ${cfg.stateDir}/iventoy.sh
+
+        if [ ! -e ${cfg.stateDir}/user ]; then
+          cp -a ${cfg.package}/share/iventoy/user ${cfg.stateDir}/user
+        fi
+        if [ ! -e ${cfg.stateDir}/data/iventoy.dat ]; then
+          cp -a ${cfg.package}/share/iventoy/data/iventoy.dat ${cfg.stateDir}/data/iventoy.dat
+        fi
+        if [ ! -e ${cfg.stateDir}/data/mac.db ]; then
+          cp -a ${cfg.package}/share/iventoy/data/mac.db ${cfg.stateDir}/data/mac.db
+        fi
+
+        rm -rf ${cfg.stateDir}/iso
+        ln -s ${cfg.isoDir} ${cfg.stateDir}/iso
+      '';
+
+      serviceConfig = {
+        Type = "forking";
+        WorkingDirectory = cfg.stateDir;
+        PIDFile = "/run/iventoy.pid";
+        ExecStart = "${pkgs.bash}/bin/bash ${cfg.stateDir}/iventoy.sh -R start";
+        ExecStop = "${pkgs.bash}/bin/bash ${cfg.stateDir}/iventoy.sh stop";
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [
+        cfg.httpPort
+        cfg.webUiPort
+      ];
+      allowedUDPPorts = [
+        cfg.tftpPort
+        cfg.proxyDhcpPort
+      ];
+    };
+  };
+}

--- a/outputs/iventoy.nix
+++ b/outputs/iventoy.nix
@@ -6,6 +6,7 @@
 }:
 let
   system = "x86_64-linux";
+  iventoyOverlay = import ../overlays/iventoy.nix;
   pkgs = import inputs.nixpkgs {
     inherit system;
     config = commonNixpkgsConfig;
@@ -15,9 +16,7 @@ in
 {
   nixosModules.iventoy = ../modules/nixos/services/iventoy.nix;
 
-  overlays.iventoy = final: prev: {
-    iventoy-free = prev.callPackage ../pkgs/iventoy-free.nix { };
-  };
+  overlays.iventoy = iventoyOverlay;
 
   packages.${system}.iventoy-free = pkgs.iventoy-free;
 }

--- a/outputs/iventoy.nix
+++ b/outputs/iventoy.nix
@@ -1,0 +1,23 @@
+{
+  inputs,
+  commonNixpkgsConfig,
+  commonOverlays,
+  ...
+}:
+let
+  system = "x86_64-linux";
+  pkgs = import inputs.nixpkgs {
+    inherit system;
+    config = commonNixpkgsConfig;
+    overlays = commonOverlays;
+  };
+in
+{
+  nixosModules.iventoy = ../modules/nixos/services/iventoy.nix;
+
+  overlays.iventoy = final: prev: {
+    iventoy-free = prev.callPackage ../pkgs/iventoy-free.nix { };
+  };
+
+  packages.${system}.iventoy-free = pkgs.iventoy-free;
+}

--- a/overlays/iventoy.nix
+++ b/overlays/iventoy.nix
@@ -1,0 +1,3 @@
+final: prev: {
+  iventoy-free = prev.callPackage ../pkgs/iventoy-free.nix { };
+}

--- a/overlays/packages.nix
+++ b/overlays/packages.nix
@@ -8,6 +8,11 @@
     proxmenux = prev.callPackage ../pkgs/proxmenux.nix { };
   })
 
+  # iVentoy Free Edition (PXE ISO menu server)
+  (final: prev: {
+    iventoy-free = prev.callPackage ../pkgs/iventoy-free.nix { };
+  })
+
   # Factory.ai Droid CLI
   (final: prev: {
     factory-droid = prev.callPackage ../pkgs/factory-droid.nix { };

--- a/overlays/packages.nix
+++ b/overlays/packages.nix
@@ -9,9 +9,7 @@
   })
 
   # iVentoy Free Edition (PXE ISO menu server)
-  (final: prev: {
-    iventoy-free = prev.callPackage ../pkgs/iventoy-free.nix { };
-  })
+  (import ./iventoy.nix)
 
   # Factory.ai Droid CLI
   (final: prev: {

--- a/pkgs/iventoy-free.nix
+++ b/pkgs/iventoy-free.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  patchelf,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "iventoy-free";
+  version = "1.0.26";
+
+  src = fetchurl {
+    url = "https://github.com/ventoy/PXE/releases/download/v${version}/iventoy-${version}-linux-free.tar.gz";
+    hash = "sha256-B/8JyTDHmw5OSCTAm34qYhlJh3e2vih+9NusgG8ofa8=";
+  };
+
+  nativeBuildInputs = [ patchelf ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/iventoy"
+    cp -a . "$out/share/iventoy"
+
+    patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
+      "$out/share/iventoy/lib/iventoy"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "iVentoy Free Edition PXE server";
+    homepage = "https://www.iventoy.com/";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## **User description**
## Summary
- package iVentoy Free v1.0.26 and expose it as a flake package/overlay
- add reusable `services.iventoy` NixOS module via `nixosModules.iventoy`
- enable iVentoy on router with ISOs under `/srv/pxe/images` and router-firewall ports
- configure router Technitium DHCP scope for iVentoy External mode
- scope root SSH key login to LAN and management recovery networks

## Dependency
- Depends on https://github.com/deepwatrcreatur/nix-router-optimized/pull/10 for the Technitium DHCP PXE scope options.

## Validation
- nix build .#packages.x86_64-linux.iventoy-free
- nix build .#nixosConfigurations.router.config.system.build.toplevel --override-input nix-router-optimized path:/home/deepwatrcreatur/flakes/nix-router-optimized
- nix build .#nixosConfigurations.router-backup.config.system.build.toplevel --override-input nix-router-optimized path:/home/deepwatrcreatur/flakes/nix-router-optimized
- git diff --cached --check
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iVentoy PXE service and package for serving boot ISOs and a web UI.

* **Configuration**
  * DHCP updated to provide iVentoy boot parameters and TFTP server addresses.
  * Firewall rules added to allow iVentoy traffic (TCP 16000, 26000; UDP 69, 4011).

* **Security**
  * Root SSH password login disabled; an explicit stable root SSH key was added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add iVentoy PXE boot support on the router and restrict root SSH access**

### What Changed
- The router now runs iVentoy so LAN clients can boot ISO images from `/srv/pxe/images`
- DHCP now points PXE clients to the router’s iVentoy boot file and TFTP/PXE proxy services for External mode booting
- Router firewall access is opened for iVentoy’s web UI and boot services
- Root SSH login is now limited to the LAN and management networks, with a fixed authorized key for recovery access

### Impact
`✅ LAN PXE boot from ISO files`
`✅ Fewer manual boot media steps`
`✅ Safer router recovery access`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
