### PR TITLE
feat(signing): wire SSH signing to all hosts, drop gpg-agent imports

### DIFF
--- a/docs/tooling-work-items/25-ssh-signing-host-wiring.md
+++ b/docs/tooling-work-items/25-ssh-signing-host-wiring.md
@@ -1,6 +1,6 @@
 # 25 SSH Commit Signing — Host Wiring
 
-Status: `ready`
+Status: `in-progress`
 
 Suggested branch: `feat/tooling-ssh-signing-hosts`
 

--- a/users/deepwatrcreatur/hosts/attic-cache/default.nix
+++ b/users/deepwatrcreatur/hosts/attic-cache/default.nix
@@ -14,7 +14,8 @@
     ./rbw.nix
     ../../../../modules/home-manager/git.nix
 
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
   ];
 
   # Set home directory for Home Manager

--- a/users/deepwatrcreatur/hosts/authentik-host/default.nix
+++ b/users/deepwatrcreatur/hosts/authentik-host/default.nix
@@ -7,7 +7,8 @@
   imports = [
     ../..
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
   ];
 
   home.homeDirectory = "/home/deepwatrcreatur";

--- a/users/deepwatrcreatur/hosts/homeserver/default.nix
+++ b/users/deepwatrcreatur/hosts/homeserver/default.nix
@@ -13,7 +13,8 @@
     ./nh.nix
     ./rbw.nix
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ../../../../modules/home-manager/agenix-user-secrets.nix
   ];
 

--- a/users/deepwatrcreatur/hosts/inference-vm/default.nix
+++ b/users/deepwatrcreatur/hosts/inference-vm/default.nix
@@ -10,7 +10,8 @@
   # Inference VM specific configuration for deepwatrcreatur
   imports = [
     ../.. # Import default user config
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ./just.nix
     ../../../../modules/home-manager/gpu-monitoring.nix
     # Temporarily disable to fix home-manager startup failure

--- a/users/deepwatrcreatur/hosts/macminim4/default.nix
+++ b/users/deepwatrcreatur/hosts/macminim4/default.nix
@@ -11,7 +11,8 @@
     ../../default.nix # Import main user config (includes SSH keys and common modules)
     ../../../../modules/home-manager/ghostty
     #../../../../modules/home-manager/zed.nix
-    ../../../../modules/home-manager/gpg-mac.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ../../../../modules/home-manager/env-darwin.nix
 
     ./nh.nix

--- a/users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/default.nix
+++ b/users/deepwatrcreatur/hosts/nixos-lxc/nixos_lxc/default.nix
@@ -13,7 +13,8 @@
     ./nh.nix
     ./rbw.nix
     ../../../../../modules/home-manager/git.nix
-    ../../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../../modules/home-manager/ssh-agent.nix
     #../../../../../modules/home-manager/rclone.nix
   ];
 

--- a/users/deepwatrcreatur/hosts/podman/default.nix
+++ b/users/deepwatrcreatur/hosts/podman/default.nix
@@ -10,7 +10,8 @@
   imports = [
     ../.. # default config for deepwatrcreatur (up 2 levels)
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-agent-ssh.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ../../../../modules/home-manager/agenix-user-secrets.nix
   ];
 

--- a/users/deepwatrcreatur/hosts/workstation/default.nix
+++ b/users/deepwatrcreatur/hosts/workstation/default.nix
@@ -14,7 +14,8 @@
     ../../../../modules/home-manager/agenix-user-secrets.nix
     ../../../../modules/home-manager/gnome-cosmic-style.nix
     ../../../../modules/home-manager/ghostty
-    ../../../../modules/home-manager/gpg-agent-cross-de.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
+    ../../../../modules/home-manager/ssh-agent.nix
     ../../../../modules/home-manager/zed.nix
     ../../../../modules/home-manager/common/dmux.nix
   ];

--- a/users/root/default.nix
+++ b/users/root/default.nix
@@ -94,7 +94,7 @@ in
     ./git.nix # <--- Import git configuration
     ./env.nix
     ../../modules/home-manager/git.nix # Keep this import if it provides other common git modules
-    ../../modules/home-manager/gpg-cli.nix
+    ../../modules/home-manager/git-ssh-signing.nix
     ../../modules/home-manager
   ];
 

--- a/users/root/hosts/attic-cache/default.nix
+++ b/users/root/hosts/attic-cache/default.nix
@@ -12,7 +12,7 @@
     ./justfile.nix
     ./nh.nix
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-cli.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
   ];
 
   # Disable attic-client for root (no SOPS secrets configured)

--- a/users/root/hosts/nixos-lxc/nixos_lxc/default.nix
+++ b/users/root/hosts/nixos-lxc/nixos_lxc/default.nix
@@ -12,7 +12,7 @@
     ./nixos_lxc-justfile.nix
     ./nh.nix
     ../../../../../modules/home-manager/git.nix
-    ../../../../../modules/home-manager/gpg-cli.nix
+    ../../../../../modules/home-manager/git-ssh-signing.nix
   ];
 
   # Add packages

--- a/users/root/hosts/proxmox/default.nix
+++ b/users/root/hosts/proxmox/default.nix
@@ -14,7 +14,7 @@ in
     ./nh.nix
     ./proxmox-shell-extra.nix
     ../../../../modules/home-manager/git.nix
-    ../../../../modules/home-manager/gpg-cli.nix
+    ../../../../modules/home-manager/git-ssh-signing.nix
     # Selectively import only essential modules to avoid activation issues
     ../../../../modules/home-manager/user-secrets.nix
     ../../../../modules/home-manager/agenix-user-secrets.nix


### PR DESCRIPTION
## **User description**
## Summary

Replaces all GPG module imports across 12 host configs with the new SSH signing stack from #112.

**deepwatrcreatur (8 hosts)** — swap to `git-ssh-signing.nix` + `ssh-agent.nix`:
- macminim4, workstation, homeserver, inference-vm, attic-cache, podman, authentik-host, nixos-lxc

**root (4 hosts)** — swap to `git-ssh-signing.nix` (no ssh-agent; root doesn't interactively sign):
- default, attic-cache, proxmox, nixos-lxc

GPG module files are left in place; deleted in follow-up PR (item 26).

Replaces #113 (rebased cleanly onto main after #112 squash-merge).

## Test plan

- [x] `nix-instantiate --parse` on macminim4, workstation, homeserver, root — clean
- [ ] `darwin-rebuild test` on macminim4 confirms no gpg-agent
- [ ] `nixos-rebuild test` on workstation confirms no `services.gpg-agent`
- [ ] `git commit` succeeds without passphrase prompt on a fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SSH signing host wiring workflow status to in-progress.

* **Chores**
  * Refactored SSH and Git signing authentication configuration across multiple host environments to use dedicated signing and agent modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Switch all configured hosts to SSH-based Git commit signing**

### What Changed
- Hosts that used GPG signing now use the SSH signing setup instead, so commits can be signed without the old GPG agent flow.
- Deepwatrcreatur hosts now load SSH signing plus an SSH agent, which keeps interactive signing available on machines where the user signs commits directly.
- Root hosts now use SSH signing only, matching their non-interactive use and removing the GPG CLI-based signing setup.
- The SSH signing work item is marked as in progress in the docs.

### Impact
`✅ Fewer GPG signing prompts`
`✅ Easier commit signing on all configured hosts`
`✅ Cleaner root signing setup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=kdHaBS2_p0hWqAeuimYqap3Yjq7SInQ4PB-1KA6lsmY&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
