### PR TITLE
docs(router): Kea DHCP migration work items 30-32

### DIFF
--- a/docs/router-work-items/30-kea-tsig-key-provisioning.md
+++ b/docs/router-work-items/30-kea-tsig-key-provisioning.md
@@ -1,0 +1,50 @@
+# 30 Kea DDNS TSIG Key Provisioning
+
+Status: `ready`
+Suggested branch: `feat/router-kea-tsig-key`
+Priority: `high`
+
+## Goal
+
+Generate a TSIG key for Kea D2 ↔ Technitium RFC2136 authentication, store it
+as an agenix secret, and wire it into the router host so both Kea and the
+Technitium sync service can read it at runtime.
+
+## Why
+
+The TSIG key is the shared secret that lets Kea D2 sign RFC2136 DNS update
+requests and lets Technitium verify them. It must be provisioned before the
+`router-kea` module (item 31) can be tested end-to-end.
+
+## Validation Findings
+
+Tested manually on 2026-04-18:
+- Technitium 14.0 on router accepts RFC2136 updates from 127.0.0.1 ✓
+- TSIG HMAC-SHA256 works once the key is registered in Technitium settings ✓
+- Technitium TSIG key API: POST `api/settings/set?tsigKeys=name|b64secret|hmac-sha256`
+  (sets the global TSIG key list; existing keys are replaced, so always send full list)
+- Zone update policy: `api/zones/options/set?zone=…&update=Allow&updateNetworkACL=127.0.0.1`
+- `BADKEY` error means the key is not yet registered in Technitium settings (not a
+  fundamental incompatibility)
+
+## Scope
+
+- Generate TSIG key: `openssl rand -base64 32`
+- Encrypt as `secrets-agenix/kea-ddns-tsig-key.age` with router host key
+- Add to `secrets.nix` with router public key
+- Expose on router via `age.secrets.kea-ddns-tsig-key`
+- Document the path so items 31 and 32 can reference it
+
+## Non-Goals
+
+- Kea itself (item 31)
+- Technitium zone reconfiguration (item 32)
+
+## Validation
+
+- `nix eval` on router host confirms secret path resolves
+- `agenix-edit --decrypt` confirms secret is readable with router host key
+
+## Dependencies
+
+None — standalone secret provisioning.

--- a/docs/router-work-items/31-router-kea-module.md
+++ b/docs/router-work-items/31-router-kea-module.md
@@ -1,0 +1,78 @@
+# 31 router-kea Module
+
+Status: `ready`
+Suggested branch: `feat/router-kea-module`
+Priority: `high`
+
+## Goal
+
+Implement `modules/router-kea.nix` in `nix-router-optimized` with `services.router-kea`
+offering DHCPv4 (kea-dhcp4) and DDNS (kea-dhcp-ddns / D2) with TSIG-authenticated
+RFC2136 updates to an authoritative DNS server (Technitium or any other).
+
+## Why
+
+The `router-dhcp` module uses systemd-networkd's built-in DHCP server, which has no
+DNS registration path. Kea with D2 gives dynamic lease → DNS A-record registration
+automatically, solving the "unknown host on LAN" problem.
+
+## Scope
+
+### `modules/router-kea.nix` in `nix-router-optimized`
+
+```nix
+options.services.router-kea = {
+  enable = mkEnableOption "Kea DHCPv4 + DDNS for router LAN clients";
+
+  dhcp4 = {
+    interfaces    # listOf str — defaults to LAN ifaces from router-networking
+    subnet        # str — CIDR (e.g. "10.10.0.0/16")
+    poolRanges    # listOf { start; end; } — dynamic pool(s)
+    defaultLeaseTimeSec  # default 86400
+    maxLeaseTimeSec      # default 172800
+    reservations  # listOf { hw-address; ip-address; hostname; }
+    ddnsEnabled   # bool, default true — send DDNS updates
+  };
+
+  ddns = {
+    enable         # bool — enables kea-dhcp-ddns service
+    serverAddress  # str — DNS server to update, default "127.0.0.1"
+    serverPort     # int, default 53
+    tsigKeyFile    # path — runtime path to TSIG key secret (base64)
+    tsigKeyName    # str — key name as registered in Technitium
+    tsigAlgorithm  # str, default "HMAC-SHA256"
+    forwardZone    # str — e.g. "deepwatercreature.com"
+    reverseZone    # str — e.g. "10.10.in-addr.arpa" (optional)
+  };
+};
+```
+
+- Wire `services.kea.dhcp4` and `services.kea.dhcp-ddns`
+- Auto-derive `interfaces` from `services.router-networking.routedInterfaces` (LAN role)
+- Open UDP 67, 68 on LAN interfaces via `services.router-firewall.trustedUdpPorts`
+- Disable `services.router-dhcp` assertion hint if both are enabled simultaneously
+
+### Integration notes
+
+- `tsigKeyFile` should point to `config.age.secrets.kea-ddns-tsig-key.path`
+  (item 30); the module itself does not manage secrets, just reads the path
+- Kea config files contain the raw TSIG key — use a `preStart` script or
+  Kea's `secret-file` reference to avoid writing the key to the Nix store
+- Register module as `router-kea` in `flake.nix` and include in
+  `nixosModules.default`
+
+## Non-Goals
+
+- Technitium zone reconfiguration (item 32)
+- Kea HA (future item)
+- DHCPv6
+
+## Validation
+
+- `nix-instantiate --parse` on the new module
+- `nix build .#checks.x86_64-linux.nixos-eval` passes in `nix-router-optimized`
+- Test eval of a synthetic config enabling `services.router-kea` succeeds
+
+## Dependencies
+
+- Item 30 (TSIG key must exist to test end-to-end, but module can be written first)

