### PR TITLE
feat(tooling): add cass-style session search helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,8 @@ For detailed managed authentication paths (including `gemini-cli`), see `docs/to
 
 **Recent additions**
 - Added `ast-grep` (`sg`) to the common tool set.
+- Added `cass-session-search` for CASS-style search across local agent
+  sessions; see `docs/cass-session-search.md` for usage and privacy notes.
 
 ### Git Workflow
 Before pushing changes that affect remote hosts:

--- a/docs/cass-session-search.md
+++ b/docs/cass-session-search.md
@@ -1,0 +1,56 @@
+# Cass-style Session Search
+
+This repo provides a small helper, `cass-session-search`, to make prior
+coding-agent sessions searchable from terminal environments that use this
+flake.
+
+## Command
+
+```bash
+cass-session-search [--roots] [RG_ARGS...] PATTERN
+```
+
+Examples:
+
+```bash
+cass-session-search router dashboard
+cass-session-search --fixed-strings 'agent-guards.nix'
+cass-session-search --roots
+```
+
+The command is a thin wrapper around `ripgrep` that targets local agent
+session directories.
+
+## Session Roots
+
+By default, the following roots are searched (when they exist):
+
+- `$HOME/.copilot/session-state` (GitHub Copilot CLI sessions)
+- `$HOME/.claude/sessions` (Claude Code sessions)
+- `$HOME/.gemini/history` (Gemini CLI per-project history)
+
+You can override the roots by setting `CASS_SESSION_ROOTS` to a
+colon-separated list of directories before running the command.
+
+## Rollout Model
+
+- **Host-local only**: the search operates on local session files and does
+  not talk to any remote service.
+- **No automatic docs export**: results stay in the terminal; this command
+  does not write back into the repo or other documentation.
+
+## Privacy and Retention
+
+- All data searched is already present on the local machine under your
+  normal user account.
+- The command does not transmit session content over the network.
+- If you want to exclude specific directories, either remove them from
+  `CASS_SESSION_ROOTS` or point `CASS_SESSION_ROOTS` at a narrower set of
+  paths.
+
+## Refreshing the Index
+
+`cass-session-search` does not maintain its own index; it searches the
+current contents of the configured session directories each time it runs.
+To "refresh" the view, ensure your agent tools have flushed their latest
+sessions to disk and rerun the search command.

--- a/docs/tooling-work-items/15-cass-session-search-integration.md
+++ b/docs/tooling-work-items/15-cass-session-search-integration.md
@@ -1,6 +1,6 @@
 # 15 CASS Session Search Integration
 
-Status: `ready`
+Status: `done`
 
 Suggested branch: `feat/tooling-cass-session-search`
 
@@ -40,6 +40,22 @@ many recurring tasks where prior debugging context matters:
 - inventing a new long-form documentation system
 - automatically turning every session into repo docs
 - solving procedural memory extraction in the same PR
+
+## Implementation (current)
+
+- `scripts/cass-session-search.sh` implements a small wrapper around
+  `ripgrep` that searches local agent session directories.
+- `modules/home-manager/common/cass-session-search.nix` packages this as
+  a `cass-session-search` binary and is imported by
+  `modules/home-manager/common/coding-agents.nix`, with
+  `programs.cass-session-search.enable` defaulting to `true`.
+- By default, the command searches these roots when they exist:
+  `$HOME/.copilot/session-state`, `$HOME/.claude/sessions`, and
+  `$HOME/.gemini/history`. Operators can override this via the
+  `CASS_SESSION_ROOTS` environment variable.
+- The behavior and privacy model are documented in
+  `docs/cass-session-search.md`, and `AGENTS.md` links to that doc for
+  agent-facing discovery.
 
 ## Validation
 

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -32,7 +32,7 @@ wrappers, shell defaults, and related repo operations.
 4. [`25-agent-build-cache-fallback-and-trust.md`](./25-agent-build-cache-fallback-and-trust.md) - `in-progress`
 5. [`14-dcg-pretooluse-guard.md`](./14-dcg-pretooluse-guard.md) - `done`
 6. [`27-gemini-cli-managed-auth-path.md`](./27-gemini-cli-managed-auth-path.md) - `done`
-7. [`15-cass-session-search-integration.md`](./15-cass-session-search-integration.md) - `ready`
+7. [`15-cass-session-search-integration.md`](./15-cass-session-search-integration.md) - `done`
 8. [`16-cm-procedural-memory-bootstrap.md`](./16-cm-procedural-memory-bootstrap.md) - `ready`
 9. [`17-agent-mail-workflow-fit.md`](./17-agent-mail-workflow-fit.md) - `ready`
 10. [`18-beads-task-graph-integration.md`](./18-beads-task-graph-integration.md) - `ready`

--- a/modules/home-manager/common/cass-session-search.nix
+++ b/modules/home-manager/common/cass-session-search.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.cass-session-search;
+  cassPackage = pkgs.writeShellApplication {
+    name = "cass-session-search";
+    runtimeInputs = [ pkgs.ripgrep ];
+    text = builtins.readFile ../../../scripts/cass-session-search.sh;
+  };
+in
+{
+  options.programs.cass-session-search = {
+    enable = lib.mkEnableOption "CASS-style search over local coding-agent sessions";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cassPackage ];
+  };
+}

--- a/modules/home-manager/common/coding-agents.nix
+++ b/modules/home-manager/common/coding-agents.nix
@@ -12,9 +12,11 @@
     inputs.nix-rtk.homeManagerModules.default
     inputs.qmd.homeModules.default
     ./agent-guards.nix
+    ./cass-session-search.nix
   ];
 
   programs.agent-guards.enable = lib.mkDefault true;
+  programs.cass-session-search.enable = lib.mkDefault true;
 
   # Enable RTK hooks with Claude enabled by default
   programs.rtk-hooks = {

--- a/scripts/cass-session-search.sh
+++ b/scripts/cass-session-search.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: cass-session-search [--roots] [RG_ARGS...] PATTERN
+
+Search prior coding-agent sessions (Claude, Copilot, Gemini) for PATTERN.
+
+Examples:
+  cass-session-search router dashboard
+  cass-session-search --fixed-strings 'agent-guards.nix'
+  cass-session-search --roots
+
+Options:
+  --roots   Print the session roots that will be searched and exit.
+
+All additional arguments are passed through to ripgrep. The default
+session roots are:
+  - $HOME/.copilot/session-state
+  - $HOME/.claude/sessions
+  - $HOME/.gemini/history
+
+You can override the search roots by setting CASS_SESSION_ROOTS to a
+colon-separated list of directories.
+EOF
+}
+
+if [[ "${1-}" == "--help" || "${1-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+# Build list of session roots
+roots=()
+
+if [[ -n "${CASS_SESSION_ROOTS-}" ]]; then
+  IFS=':' read -r -a roots <<<"$CASS_SESSION_ROOTS"
+else
+  default_roots=(
+    "$HOME/.copilot/session-state"
+    "$HOME/.claude/sessions"
+    "$HOME/.gemini/history"
+  )
+  for path in "${default_roots[@]}"; do
+    if [[ -d "$path" ]]; then
+      roots+=("$path")
+    fi
+  done
+fi
+
+if [[ "${1-}" == "--roots" ]]; then
+  if ((${#roots[@]} == 0)); then
+    echo "cass-session-search: no session roots found" >&2
+    exit 1
+  fi
+  printf '%s
+' "${roots[@]}"
+  exit 0
+fi
+
+if ((${#roots[@]} == 0)); then
+  echo "cass-session-search: no session roots found" >&2
+  echo "Set CASS_SESSION_ROOTS or ensure local agent session directories exist." >&2
+  exit 1
+fi
+
+if ((${#} == 0)); then
+  usage >&2
+  exit 1
+fi
+
+# Delegate to ripgrep; runtimeInputs ensure rg is on PATH.
+exec rg --no-messages --hidden "$@" "${roots[@]}"


### PR DESCRIPTION
## **User description**
Expose cass-session-search wrapper over ripgrep for local agent sessions (Claude, Copilot, Gemini), wired via a Home Manager module and documented for agents.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
Search local agent session history from the terminal

### What Changed
- Added a new `cass-session-search` command that searches local Claude, Copilot, and Gemini session files for a term you provide
- The command can show which session folders it will search, and it lets you override the default folders with an environment variable
- Enabled the command by default for the common coding-agent setup and added user-facing docs and guidance

### Impact
`✅ Faster lookup of past debugging context`
`✅ Easier search across Claude, Copilot, and Gemini sessions`
`✅ Clearer guidance on where session data is read from`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
