### PR TITLE
feat(signing): wire SSH signing to all hosts, drop gpg-agent imports

### DIFF
--- a/docs/tooling-work-items/24-ssh-commit-signing-modules.md
+++ b/docs/tooling-work-items/24-ssh-commit-signing-modules.md
@@ -1,0 +1,55 @@
+# 24 SSH Commit Signing — Core Modules
+
+Status: `in-progress`
+
+Suggested branch: `feat/tooling-ssh-signing-modules`
+
+## Goal
+
+Replace GPG commit signing with SSH key signing across the fleet.
+Deliver two new HM modules and update `git.nix` / `users/root/git.nix`.
+
+## Why
+
+GPG adds pinentry complexity, platform-specific agents (pinentry-mac,
+pinentry-gtk2, pinentry-curses), and per-host workarounds. SSH signing
+uses the same key already in the SSH agent — no extra daemon, no
+passphrase prompts for agents, identical behaviour on NixOS and darwin.
+
+## Scope
+
+- `modules/home-manager/git-ssh-signing.nix`
+  - sets `gpg.format = "ssh"`, `commit.gpgsign = true`
+  - sets `user.signingkey = "~/.ssh/id_ed25519.pub"`
+  - sets `gpg.ssh.allowedSignersFile = "~/.config/git/allowed_signers"`
+  - `home.activation` script writes `allowed_signers` from the live pubkey
+- `modules/home-manager/ssh-agent.nix`
+  - Linux: `services.ssh-agent.enable = true`
+  - Darwin: `programs.ssh.extraConfig` with `AddKeysToAgent yes` / `UseKeychain yes`
+- `modules/home-manager/git.nix`
+  - switch `user.signingkey` to SSH pubkey path
+  - replace `gpg.format` (remove implicit OpenPGP default)
+  - remove all `GPG_TTY` shell export blocks (bash/zsh/fish/nushell)
+- `users/root/git.nix`
+  - switch `signing.key` to SSH pubkey path
+  - remove `0x` GPG key ID
+
+## Non-Goals
+
+- Host wiring (done in item 25)
+- Deletion of GPG modules (done in item 26)
+
+## Validation
+
+- `nix-instantiate --parse` on both new modules
+- eval `nixosConfigurations.workstation.config.programs.git.settings`
+  confirms `gpg.format = "ssh"` and no `gpgsign` referencing the old key
+
+## Dependencies
+
+None — can land independently.
+
+## Follow-up
+
+- Item 25: wire all hosts
+- Item 26: remove GPG modules

--- a/docs/tooling-work-items/25-ssh-signing-host-wiring.md
+++ b/docs/tooling-work-items/25-ssh-signing-host-wiring.md
@@ -1,6 +1,6 @@
 # 25 SSH Commit Signing — Host Wiring
 
-Status: `ready`
+Status: `in-progress`
 
 Suggested branch: `feat/tooling-ssh-signing-hosts`
 

--- a/docs/tooling-work-items/25-ssh-signing-host-wiring.md
+++ b/docs/tooling-work-items/25-ssh-signing-host-wiring.md
@@ -1,0 +1,52 @@
+# 25 SSH Commit Signing — Host Wiring
+
+Status: `ready`
+
+Suggested branch: `feat/tooling-ssh-signing-hosts`
+
+## Goal
+
+Replace all GPG module imports across every host with the new SSH
+signing + SSH agent modules from item 24.
+
+## Why
+
+Items 24 delivers the modules; this item wires them in everywhere so
+the full fleet drops its gpg-agent dependency.
+
+## Scope
+
+Replace GPG imports in:
+
+### deepwatrcreatur user (8 hosts)
+- `users/deepwatrcreatur/hosts/macminim4/default.nix` — `gpg-mac.nix`
+- `users/deepwatrcreatur/hosts/workstation/default.nix` — `gpg-agent-cross-de.nix`
+- `users/deepwatrcreatur/hosts/homeserver/default.nix` — `gpg-agent-ssh.nix`
+- `users/deepwatrcreatur/hosts/inference-vm/default.nix` — `gpg-agent-ssh.nix`
+- `users/deepwatrcreatur/hosts/attic-cache/default.nix` — `gpg-agent-ssh.nix`
+- `users/deepwatrcreatur/hosts/podman/default.nix` — `gpg-agent-ssh.nix`
+- `users/deepwatrcreatur/hosts/authentik-host/default.nix` — `gpg-agent-ssh.nix`
+- `users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/default.nix` — `gpg-agent-ssh.nix`
+
+### root user (4 hosts)
+- `users/root/default.nix` — `gpg-cli.nix`
+- `users/root/hosts/attic-cache/default.nix` — `gpg-cli.nix`
+- `users/root/hosts/proxmox/default.nix` — `gpg-cli.nix`
+- `users/root/hosts/nixos-lxc/nixos_lxc/default.nix` — `gpg-cli.nix`
+
+Each replacement: remove GPG module import, add `git-ssh-signing.nix`
+import and (for deepwatrcreatur) `ssh-agent.nix` import.
+
+## Non-Goals
+
+- Module creation (item 24)
+- Module deletion (item 26)
+
+## Validation
+
+- `nix-instantiate --parse` on all modified host files
+- eval at least one nixos and one darwin host confirms no gpg-agent
+
+## Dependencies
+
+- Item 24 must be merged first (or developed in the same branch)