--- a/docs/router-work-items/32-kea-dhcp-cutover.md
+++ b/docs/router-work-items/32-kea-dhcp-cutover.md
@@ -1,0 +1,88 @@
+# 32 Kea DHCP Cutover
+
+Status: `blocked`
+Suggested branch: `feat/router-kea-cutover`
+Priority: `high`
+
+## Goal
+
+Switch the router from Technitium's built-in DHCP to Kea, port all existing
+reservations, enable RFC2136 DDNS registration in Technitium, and disable
+Technitium DHCP so all lease-to-DNS registration flows through Kea D2.
+
+## Why
+
+Technitium DHCP and its DNS registration run as a single coupled unit with no
+external interface. Kea D2 gives auditable, declarative lease→DNS registration
+via RFC2136. Dynamic clients (phones, laptops, IoT) will finally show up by
+hostname in Technitium DNS.
+
+## Scope
+
+### In `hosts/nixos/router/networking.nix` (or `role.nix`)
+
+1. **Enable Kea**
+   ```nix
+   services.router-kea = {
+     enable = true;
+     dhcp4 = {
+       subnet   = topology.networks.lan.cidr;
+       poolRanges = [{ start = "10.10.10.100"; end = "10.10.10.250"; }];
+       reservations = <ported from services.router-technitium.dhcpReservations>;
+     };
+     ddns = {
+       enable       = true;
+       tsigKeyFile  = config.age.secrets.kea-ddns-tsig-key.path;
+       tsigKeyName  = "kea-ddns";
+       forwardZone  = topology.domain;
+       reverseZone  = "10.10.in-addr.arpa";
+     };
+   };
+   ```
+
+2. **Disable Technitium DHCP scopes**
+   Remove or comment out `services.router-technitium.scopes`.
+   Keep `services.router-technitium.dhcpReservations` empty (or remove).
+
+3. **Enable Technitium RFC2136 via sync service**
+   Add a `technitium-enable-rfc2136` systemd service (one-shot, similar to
+   existing scope/reservation sync services) that:
+   - POSTs `api/settings/set?tsigKeys=kea-ddns|<secret>|hmac-sha256`
+   - POSTs `api/zones/options/set?zone=<domain>&update=Allow&updateNetworkACL=127.0.0.1`
+     for both the forward and reverse zones
+   - Reads the TSIG secret from `config.age.secrets.kea-ddns-tsig-key.path`
+   - Runs after `technitium-dns-server.service` and after agenix decryption
+
+### Reservation migration
+
+Port `lib/hosts.nix` `dhcpReservation` entries to `services.router-kea.dhcp4.reservations`
+format:
+```nix
+{ hw-address = host.dhcpReservation.macAddress;
+  ip-address = host.ip;
+  hostname   = name; }
+```
+
+## Cutover sequence (manual / one-time)
+
+1. Deploy with both Kea and Technitium DHCP disabled → verify Kea starts clean
+2. Re-enable Kea; let a few clients renew
+3. Verify A records appear in Technitium for dynamic clients
+4. Keep Technitium DHCP disabled permanently
+
+## Non-Goals
+
+- Kea HA (future item)
+- Removing Technitium entirely
+
+## Validation
+
+- `dig @10.10.10.1 <dynamic-client-hostname>.deepwatercreature.com` resolves
+- `kea-dhcp4` logs show leases being issued
+- `kea-dhcp-ddns` logs show RFC2136 updates sent and `NOERROR` returned from Technitium
+- Technitium web UI → Zones → `deepwatercreature.com` shows dynamically registered A records
+
+## Dependencies
+
+- Item 30 (TSIG key secret) — must be merged first
+- Item 31 (router-kea module) — must be merged first

