### PR TITLE
fix(tooling): avoid beads br command collision

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,8 @@ For detailed managed authentication paths (including `gemini-cli`), see `docs/to
 - Beads task-graph wiring is now partially in place; see
   `docs/beads-migration-plan.md` and
   `docs/tooling-work-items/18-beads-task-graph-integration.md` for details.
+  Use the repo-managed `beads-rust` command for the Rust CLI; `br` may refer to
+  the Homebrew viewer on some hosts.
 
 ### Git Workflow
 Before pushing changes that affect remote hosts:

--- a/docs/agent-fleet-flake-design.md
+++ b/docs/agent-fleet-flake-design.md
@@ -38,7 +38,7 @@ This reduces the agent-tooling surface in `unified-nix-configuration` from
 | `fnox` | Credential proxy for all wrapped CLI tools |
 | `nix-rtk` | RTK token-saver + Claude Code hook integration |
 | `llm-agents` | Package set: claude-code, opencode, codex, etc. |
-| `beads-rust` | Task graph tracker (`br` CLI) |
+| `beads-rust` | Task graph tracker (`beads-rust` wrapper around upstream `br`) |
 | `worktrunk` | Git worktree manager for parallel agent branches |
 
 ### Experimental (newer, interface may evolve)

--- a/docs/beads-migration-plan.md
+++ b/docs/beads-migration-plan.md
@@ -1,12 +1,14 @@
 # beads_rust Migration Plan
 
 This document captures the design for replacing the hand-rolled markdown
-work-item queue in `docs/*/` with `beads_rust` (`br`), a Rust-based local-first
-task tracker built specifically for agentic workflows.
+work-item queue in `docs/*/` with `beads_rust`, a Rust-based local-first task
+tracker built specifically for agentic workflows. In this repo, the
+repo-managed command is `beads-rust`, which wraps the upstream `br` binary to
+avoid colliding with the Homebrew `beads_viewer` `br` command.
 
-**Status: In progress.** Initial `.beads/` wiring, ignore rules, and
-START-HERE/agent-prompts updates are in place; actual `br init` and queue
-migration remain pending on `br` installation or packaging.
+**Status: In progress.** Initial `.beads/` wiring, ignore rules, repo-managed
+CLI packaging, and START-HERE/agent-prompts updates are in place; actual
+`beads-rust init` and queue migration remain pending on deployment.
 
 ---
 
@@ -17,12 +19,12 @@ that accumulate as queue size grows:
 
 | Pain point | Current system | beads_rust |
 |---|---|---|
-| Discovering next unblocked task | Agent reads README ranking + checks each file | `br ready --json` — one call |
-| Claiming a task atomically | Edit the markdown file in a branch | `br claim <id>` — atomic assign + status |
+| Discovering next unblocked task | Agent reads README ranking + checks each file | `beads-rust ready --json` — one call |
+| Claiming a task atomically | Edit the markdown file in a branch | `beads-rust claim <id>` — atomic assign + status |
 | Expressing dependencies | Informal "blocked-by" prose | First-class `dep add` with typed relationships |
 | Priority | Ordered list in README (manual reorder) | Numeric field; `bv --robot-triage` for graph-aware routing |
-| Status transitions | Text edit inside the file | `br update --status` or `br close` |
-| Searching history | `grep` across closed files | `br search <query>` (BM25 full-text) |
+| Status transitions | Text edit inside the file | `beads-rust update --status` or `beads-rust close` |
+| Searching history | `grep` across closed files | `beads-rust search <query>` (BM25 full-text) |
 | Multiple queues | Separate `tooling-work-items/` and `router-work-items/` | Single `.beads/` store; differentiated by labels or epics |
 
 The markdown system has one advantage beads doesn't: rich prose that explains
@@ -50,8 +52,8 @@ suffices.
 | `## Scope` | `acceptance_criteria` | Maps naturally |
 | `## Non-Goals` | `notes` | Append to notes |
 | `## Validation` | `acceptance_criteria` | Merge with Scope |