--- a/docs/tooling-work-items/26-remove-gpg-modules.md
+++ b/docs/tooling-work-items/26-remove-gpg-modules.md
@@ -1,0 +1,45 @@
+# 26 Remove GPG Modules
+
+Status: `ready`
+
+Suggested branch: `feat/tooling-remove-gpg-modules`
+
+## Goal
+
+Delete the five GPG HM modules and `ssh-auth-session.nix` (which was
+only activated when gpg-agent SSH support was enabled) once no host
+imports them.
+
+## Why
+
+Dead code. All hosts will have migrated to SSH signing by item 25.
+Removing the files prevents future accidental re-use and shrinks the
+module surface.
+
+## Scope
+
+Delete:
+- `modules/home-manager/gpg-agent-cross-de.nix`
+- `modules/home-manager/gpg-agent-ssh.nix`
+- `modules/home-manager/gpg-cli.nix`
+- `modules/home-manager/gpg-desktop-linux.nix`
+- `modules/home-manager/gpg-mac.nix`
+- `modules/home-manager/common/ssh-auth-session.nix` (guarded by
+  `services.gpg-agent.enable` — no longer needed)
+
+Verify nothing else imports these files before deleting.
+
+## Non-Goals
+
+- Removing `gnupg` from any host if it's used for non-signing purposes
+  (e.g. secret decryption via age). Check before deleting.
+
+## Validation
+
+- `grep -r "gpg-agent\|gpg-cli\|gpg-mac\|gpg-desktop\|ssh-auth-session"
+  modules/ users/` returns zero results after deletion
+- Full eval of a nixos and a darwin host succeeds
+
+## Dependencies
+
+- Item 25 must be merged first

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -26,4 +26,6 @@ wrappers, shell defaults, and related repo operations.
 
 ## Current Ranked Queue
 
-No active items.
+1. [24 SSH Commit Signing — Core Modules](./24-ssh-commit-signing-modules.md) — `in-progress`
+2. [25 SSH Commit Signing — Host Wiring](./25-ssh-signing-host-wiring.md) — `ready`, depends on 24
+3. [26 Remove GPG Modules](./26-remove-gpg-modules.md) — `ready`, depends on 25

