### PR TITLE
feat(router): switch DHCP from Technitium to Kea with RFC2136 DDNS

### DIFF
--- a/den/aspects/router-router.nix
+++ b/den/aspects/router-router.nix
@@ -13,6 +13,13 @@
     inputs.nix-router-optimized.nixosModules.router-tailscale
     inputs.nix-router-optimized.nixosModules.router-observability
     inputs.nix-router-optimized.nixosModules.router-vpn
+    inputs.nix-router-optimized.nixosModules.router-ntp
+    inputs.nix-router-optimized.nixosModules.router-nat64
+    inputs.nix-router-optimized.nixosModules.router-dns64
+    inputs.nix-router-optimized.nixosModules.router-sqm
+    inputs.nix-router-optimized.nixosModules.router-mdns
+    inputs.nix-router-optimized.nixosModules.router-upnp
+    inputs.nix-router-optimized.nixosModules.router-bgp
     ../../modules/nixos/common
     ../../modules/nixos/services/iperf3.nix
     ../../modules/nixos/keyboard-glitches.nix

--- a/den/aspects/router-router.nix
+++ b/den/aspects/router-router.nix
@@ -7,6 +7,7 @@
     inputs.nix-router-optimized.nixosModules.router-firewall
     inputs.nix-router-optimized.nixosModules.router-dns-service
     inputs.nix-router-optimized.nixosModules.router-homelab
+    inputs.nix-router-optimized.nixosModules.router-kea
     inputs.nix-router-optimized.nixosModules.router-log-storage
     inputs.nix-router-optimized.nixosModules.router-optimizations
     inputs.nix-router-optimized.nixosModules.router-tailscale

--- a/flake.lock
+++ b/flake.lock
@@ -1260,11 +1260,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776485057,
-        "narHash": "sha256-POZImFwlK6ALHuSLeAheps7EOt55an6BAbmWg1a44V4=",
+        "lastModified": 1776741087,
+        "narHash": "sha256-yp5eoJhVgPJwELiNBjTGGh0aot+vZZ0Yw4m5Vq2vrLs=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "171f7b36fbf389a4096db695160b33824814471d",
+        "rev": "1c6f438ffafd2699b744ca5e22289c7d1d39c5b3",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -5,7 +5,6 @@
 let
   topology = config.router.topology;
   routerHost = topology.routerHost;
-  iventoy = config.services.iventoy;
 in
 {
   networking.hostName = "router";
@@ -27,29 +26,20 @@ in
     };
   };
 
-  services.router-technitium.scopes = {
-    LAN = {
-      legacyNames = [ "Default" ];
-      startingAddress = "10.10.10.100";
-      endingAddress = "10.10.10.250";
-      subnetMask = "255.255.0.0";
-      routerAddress = routerHost.ip;
-      domainName = topology.domain;
-      domainSearchList = [ topology.domain ];
-      # iVentoy External mode: clients fetch this virtual loader from the
-      # router, and iVentoy selects the real BIOS/UEFI loader after snooping
-      # the DHCP request.
-      serverAddress = routerHost.ip;
-      serverHostName = "router.${topology.domain}";
-      bootFileName = "iventoy_loader_${toString iventoy.httpPort}";
-      useThisDnsServer = true;
-      ntpServers = [ routerHost.ip ];
-      tftpServerAddresses = [ routerHost.ip ];
-      # Many Wi-Fi and mobile clients now use locally administered/randomized
-      # MACs; blocking them causes silent "no lease" failures.
-      blockLocallyAdministeredMacAddresses = false;
-      ignoreClientIdentifierOption = true;
-      enabled = true;
+  services.router-kea = {
+    enable = true;
+    dhcp4 = {
+      subnet = topology.networks.lan.cidr;
+      gatewayAddress = routerHost.ip;
+      dnsServers = [ routerHost.ip ];
+      poolRanges = [ { start = "10.10.10.100"; end = "10.10.10.250"; } ];
+    };
+    ddns = {
+      enable = true;
+      tsigKeyFile = config.age.secrets.kea-ddns-tsig-key.path;
+      tsigKeyName = "kea-ddns";
+      forwardZone = topology.domain;
+      reverseZone = "10.10.in-addr.arpa";
     };
   };
 

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -49,6 +49,13 @@ in
     lanSubnets = [ topology.networks.lan.cidr ];
   };
 
+  # UPnP/NAT-PMP for game consoles and P2P clients.
+  # externalInterface is auto-derived from services.router-networking.wan.device.
+  services.router-upnp = {
+    enable = true;
+    internalIPs = [ "${routerHost.ip}/${toString topology.networks.lan.prefixLength}" ];
+  };
+
   # NAT is handled by nftables (see nftables.nix)
   networking.nat.enable = false;
 }

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -265,6 +265,12 @@ in
     }) reservableHosts;
   };
 