-| `## Implementation` (outcome) | `notes` (post-close) | Add as a comment after `br close` |
-| `blocked-by: item-X` (informal) | `br dep add X Y --type Blocks` | First-class dependency |
+| `## Implementation` (outcome) | `notes` (post-close) | Add as a comment after `beads-rust close` |
+| `blocked-by: item-X` (informal) | `beads-rust dep add X Y --type Blocks` | First-class dependency |
 | README ranked order | `priority` (0=Critical … 4=Backlog) | Numeric; `bv` handles graph-aware re-ranking |
 | Queue folder (`tooling-work-items/`) | label `tooling` on each bead | Single store, differentiated by label |
 | `router-work-items/` | label `router` | Same store, different label |
@@ -60,16 +62,15 @@ suffices.
 
 ## Installation
 
-beads_rust is not yet in nixpkgs. Install the binary directly:
+beads_rust is not yet in nixpkgs. This repo packages the upstream flake and
+wraps it as the `beads-rust` command.
 
 ```bash
-bash <(curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/main/install.sh?$(date +%s)")
-# Binary lands in ~/.local/bin/br
-br --version
+beads-rust --version
 ```
 
-For reproducibility in this repo, add a nix derivation (see "Nix packaging"
-section below) rather than relying on the raw install script long-term.
+If you intentionally install the upstream raw binary as `br` outside Nix, you
+can still use the migration script by setting `BEADS_RUST_CMD=br`.
 
 ---
 
@@ -80,7 +81,7 @@ git-trackable; the SQLite database is derived and should be gitignored.
 
 ```bash
 cd ~/flakes/unified-nix-configuration
-br init
+beads-rust init
 ```
 
 Add to `.gitignore`:
@@ -90,7 +91,7 @@ Add to `.gitignore`:
 .beads/*.db-wal
 ```
 
-Track `issues.jsonl` in git. Each `br sync --flush-only` exports the SQLite
+Track `issues.jsonl` in git. Each `beads-rust sync --flush-only` exports the SQLite
 state back to JSONL for committing.
 
 ---
@@ -101,25 +102,25 @@ state back to JSONL for committing.
 
 ```bash
 # Human-readable
-br ready --labels tooling
+beads-rust ready --labels tooling
 
 # Machine-readable for agent scripts / START-HERE equivalent
-RUST_LOG=error br ready --labels tooling --json
+RUST_LOG=error beads-rust ready --labels tooling --json
 ```
 
 ### Claiming a task (atomic)
 
 ```bash
-RUST_LOG=error BR_ACTOR=claude-code br claim <id>
+RUST_LOG=error BR_ACTOR=claude-code beads-rust claim <id>
 # Sets assignee=claude-code, status=InProgress atomically
 ```
 
 ### Completing a task
 
 ```bash
-br close <id> --reason "PR #42 merged"
-br comments <id> --add "Outcome: <brief summary of what changed>"
-br sync --flush-only
+beads-rust close <id> --reason "PR #42 merged"
+beads-rust comments <id> --add "Outcome: <brief summary of what changed>"
+beads-rust sync --flush-only
 git add .beads/issues.jsonl
 git commit -m "beads: close <id> — <title>"
 ```
@@ -127,7 +128,7 @@ git commit -m "beads: close <id> — <title>"
 ### Adding a dependency
 
 ```bash
-br dep add <blocker-id> <blocked-id> --type Blocks
+beads-rust dep add <blocker-id> <blocked-id> --type Blocks
 ```
 
 ---
@@ -138,7 +139,7 @@ Both queues are currently empty. When the next queue is created, populate beads
 directly instead of writing markdown files:
 
 ```bash
-br create "Title" \
+beads-rust create "Title" \
   --type Task \
   --priority 2 \
   --labels tooling \
@@ -150,7 +151,7 @@ If items are already in markdown and a migration is needed, use this pattern:
 
 ```bash
 # For each file in docs/tooling-work-items/:
-br create "$(head -1 FILE.md | sed 's/# //')" \
+beads-rust create "$(head -1 FILE.md | sed 's/# //')" \
   --type Task \
   --priority 2 \
   --labels tooling \
@@ -160,12 +161,13 @@ br create "$(head -1 FILE.md | sed 's/# //')" \
 
 For items already `done`, close them immediately after creating:
 ```bash
-br close <new-id> --reason "Completed prior to beads adoption"
+beads-rust close <new-id> --reason "Completed prior to beads adoption"
 ```
 
 For this repo's tooling queue, the helper script
 `scripts/beads-migrate-tooling.sh` automates this migration pattern for all
-`ready` and `in-progress` items once `br` is installed and `br init` has run.
+`ready` and `in-progress` items once `beads-rust` is installed and
+`beads-rust init` has run.
 
 ---
 
@@ -177,22 +179,22 @@ Replace the current manual instructions with a beads-aware version:
 ## Finding work
 
 Run:
-  br ready --labels tooling --json
+  beads-rust ready --labels tooling --json
 
 Pick the highest-priority item (lowest priority number). Claim it:
-  BR_ACTOR=<your-name> br claim <id>
+  BR_ACTOR=<your-name> beads-rust claim <id>
 
 When done, close and sync:
-  br close <id> --reason "PR #<n> merged"
-  br sync --flush-only
+  beads-rust close <id> --reason "PR #<n> merged"
+  beads-rust sync --flush-only
   git add .beads/issues.jsonl && git commit -m "beads: close <id>"
 ```
 
 The `agent-prompts.md` dispatch prompt becomes:
 
 ```
-Run `br ready --labels tooling --json` to find the next unblocked item.
-Claim it with `BR_ACTOR=claude-code br claim <id>`, do the work in a
+Run `beads-rust ready --labels tooling --json` to find the next unblocked item.
+Claim it with `BR_ACTOR=claude-code beads-rust claim <id>`, do the work in a
 dedicated branch, and close the bead when the PR merges.
 ```
 
@@ -207,14 +209,15 @@ Agents query it for priority-ranked, dependency-aware task selection:
 bv --robot-triage --labels tooling
 ```
 
-Install separately (same install-script pattern as `br`). Only worth adding
+Install separately alongside `beads-rust`. Only worth adding
 once the queue regularly has 10+ items with non-trivial dependency graphs.
 
 ---
 
 ## Nix packaging
 
-Neither `br` nor `bv` are in nixpkgs yet. The simplest approach for this repo:
+Neither the repo-managed `beads-rust` wrapper nor `bv` are in nixpkgs yet. The
+simplest approach for this repo:
 
 ```nix
 # In an overlay or pkgs/beads-rust.nix
@@ -233,7 +236,7 @@ beads-rust = pkgs.rustPlatform.buildRustPackage {
 
 Add to `modules/home-manager/common/coding-agents.nix` once packaged:
 ```nix
-home.packages = [ pkgs.beads-rust ];
+home.packages = [ pkgs.beads-rust-cli ];
 ```
 
 ---
@@ -245,8 +248,8 @@ Even after migrating to beads, keep:
 - `docs/` — for long-form design docs, architecture notes, and planning
   documents like this one. These are not tasks; they don't belong in beads.
 - `docs/*/README.md` — brief human overview of each queue area; link to
-  `br list --labels <area>` output as the live queue.
-- `docs/*/START-HERE.md` — updated to reference `br ready` instead of the
+  `beads-rust list --labels <area>` output as the live queue.
+- `docs/*/START-HERE.md` — updated to reference `beads-rust ready` instead of the
   ranked list.
 
 The markdown work-item *files* (`01-foo.md`, `02-bar.md`) are the only thing
@@ -275,11 +278,11 @@ Migrate when **two or more** of these are true:
 
 As of the initial wiring for this repo:
 
-- [ ] Install `br` to `~/.local/bin/` (or package as nix derivation)
-- [ ] `br init` at repo root; add SQLite files to `.gitignore`
+- [ ] Deploy `beads-rust` via the repo-managed wrapper package
+- [ ] `beads-rust init` at repo root; add SQLite files to `.gitignore`
 - [x] Commit `.beads/issues.jsonl` (initially empty)
 - [ ] Migrate any existing markdown items or start fresh if queues are empty
-- [x] Update `docs/tooling-work-items/START-HERE.md` to reference `br ready` (with README fallback when `br` is absent)
+- [x] Update `docs/tooling-work-items/START-HERE.md` to reference `beads-rust ready` (with README fallback when the CLI is absent)
 - [x] Update `docs/router-work-items/START-HERE.md` similarly
 - [x] Update `agent-prompts.md` in each queue folder
 - [ ] (Optional) Install `bv` and validate `--robot-triage` output

--- a/docs/robot-triage.md
+++ b/docs/robot-triage.md
@@ -5,12 +5,13 @@ selection once the `.beads/` store is populated.
 
 ## Prerequisites
 
-1. **`br` installed** — the `beads_rust` CLI creates and manages the store.
+1. **`beads-rust` installed** — the repo-managed wrapper around the
+   `beads_rust` CLI creates and manages the store.
    Enabled on workstation via `programs.beads.enable = true`.
-2. **Store initialised** — run `br init` in the repo root once.
+2. **Store initialised** — run `beads-rust init` in the repo root once.
 3. **Items migrated** — run `scripts/beads-migrate-tooling.sh` to import
    the current markdown queue into beads.
-4. **`bv` installed** — the `beads_viewer` TUI; enabled alongside `br`.
+4. **`bv` installed** — the `beads_viewer` TUI; enabled alongside `beads-rust`.
 
 ## Quick Reference
 
@@ -57,25 +58,25 @@ scripts/beads-migrate-tooling.sh
 
 # 2. Ask bv what to do next
 NEXT=$(bv --robot-triage --labels tooling --json | jq -r '.[0].id')
-br start "$NEXT"
+beads-rust start "$NEXT"
 
 # 3. Do the work...
 
 # 4. Close the bead and let bv update its graph
-br finish "$NEXT"
+beads-rust finish "$NEXT"
 ```
 
 ## Graph-Aware Re-ranking
 
 Unlike the static README ordered list, `bv` re-ranks dynamically as tasks