--- a/docs/router-work-items/README.md
+++ b/docs/router-work-items/README.md
@@ -53,3 +53,6 @@ in parallel on separate worktrees.
 6. [`28-router-dashboard-review-hardening.md`](./28-router-dashboard-review-hardening.md) - `ready`
 7. [`29-router-cutover-validation-hardening.md`](./29-router-cutover-validation-hardening.md) - `ready`
 8. [`27-router-pxe-boot-module-plumbing.md`](./27-router-pxe-boot-module-plumbing.md) - `ready`
+9. [`30-kea-tsig-key-provisioning.md`](./30-kea-tsig-key-provisioning.md) - `ready`
+10. [`31-router-kea-module.md`](./31-router-kea-module.md) - `ready`
+11. [`32-kea-dhcp-cutover.md`](./32-kea-dhcp-cutover.md) - `blocked` (needs 30 + 31)


### PR DESCRIPTION
## **User description**
## Summary

Adds work items 30–32 covering the full path from TSIG key provisioning to Kea DHCP cutover, following live validation against Technitium 14.0.

- **Item 30** (`ready`): Generate and agenix-encrypt the Kea DDNS TSIG key for the router
- **Item 31** (`ready`): Implement `router-kea.nix` module in `nix-router-optimized` (kea-dhcp4 + kea-dhcp-ddns with TSIG)
- **Item 32** (`blocked` on 30+31): Port reservations, enable RFC2136 on Technitium zones, cut over from Technitium DHCP to Kea

## Validation findings (live test 2026-04-18)

- Plain RFC2136 `nsupdate` from 127.0.0.1 → Technitium 14.0 ✅
- TSIG HMAC-SHA256 `nsupdate` with registered key → Technitium 14.0 ✅
- TSIG key registration API: `POST api/settings/set?tsigKeys=name|b64secret|hmac-sha256`
- Zone update policy API: `POST api/zones/options/set?zone=…&update=Allow&updateNetworkACL=127.0.0.1`
- `BADKEY` error = key not yet registered in Technitium settings (not a compatibility issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Document the router's Kea DHCP migration plan**

### What Changed
- Added a new work item list entry for TSIG key provisioning, the Kea DHCP module, and the DHCP cutover
- Added a TSIG key provisioning task with validation notes for Technitium DNS updates
- Added a Kea module task covering DHCP, DDNS, reservations, and TSIG-based DNS updates
- Added a cutover task describing how to move client leases and DNS updates from Technitium DHCP to Kea

### Impact
`✅ Clearer router migration plan`
`✅ Fewer missed DNS registration steps`
`✅ Safer DHCP cutover sequencing`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=BGQ-aXB84A_aKBoz1IsBAVUfch09day_UL0UzVbshw0&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