--- a/modules/home-manager/git-ssh-signing.nix
+++ b/modules/home-manager/git-ssh-signing.nix
@@ -1,0 +1,32 @@
+# modules/home-manager/git-ssh-signing.nix
+#
+# Configures git to sign commits with the host's SSH key instead of GPG.
+# Works identically on NixOS and darwin: no pinentry, no gpg-agent.
+#
+# Requires: ~/.ssh/id_ed25519 (or id_rsa) to exist on the host.
+# GitHub: register the same key under Settings → SSH keys → Signing keys.
+{ config, lib, ... }:
+let
+  email = config.programs.git.settings.user.email or "deepwatrcreatur@gmail.com";
+  allowedSigners = "${config.xdg.configHome}/git/allowed_signers";
+in
+{
+  programs.git.settings = {
+    gpg.format = "ssh";
+    commit.gpgsign = true;
+    tag.gpgsign = true;
+    "user".signingkey = "~/.ssh/id_ed25519.pub";
+    "gpg.ssh".allowedSignersFile = allowedSigners;
+  };
+
+  # Write allowed_signers at activation time from the live public key.
+  # This is needed for `git log --show-signature` to verify local commits.
+  home.activation.writeGitAllowedSigners = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    _pub="$HOME/.ssh/id_ed25519.pub"
+    _out="${allowedSigners}"
+    if [ -f "$_pub" ]; then
+      mkdir -p "$(dirname "$_out")"
+      printf '%s namespaces="git" %s\n' "${email}" "$(cat "$_pub")" > "$_out"
+    fi
+  '';
+}

--- a/modules/home-manager/git.nix
+++ b/modules/home-manager/git.nix
@@ -168,13 +168,6 @@ in
       # See docs/tooling-work-items/01-github-token-shell-export-removal.md
       # and pkgs/gh-fnox.nix for the wrapper/credential flow.
 
-      # GPG settings for automated commits (prevents password prompts in CI/agents)
-      export GPG_TTY=$(tty 2>/dev/null || echo "")
-      # Allow automated tools to bypass pinentry when in non-interactive mode
-      if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
-        export GPG_TERMINAL_PROMPT_DISABLE=1
-      fi
-
       # SSH environment: disable interactive TUI features over SSH
       if [ -n "$SSH_CONNECTION" ]; then
         export CI=true
@@ -187,13 +180,6 @@ in
       # GitHub token is intentionally not exported globally anymore.
       # See docs/tooling-work-items/01-github-token-shell-export-removal.md
       # and pkgs/gh-fnox.nix for the wrapper/credential flow.
-
-      # GPG settings for automated commits (prevents password prompts in CI/agents)
-      export GPG_TTY=$(tty 2>/dev/null || echo "")
-      # Allow automated tools to bypass pinentry when in non-interactive mode
-      if [ -z "$TERM" ] || [ "$TERM" = "dumb" ]; then
-        export GPG_TERMINAL_PROMPT_DISABLE=1
-      fi
 
       # SSH environment: disable interactive TUI features over SSH
       if [ -n "$SSH_CONNECTION" ]; then
@@ -208,13 +194,6 @@ in
       # See docs/tooling-work-items/01-github-token-shell-export-removal.md
       # and pkgs/gh-fnox.nix for the wrapper/credential flow.
 
-      # GPG settings for automated commits (prevents password prompts in CI/agents)
-      set -gx GPG_TTY (tty 2>/dev/null; or echo "")
-      # Allow automated tools to bypass pinentry when in non-interactive mode
-      if test -z "$TERM" -o "$TERM" = "dumb"
-        set -gx GPG_TERMINAL_PROMPT_DISABLE 1
-      end
-
       # SSH environment: disable interactive TUI features over SSH
       if test -n "$SSH_CONNECTION"
         set -gx CI true
@@ -227,13 +206,6 @@ in
       # GitHub token is intentionally not exported globally anymore.
       # See docs/tooling-work-items/01-github-token-shell-export-removal.md
       # and pkgs/gh-fnox.nix for the wrapper/credential flow.