-are completed or new dependency edges are added. After `br finish` closes a
+are completed or new dependency edges are added. After `beads-rust finish` closes a
 bead, the next `bv --robot-triage` call will reflect the freed-up blockers.
 
 To add dependency edges:
 
 ```bash
 # task B depends on (is blocked by) task A:
-br link A B --type blocks
+beads-rust link A B --type blocks
 ```
 
 ## Bootstrapping
@@ -84,7 +85,7 @@ If the `.beads/` store does not exist yet:
 
 ```bash
 cd ~/flakes/unified-nix-configuration
-br init
+beads-rust init
 scripts/beads-migrate-tooling.sh
 bv --robot-triage --labels tooling --json | jq '.[0:3]'
 ```

--- a/docs/router-work-items/START-HERE.md
+++ b/docs/router-work-items/START-HERE.md
@@ -15,8 +15,8 @@ Read first:
 - [`README.md`](./README.md)
 - [`agent-prompts.md`](./agent-prompts.md)
 
-If `br` is available and `.beads/issues.jsonl` exists, use
-`br ready --labels router --json` as the primary queue surface. Otherwise,
+If `beads-rust` is available and `.beads/issues.jsonl` exists, use
+`beads-rust ready --labels router --json` as the primary queue surface. Otherwise,
 fall back to the ordered list in [`README.md`](./README.md).
 
 ## How To Choose Work

--- a/docs/router-work-items/agent-prompts.md
+++ b/docs/router-work-items/agent-prompts.md
@@ -16,8 +16,9 @@ Before using any prompt, read:
 
 - [`START-HERE.md`](./START-HERE.md)
 
-If `br` is available, prefer `br ready --labels router --json` to discover
-unblocked work; otherwise, follow the README-ranked queue.
+If `beads-rust` is available, prefer
+`beads-rust ready --labels router --json` to discover unblocked work;
+otherwise, follow the README-ranked queue.
 
 Important:
 

--- a/docs/tooling-work-items/18-beads-task-graph-integration.md
+++ b/docs/tooling-work-items/18-beads-task-graph-integration.md
@@ -6,7 +6,8 @@ Suggested branch: `feat/tooling-beads-integration`
 
 ## Goal
 
