### PR TITLE
fix(router): NTP server via router-ntp module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1260,11 +1260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776031257,
-        "narHash": "sha256-Id2LCO/PXIfjQh3iJUnZd6kyjTWNYh5McE0zrm/69Rk=",
+        "lastModified": 1776485057,
+        "narHash": "sha256-POZImFwlK6ALHuSLeAheps7EOt55an6BAbmWg1a44V4=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "0eccfa36921ad50b2a80608d6cc97f22031573ca",
+        "rev": "171f7b36fbf389a4096db695160b33824814471d",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -56,7 +56,7 @@ in
   # NTP server — serves LAN clients (advertised via DHCP option 42 above).
   services.router-ntp = {
     enable = true;
-    lanSubnets = [ "10.10.0.0/16" ];
+    lanSubnets = [ topology.networks.lan.cidr ];
   };
 
   # NAT is handled by nftables (see nftables.nix)

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -53,6 +53,12 @@ in
     };
   };
 
+  # NTP server — serves LAN clients (advertised via DHCP option 42 above).
+  services.router-ntp = {
+    enable = true;
+    lanSubnets = [ "10.10.0.0/16" ];
+  };
+
   # NAT is handled by nftables (see nftables.nix)
   networking.nat.enable = false;
 }


### PR DESCRIPTION
## **User description**
## Summary

- Adds `modules/router-ntp.nix` to `nix-router-optimized` — a proper `services.router-ntp` module with `mkEnableOption`, configurable upstream servers, LAN subnets, and local stratum
- The module enables `services.chrony`, disables `systemd-timesyncd` (client-only), and opens UDP 123 on trusted interfaces via `services.router-firewall.trustedUdpPorts`
- Updates `hosts/nixos/router/networking.nix` to use `services.router-ntp.enable = true; lanSubnets = ["10.10.0.0/16"]` instead of inline chrony config
- Bumps `nix-router-optimized` flake input to `171f7b3`

## Test plan

- [ ] Deploy to router and confirm `systemctl status chronyd` is active
- [ ] Verify `ss -ulnp | grep :123` shows chrony listening
- [ ] Verify LAN client (e.g. SIP phone) picks up correct time via DHCP option 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* NTP server now available on the router to provide time synchronization for LAN clients on the 10.10.0.0/16 subnet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Enable LAN NTP service on the router**

### What Changed
- The router now serves time to LAN clients through the dedicated NTP service
- LAN access is limited to the 10.10.0.0/16 network
- DHCP continues to advertise the router as the local time server

### Impact
`✅ Working time sync for LAN devices`
`✅ Fewer client clock drift issues`
`✅ Clearer router time server setup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=fUWSk8yNrdDDDBMBQzAuxHweWujUZg4BVZtHBz9TFvQ&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