-
-      # GPG settings for automated commits (prevents password prompts in CI/agents)
-      $env.GPG_TTY = (try { tty } catch { "" })
-      # Allow automated tools to bypass pinentry when in non-interactive mode
-      if ($env.TERM == "" or $env.TERM == "dumb") {
-        $env.GPG_TERMINAL_PROMPT_DISABLE = "1"
-      }
 
       # SSH environment: disable interactive TUI features over SSH
       if ($env.SSH_CONNECTION? != null) {
@@ -274,8 +246,10 @@ in
         "credential \"https://github.com\"".helper = "!gh auth git-credential";
         "credential \"https://gist.github.com\"".helper = "!gh auth git-credential";
 
+        gpg.format = "ssh";
         commit.gpgsign = true;
-        user.signingkey = "EF1502C27653693B";
+        tag.gpgsign = true;
+        user.signingkey = "~/.ssh/id_ed25519.pub";
 
         # Delta settings
         delta.navigate = true;

--- a/modules/home-manager/ssh-agent.nix
+++ b/modules/home-manager/ssh-agent.nix
@@ -1,0 +1,21 @@
+# modules/home-manager/ssh-agent.nix
+#
+# Standalone SSH auth agent — no gpg-agent dependency.
+#
+# Linux:  starts ssh-agent as a systemd user service (home-manager).
+# Darwin: macOS Keychain handles the SSH agent natively; we just set
+#         AddKeysToAgent + UseKeychain in ssh config so keys are loaded
+#         on first use without a passphrase prompt every session.
+{ config, lib, pkgs, ... }:
+{
+  # Linux: systemd user SSH agent
+  services.ssh-agent.enable = lib.mkIf pkgs.stdenv.isLinux true;
+
+  # Darwin: delegate to macOS Keychain agent
+  programs.ssh.extraConfig = lib.mkIf pkgs.stdenv.isDarwin ''
+    Host *
+      AddKeysToAgent yes
+      UseKeychain yes
+      IdentityFile ~/.ssh/id_ed25519
+  '';
+}

--- a/users/deepwatrcreatur/hosts/attic-cache/default.nix
+++ b/users/deepwatrcreatur/hosts/attic-cache/default.nix
@@ -14,7 +14,8 @@
     ./rbw.nix
     ../../../../modules/home-manager/git.nix
 
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
   ];
 
   # Set home directory for Home Manager

--- a/users/deepwatrcreatur/hosts/authentik-host/default.nix
+++ b/users/deepwatrcreatur/hosts/authentik-host/default.nix
@@ -7,7 +7,8 @@
   imports = [
     ../..
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
   ];
 
   home.homeDirectory = "/home/deepwatrcreatur";

--- a/users/deepwatrcreatur/hosts/homeserver/default.nix
+++ b/users/deepwatrcreatur/hosts/homeserver/default.nix
@@ -13,7 +13,8 @@
     ./nh.nix
     ./rbw.nix
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ../../../../modules/home-manager/agenix-user-secrets.nix
   ];
 

--- a/users/deepwatrcreatur/hosts/inference-vm/default.nix
+++ b/users/deepwatrcreatur/hosts/inference-vm/default.nix
@@ -10,7 +10,8 @@
   # Inference VM specific configuration for deepwatrcreatur
   imports = [
     ../.. # Import default user config
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ./just.nix
     ../../../../modules/home-manager/gpu-monitoring.nix
     # Temporarily disable to fix home-manager startup failure

--- a/users/deepwatrcreatur/hosts/macminim4/default.nix
+++ b/users/deepwatrcreatur/hosts/macminim4/default.nix
@@ -11,7 +11,8 @@
     ../../default.nix # Import main user config (includes SSH keys and common modules)
     ../../../../modules/home-manager/ghostty
     #../../../../modules/home-manager/zed.nix
-    ../../../../modules/home-manager/gpg-mac.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ../../../../modules/home-manager/env-darwin.nix
 
     ./nh.nix

--- a/users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/default.nix
+++ b/users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/default.nix
@@ -13,7 +13,8 @@
     ./nh.nix
     ./rbw.nix
     ../../../../../modules/home-manager/git.nix
-    ../../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../../modules/home-manager/ssh-agent.nix
     #../../../../../modules/home-manager/rclone.nix
   ];
 

--- a/users/deepwatrcreatur/hosts/podman/default.nix
+++ b/users/deepwatrcreatur/hosts/podman/default.nix
@@ -10,7 +10,8 @@
   imports = [
     ../.. # default config for deepwatrcreatur (up 2 levels)
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ../../../../modules/home-manager/agenix-user-secrets.nix
   ];
 

--- a/users/deepwatrcreatur/hosts/workstation/default.nix
+++ b/users/deepwatrcreatur/hosts/workstation/default.nix
@@ -14,7 +14,8 @@
     ../../../../modules/home-manager/agenix-user-secrets.nix
     ../../../../modules/home-manager/gnome-cosmic-style.nix
     ../../../../modules/home-manager/ghostty