-Migrate the flat markdown work-item queue into `beads_rust` (br) to enable
+Migrate the flat markdown work-item queue into `beads_rust` (via the
+repo-managed `beads-rust` command) to enable
 programmatic dependency tracking and "ready" task surfacing for agents.
 
 ## Why
@@ -14,18 +15,18 @@ programmatic dependency tracking and "ready" task surfacing for agents.
 This repo's `docs/tooling-work-items/` queue is currently a flat, manually
 ranked markdown list. While simple, it does not represent the real dependency
 edges between tasks (e.g., CASS should land before CM). `beads` allows an
-agent to ask `br ready --json` and get a list of unblocked work, removing the
+agent to ask `beads-rust ready --json` and get a list of unblocked work, removing the
 need for human-curated ranking in READMEs.
 
 ## Scope
 
-- initialize `beads` in this repo (`br init`)
+- initialize `beads` in this repo (`beads-rust init`)
 - ingest the current `ready` and `in-progress` items from the markdown queue
 - define dependency edges between related tasks (e.g., CASS -> CM)
 - document the new workflow:
-  - `br add` for new tasks
-  - `br start` / `br finish` for state transitions
-  - how to view the graph via `br status`
+  - `beads-rust add` for new tasks
+  - `beads-rust start` / `beads-rust finish` for state transitions
+  - how to view the graph via `beads-rust status`
 - evaluate whether the `.beads/` SQLite/JSONL data should be committed
   (standard beads practice)
 
@@ -41,14 +42,15 @@ need for human-curated ranking in READMEs.
   in-progress wiring state, with `.beads/` layout, ignore rules, and
   docs checklist updated.
 - `.beads/issues.jsonl` is committed empty and `.beads/*.db*` are gitignored;
-  operators can run `br init` and migrate queues once `br` is installed.
+  operators can run `beads-rust init` and migrate queues once the repo-managed
+  CLI is installed.
 - `scripts/beads-migrate-tooling.sh` migrates the current tooling queue's
-  `ready` and `in-progress` items into beads when `br` is available.
+  `ready` and `in-progress` items into beads when `beads-rust` is available.
 - `START-HERE.md` and `agent-prompts.md` for both tooling and router now
   describe beads-aware workflows while preserving README-based fallbacks.
 
 ## Validation
 
-- `br ready` correctly identifies unblocked tasks
-- `br status` shows a coherent graph of current work
+- `beads-rust ready` correctly identifies unblocked tasks
+- `beads-rust status` shows a coherent graph of current work
 - docs explain the shift from "Ranked Queue" to "Dependency Graph"

--- a/docs/tooling-work-items/START-HERE.md
+++ b/docs/tooling-work-items/START-HERE.md
@@ -15,8 +15,8 @@ Read first:
 - [`README.md`](./README.md)
 - [`agent-prompts.md`](./agent-prompts.md)
 
-If `br` is available and `.beads/issues.jsonl` exists, use
-`br ready --labels tooling --json` as the primary queue surface. If `bv` is
+If `beads-rust` is available and `.beads/issues.jsonl` exists, use
+`beads-rust ready --labels tooling --json` as the primary queue surface. If `bv` is
 also available, use `bv --robot-triage --labels tooling --json` for
 PageRank/critical-path ranked suggestions. Otherwise, fall back to the
 ordered list in [`README.md`](./README.md).

--- a/docs/tooling-work-items/agent-prompts.md
+++ b/docs/tooling-work-items/agent-prompts.md
@@ -4,8 +4,8 @@ Use these prompts to dispatch other agents onto the tooling queue.
 
 ## Prompt 1
 
-Read [`docs/tooling-work-items/START-HERE.md`](./START-HERE.md). If `br` is
-available, run `br ready --labels tooling --json` and claim the
+Read [`docs/tooling-work-items/START-HERE.md`](./START-HERE.md). If `beads-rust`
+is available, run `beads-rust ready --labels tooling --json` and claim the
 highest-priority unblocked item. Otherwise, take the highest-priority item in
 `README.md` still marked `Status: \`ready\``. Focus only on that one item, keep
 the work to one PR, and update the item status in your branch.