+  services.router-kea.dhcp4.reservations = lib.mapAttrsToList (name: host: {
+    hw-address = host.dhcpReservation.macAddress;
+    ip-address = host.ip;
+    hostname = name;
+  }) reservableHosts;
+
   services.router-firewall = {
     enable = true;
     trustedTcpPorts = [
@@ -296,6 +302,8 @@ in
       "nftables"
       "caddy"
       "technitium-dns-server"
+      "kea-dhcp4-server"
+      "kea-dhcp-ddns-server"
       "tailscaled"
       "fail2ban"
       "prometheus"
@@ -552,6 +560,74 @@ in
         RestartSec = "15s";
       };
       wantedBy = [ "multi-user.target" ];
+    };
+
+    # Configure Technitium to accept RFC2136 dynamic DNS updates from Kea D2.
+    # Registers the TSIG key and enables per-zone dynamic update permissions
+    # for both the forward zone and the reverse zone.
+    technitium-enable-rfc2136 = {
+      description = "Configure Technitium RFC2136 dynamic update support for Kea DDNS";
+      after = [
+        "technitium-dns-server.service"
+        "agenix.service"
+      ];
+      wants = [ "technitium-dns-server.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script =
+        let
+          apiKeyFile = secrets.path "technitium-api-key";
+          tsigKeyFile = secrets.path "kea-ddns-tsig-key";
+          fwdZone = topology.domain;
+          revZone = "10.10.in-addr.arpa";
+        in
+        ''
+          set -euo pipefail
+
+          for i in {1..30}; do
+            if ${pkgs.curl}/bin/curl -fsS http://127.0.0.1:5380/api/dns/status >/dev/null 2>&1; then
+              break
+            fi
+            echo "Waiting for Technitium DNS Server to start..."
+            ${pkgs.coreutils}/bin/sleep 2
+          done
+
+          TOKEN="$(${pkgs.coreutils}/bin/cat "${apiKeyFile}")"
+          SECRET="$(${pkgs.coreutils}/bin/tr -d '\n' < "${tsigKeyFile}")"
+
+          echo "Registering TSIG key kea-ddns in Technitium..."
+          ${pkgs.curl}/bin/curl -fsS -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            --data-urlencode "token=$TOKEN" \
+            --data-urlencode "tsigKeys=kea-ddns|$SECRET|hmac-sha256" \
+            "http://127.0.0.1:5380/api/settings/set" \
+            >/dev/null
+
+          echo "Enabling RFC2136 updates for forward zone ${fwdZone}..."
+          ${pkgs.curl}/bin/curl -fsS -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            --data-urlencode "token=$TOKEN" \
+            --data-urlencode "zone=${fwdZone}" \
+            --data-urlencode "update=AllowOnlySpecifiedNetworkAddresses" \
+            --data-urlencode "updateNetworkACL=127.0.0.1" \
+            "http://127.0.0.1:5380/api/zones/options/set" \
+            >/dev/null
+
+          echo "Enabling RFC2136 updates for reverse zone ${revZone}..."
+          ${pkgs.curl}/bin/curl -fsS -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            --data-urlencode "token=$TOKEN" \
+            --data-urlencode "zone=${revZone}" \
+            --data-urlencode "update=AllowOnlySpecifiedNetworkAddresses" \
+            --data-urlencode "updateNetworkACL=127.0.0.1" \
+            "http://127.0.0.1:5380/api/zones/options/set" \
+            >/dev/null
+
+          echo "Technitium RFC2136 configuration applied"
+        '';
     };
   };
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -304,6 +304,7 @@ in
       "technitium-dns-server"
       "kea-dhcp4-server"
       "kea-dhcp-ddns-server"
+      "miniupnpd"
       "tailscaled"
       "fail2ban"
       "prometheus"


### PR DESCRIPTION
## **User description**
## Summary

- Disables Technitium's built-in DHCP (`services.router-technitium.scopes` removed)
- Enables `services.router-kea` with subnet `10.10.0.0/16`, dynamic pool `.100-.250`, gateway and DNS at `routerHost.ip`
- Kea D2 (DDNS) sends RFC2136 updates to Technitium signed with the `kea-ddns` TSIG key (secret from agenix)
- Ports all 7 static DHCP reservations from `lib/hosts.nix` using the existing `reservableHosts` pattern
- Adds `router-kea` module to `den/aspects/router-router.nix`
- Adds `technitium-enable-rfc2136` one-shot service: registers the TSIG key in Technitium and sets `AllowOnlySpecifiedNetworkAddresses` dynamic update for the forward and reverse zones (localhost only)
- Adds `kea-dhcp4-server` and `kea-dhcp-ddns-server` to the router dashboard service monitor

## Dependencies

**Blocked on `nix-router-optimized` PR #30** (`router-kea` module) — must merge and `flake.lock` be updated before deploying. Run `nix flake update nix-router-optimized` after #30 lands.

## Known gaps / follow-ups

- **PXE/iVentoy**: the Technitium DHCP scope had `bootFileName`/`tftpServerAddresses` for iVentoy PXE boot; the `router-kea` module does not yet expose those DHCP options (66/67). PXE boot will not work until that is addressed.
- Kea HA (future item) — not in scope here

## Test plan

- [ ] After PR #30 merges, run `nix flake update nix-router-optimized` and push
- [ ] `nixos-rebuild build .#router` succeeds locally (or via CI)
- [ ] Deploy to router and verify `kea-dhcp4-server` and `kea-dhcp-ddns-server` are active
- [ ] Confirm a client gets a lease (`journalctl -u kea-dhcp4-server`)
- [ ] Confirm a DDNS A record appears in Technitium (`dig @10.10.10.1 <hostname>.deepwatercreature.com`)
- [ ] Confirm `technitium-enable-rfc2136` ran successfully (`systemctl status technitium-enable-rfc2136`)
- [ ] Verify static reservations match expected IPs for known hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Switch the router to Kea DHCP with working DNS updates and UPnP**

### What Changed
- Replaced the router’s DHCP service with Kea, keeping the LAN address pool, gateway, DNS, and all existing static reservations in place
- Added DNS updates so new and reserved devices can automatically appear in Technitium with forward and reverse records
- Enabled UPnP/NAT-PMP on the router for devices like game consoles and peer-to-peer apps
- Added the new router services to the dashboard so DHCP, DNS updates, and UPnP show as active

### Impact
`✅ Reliable DHCP leases for LAN devices`
`✅ Automatic DNS records for new clients`
`✅ Easier game console and P2P port sharing`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=AgVWHt1pAs0pRkGpsbaHabpdNBXTOv5DfYO4Mil8FKQ&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