-    ../../../../modules/home-manager/gpg-agent-cross-de.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ../../../../modules/home-manager/zed.nix
     ../../../../modules/home-manager/common/dmux.nix
   ];

--- a/users/root/default.nix
+++ b/users/root/default.nix
@@ -94,7 +94,7 @@ in
     ./git.nix # <--- Import git configuration
     ./env.nix
     ../../modules/home-manager/git.nix # Keep this import if it provides other common git modules
-    ../../modules/home-manager/gpg-cli.nix
+    ../../modules/home-manager/git-ssh-signing.nix
     ../../modules/home-manager
   ];
 

--- a/users/root/git.nix
+++ b/users/root/git.nix
@@ -14,9 +14,8 @@
         email = lib.mkForce "deepwatrcreatur@gmail.com";
       };
       signing.signByDefault = lib.mkForce true;
-    };
-    signing = {
-      key = "0xEF1502C27653693B";
+      gpg.format = lib.mkForce "ssh";
+      "user".signingkey = lib.mkForce "~/.ssh/id_ed25519.pub";
     };
   };
 }

--- a/users/root/hosts/attic-cache/default.nix
+++ b/users/root/hosts/attic-cache/default.nix
@@ -12,7 +12,7 @@
     ./justfile.nix
     ./nh.nix
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-cli.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
   ];
 
   # Disable attic-client for root (no SOPS secrets configured)

--- a/users/root/hosts/nixos-lxc/nixos_lxc/default.nix
+++ b/users/root/hosts/nixos-lxc/nixos_lxc/default.nix
@@ -12,7 +12,7 @@
     ./nixos_lxc-justfile.nix
     ./nh.nix
     ../../../../../modules/home-manager/git.nix
-    ../../../../../modules/home-manager/gpg-cli.nix
+    ../../../../../modules/home-manager/git-ssh-signing.nix
   ];
 
   # Add packages

--- a/users/root/hosts/proxmox/default.nix
+++ b/users/root/hosts/proxmox/default.nix
@@ -14,7 +14,7 @@ in
     ./nh.nix
     ./proxmox-shell-extra.nix
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-cli.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
     # Selectively import only essential modules to avoid activation issues
     ../../../../modules/home-manager/user-secrets.nix
     ../../../../modules/home-manager/agenix-user-secrets.nix


### PR DESCRIPTION
## **User description**
## Summary

Replaces all GPG module imports across 12 host configs with the new SSH signing stack from PR #112.

**deepwatrcreatur (8 hosts)** — swap to `git-ssh-signing.nix` + `ssh-agent.nix`:
- macminim4, workstation, homeserver, inference-vm, attic-cache, podman, authentik-host, nixos-lxc

**root (4 hosts)** — swap to `git-ssh-signing.nix` (no ssh-agent; root doesn't interactively sign):
- default, attic-cache, proxmox, nixos-lxc

GPG module files are left in place; deleted in follow-up PR (item 26).

## Dependencies

Stacks on top of #112 (`feat/tooling-ssh-signing-modules`). Base branch set accordingly — merge 112 first, then rebase this onto main.

## Test plan

- [x] `nix-instantiate --parse` on macminim4, workstation, homeserver, root/proxmox — clean
- [ ] `darwin-rebuild test` on macminim4 confirms no gpg-agent in process list
- [ ] `nixos-rebuild test` on workstation confirms `services.gpg-agent` is gone
- [ ] `git commit` succeeds without passphrase prompt on a freshly booted session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Switch host configs to SSH commit signing**

### What Changed
- Git commit and tag signing now uses SSH keys instead of GPG on all updated hosts.
- Deepwatrcreatur hosts and root hosts now load the new SSH signing setup instead of the old GPG agent modules.
- Shell startup no longer exports GPG-related variables that were only needed for the old signing flow.
- Local signature verification files are now generated from the active SSH public key so signed commits can be checked locally.

### Impact
`✅ Fewer passphrase prompts when committing`
`✅ Consistent signing across macOS and Linux`
`✅ Lower dependency on gpg-agent for Git signing`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=xIowk5L0Q5ulzYi688bBlXie8kVnUbXhHgoz1DnrY9k&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