--- a/flake.nix
+++ b/flake.nix
@@ -169,8 +169,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # beads_rust (br) — agent-first issue tracker (SQLite + JSONL)
-    # Uses upstream flake to avoid re-implementing the crane+fenix nightly build.
+    # beads_rust upstream package; the repo wraps it as `beads-rust` to avoid
+    # colliding with the Homebrew viewer's `br` command.
     beads-rust = {
       url = "github:Dicklesworthstone/beads_rust";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/home-manager/common/beads.nix
+++ b/modules/home-manager/common/beads.nix
@@ -1,12 +1,13 @@
 # modules/home-manager/common/beads.nix
-# Beads coordination stack: br (beads_rust) + bv (beads_viewer)
+# Beads coordination stack: beads-rust (repo-managed wrapper around upstream br)
+# + bv (beads_viewer)
 #
-# br  — CLI for creating, updating, and querying the .beads/ task store
+# beads-rust — CLI for creating, updating, and querying the .beads/ task store
 # bv  — TUI + robot-triage engine; reads PageRank/critical-path from store
 #
 # Usage after `home-manager switch`:
-#   br init             — initialise .beads/ in a repo
-#   br ready --json     — list unblocked tasks as JSON
+#   beads-rust init        — initialise .beads/ in a repo
+#   beads-rust ready --json — list unblocked tasks as JSON
 #   bv                  — open interactive terminal UI
 #   bv --robot-triage --labels tooling --json   — agent-friendly priority list
 {
@@ -21,12 +22,12 @@ let
 in
 {
   options.programs.beads = {
-    enable = lib.mkEnableOption "Beads coordination stack (br + bv)";
+    enable = lib.mkEnableOption "Beads coordination stack (beads-rust + bv)";
 
     enableBr = lib.mkOption {
       type = lib.types.bool;
       default = true;
-      description = "Install br (beads_rust) CLI.";
+      description = "Install the repo-managed beads-rust CLI wrapper.";
     };
 
     enableBv = lib.mkOption {
@@ -38,7 +39,7 @@ in
 
   config = lib.mkIf cfg.enable {
     home.packages =
-      lib.optional cfg.enableBr pkgs.beads-rust
+      lib.optional cfg.enableBr pkgs.beads-rust-cli
       ++ lib.optional cfg.enableBv pkgs.beads-viewer;
   };
 }

--- a/overlays/flake-inputs.nix
+++ b/overlays/flake-inputs.nix
@@ -54,7 +54,8 @@
     qmd = inputs.qmd.packages.${prev.stdenv.hostPlatform.system}.default;
   })
 
-  # beads_rust (br) — agent-first issue tracker; built via upstream crane/fenix flake
+  # beads_rust upstream package; the repo exposes it as `beads-rust` via a
+  # wrapper package to avoid colliding with the Homebrew viewer's `br` command.
   (final: prev: {
     beads-rust = inputs.beads-rust.packages.${prev.stdenv.hostPlatform.system}.default;
   })

--- a/overlays/packages.nix
+++ b/overlays/packages.nix
@@ -83,6 +83,19 @@
     beads-viewer = prev.callPackage ../pkgs/beads-viewer.nix { };
   })
 
+  # Repo-managed wrapper around the upstream beads_rust package.
+  # Expose the CLI as `beads-rust` so it does not collide with the Homebrew
+  # beads_viewer `br` command.
+  (final: prev: {
+    beads-rust-cli = prev.writeShellApplication {
+      name = "beads-rust";
+      runtimeInputs = [ final.beads-rust ];
+      text = ''
+        exec ${final.beads-rust}/bin/br "$@"
+      '';
+    };
+  })
+
   # mem0ai — semantic long-term memory layer for AI agents
   (final: prev: {
     mem0ai = prev.callPackage ../pkgs/mem0ai.nix {

--- a/scripts/beads-migrate-tooling.sh
+++ b/scripts/beads-migrate-tooling.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 #
 # Preconditions:
 # - Run from anywhere inside this git repo.
-# - `br` (beads_rust) must be installed and on PATH.
-# - `.beads/` has been initialised via `br init`.
+# - `beads-rust` must be installed and on PATH.
+# - `.beads/` has been initialised via `beads-rust init`.
 #
 # This script only ingests tooling work items that are still `ready` or
 # `in-progress`. Already-`done` items remain in markdown-only history.
@@ -14,8 +14,12 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "${repo_root}"
 
-if ! command -v br >/dev/null 2>&1; then
-  echo "error: br (beads_rust) not found on PATH; install it first" >&2
+beads_cmd="${BEADS_RUST_CMD:-beads-rust}"
+
+if ! command -v "${beads_cmd}" >/dev/null 2>&1; then
+  echo "error: ${beads_cmd} not found on PATH." >&2
+  echo "hint: this repo uses the repo-managed \`beads-rust\` wrapper to avoid colliding with the Homebrew viewer \`br\` command." >&2
+  echo "hint: if you intentionally installed the upstream CLI as raw \`br\`, rerun with BEADS_RUST_CMD=br." >&2
   exit 1
 fi
 
@@ -69,15 +73,15 @@ for rel in "${items[@]}"; do
     criteria="See ${file} for validation details."
   fi
 
-  echo "[br] creating bead for: ${title} (status=${status}, priority=${priority})" >&2
+  echo "[${beads_cmd}] creating bead for: ${title} (status=${status}, priority=${priority})" >&2
 
-  br create "${title}" \
+  "${beads_cmd}" create "${title}" \
     --type Task \
     --priority "${priority}" \
     --labels tooling \
     --description "${desc}" \
     --acceptance-criteria "${criteria}" || {
-      echo "error: br create failed for ${file}" >&2
+      echo "error: ${beads_cmd} create failed for ${file}" >&2
       exit 1
     }
 
@@ -85,10 +89,10 @@ for rel in "${items[@]}"; do
 done
 
 # Export the current SQLite state back to JSONL so it can be committed.
-if br sync --flush-only >/dev/null 2>&1; then
-  echo "br sync --flush-only completed; .beads/issues.jsonl updated" >&2
+if "${beads_cmd}" sync --flush-only >/dev/null 2>&1; then
+  echo "${beads_cmd} sync --flush-only completed; .beads/issues.jsonl updated" >&2
 else
-  echo "warning: br sync --flush-only failed; check beads_rust version" >&2
+  echo "warning: ${beads_cmd} sync --flush-only failed; check the beads_rust CLI version" >&2
 fi
 
 echo "tooling queue migration to beads_rust completed (subject to any warnings above)." >&2


### PR DESCRIPTION
## **User description**
This fixes the beads command-name collision between the Homebrew `beads_viewer` CLI and the upstream `beads_rust` binary.

Changes:
- expose the repo-managed Rust CLI as `beads-rust` via a wrapper package
- keep `bv` for the viewer/TUI
- update the Home Manager beads module to install `beads-rust-cli`
- update scripts/docs to use `beads-rust` by default
- make `scripts/beads-migrate-tooling.sh` fail clearly when only the viewer `br` is present, while still allowing `BEADS_RUST_CMD=br` as an explicit override

Validation:
- `bash -n scripts/beads-migrate-tooling.sh`
- `git diff --check`
- `nix eval --raw .#checks.x86_64-linux.module-loading-eval.outPath`
- `nix eval` of `pkgs.beads-rust-cli.name`
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Avoid the Beads `br` command collision**

### What Changed
- The repo now exposes the Beads CLI as `beads-rust` instead of `br`, so it no longer clashes with the Homebrew viewer command.
- Home Manager installs the new `beads-rust` wrapper while `bv` stays the viewer and triage tool.
- The migration script and docs now use `beads-rust` by default, and the script gives a clear fallback hint if only `br` is installed.

### Impact
`✅ Fewer command-name conflicts`
`✅ Clearer setup for Beads users`
`✅ Safer migration on hosts with Homebrew viewer tools`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=RIH2hSvxGUm2vz3p0IymsBGzLEnHwSffKStdiJCvUWw&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
