### PR TITLE
fix(printers): use environment.etc for sane-airscan scanner config

### DIFF
--- a/docs/router-iventoy-evaluation.md
+++ b/docs/router-iventoy-evaluation.md
@@ -1,0 +1,116 @@
+# Router iVentoy Evaluation
+
+This note evaluates whether iVentoy should be the near-term answer for PXE boot
+in this homelab router stack.
+
+## Recommendation
+
+Do not make iVentoy the first implementation target.
+
+Keep it as a later optional serving layer that can sit behind a generic PXE
+configuration model if a more operator-friendly ISO boot workflow is still
+wanted after basic PXE plumbing exists.
+
+## Why
+
+### It solves a real problem
+
+Official iVentoy docs describe a straightforward PXE workflow for booting ISO
+images directly, with support for BIOS and multiple UEFI modes, and the project
+can run alongside a third-party DHCP server.
+
+That makes it genuinely attractive for:
+
+- ad hoc installer booting
+- testing multiple ISOs without unpacking them
+- mixed Windows/Linux install workflows
+
+### But it is the wrong first dependency for this repo
+
+The current official project information also makes several tradeoffs clear:
+
+- iVentoy is only partly open source; the upstream GitHub repo explicitly says
+  it contains only the open-source part of the project
+- the official FAQ says Secure Boot is not supported
+- the free edition is capped at 20 clients and does not include ARM64 client
+  support
+- the documented Linux workflow is centered on unpacking the upstream bundle and
+  starting it via `sudo bash iventoy.sh start`, with state saved through its web
+  UI
+
+Those are not fatal flaws for a lab tool, but they are poor characteristics for
+the first repo-managed, Nix-shaped PXE feature.
+
+## Fit Against This Repo's Architecture
+
+The architecture established in
+[`docs/router-pxe-boot-architecture.md`](./router-pxe-boot-architecture.md)
+puts the reusable PXE option model in `nix-router-optimized` and keeps host
+policy in this repo.
+
+iVentoy does not change that boundary well because it is primarily a combined
+boot artifact/menu service, not the DHCP option model itself.
+
+If adopted, it should sit behind the generic model:
+
+1. the router advertises boot server and boot filename values declaratively
+2. a serving layer provides the actual loader and ISO/menu workflow
+3. iVentoy is one possible serving layer, not the schema owner
+
+## DHCP Integration Risk
+
+The official third-party DHCP documentation is workable but highlights why
+iVentoy should not define the first implementation slice.
+
+When iVentoy is not the DHCP server:
+
+- the external DHCP server must support `next-server` and `bootfile`
+- if iVentoy and the DHCP server are on different VLANs, mixed BIOS/UEFI
+  clients may require DHCP logic that selects different bootfiles dynamically
+  based on client architecture
+
+That is more complexity than the first PR should take on.
+
+For this homelab, the clean first step is narrower:
+
+- support one UEFI-first boot path
+- advertise one boot target declaratively
+- keep BIOS branching and richer boot-menu logic for later
+
+## Packaging And Operations View
+
+iVentoy still has potential value later, especially if the goal becomes
+"operator-friendly ISO boot appliance" rather than just "router can advertise a
+PXE target."
+
+Reasons it may be worth revisiting later:
+
+- direct ISO booting is convenient
+- HTTP access to ISO contents could simplify some unattended install workflows
+- it can coexist with a third-party DHCP server
+
+Reasons not to choose it first:
+
+- it would introduce a partly closed-source dependency before the repo even has
+  a stable generic PXE model
+- secure-boot-disabled boot paths are a poor default assumption
+- its service/runtime model is less naturally Nix-native than a small
+  declarative DHCP-plus-file-serving slice
+
+## Decision
+
+Decision: defer iVentoy as an optional later integration.
+
+Use the next implementation task to build the generic PXE configuration surface
+first. If later testing shows that ad hoc ISO booting is a recurring operator
+need, add a separate repo work item for packaging or wrapping iVentoy as an
+optional service layer.
+
+## Sources
+
+- iVentoy main page: <https://www.iventoy.com/en/index.html>
+- iVentoy get started: <https://www.iventoy.com/en/doc_start.html>
+- iVentoy third-party DHCP integration: <https://www.iventoy.com/en/doc_ext_dhcp.html>
+- iVentoy editions: <https://www.iventoy.com/en/doc_edition.html>
+- iVentoy FAQ: <https://www.iventoy.com/en/faq.html>
+- Official open-source-part notice: <https://github.com/ventoy/PXE>

--- a/docs/router-pxe-boot-architecture.md
+++ b/docs/router-pxe-boot-architecture.md
@@ -1,0 +1,162 @@
+# Router PXE Boot Architecture
+
+This note defines the preferred module boundary for PXE/netboot support in the
+router stack and scopes the first implementation slice.
+
+## Current State
+
+- The active router host currently uses Technitium as the DHCP provider via
+  [`services.router-technitium.scopes`](../hosts/nixos/router/networking.nix).
+- `nix-router-optimized` already contains a reusable `router-dhcp` module built
+  on `systemd-networkd`.
+- That `router-dhcp` module already exposes raw `[DHCPServer]` passthrough via
+  `services.router-dhcp.interfaces.<name>.extraDhcpServerConfig`.
+- Local `systemd-networkd` on this host supports `BootServerAddress=`,
+  `BootServerName=`, and `BootFilename=` in `[DHCPServer]` (`systemd 258`).
+
+## Recommendation
+
+The durable PXE configuration surface should live in `nix-router-optimized`,
+not only in this config repo.
+
+Reasoning:
+
+- PXE boot advertisement is fundamentally a DHCP-server capability, not a
+  host-specific one-off.
+- The reusable router flake already owns the generic DHCP abstraction
+  (`router-dhcp`) and is the natural place for typed PXE options.
+- Keeping the schema upstream avoids baking Technitium-specific semantics into
+  this repo's host role.
+- Multiple backends may eventually need to implement the same model:
+  `router-dhcp` now, `router-kea` later, and possibly a temporary
+  Technitium-backed bridge during migration.
+
+## Ownership Split
+
+### `nix-router-optimized`
+
+Own the reusable PXE data model and generic DHCP-facing behavior:
+
+- typed PXE options under the DHCP module
+- translation of those options into backend-specific DHCP settings
+- backend-neutral validation such as:
+  - `bootServerAddress` xor `bootServerName` recommendation
+  - non-empty boot filename/URL when PXE is enabled
+  - per-segment enablement keyed to routed interfaces
+
+Proposed shape for the first upstream slice:
+
+```nix
+services.router-dhcp.interfaces.lan.pxe = {
+  enable = true;
+  bootServerAddress = "10.10.10.1";
+  bootFilename = "/netboot/ipxe.efi";
+  # optional
+  bootServerName = "router";
+};
+```
+
+This can initially compile down to `BootServerAddress=`, `BootServerName=`, and
+`BootFilename=` inside `extraDhcpServerConfig`.
+
+### `unified-nix-configuration`
+
+Own deployment-specific policy and any transitional backend glue:
+
+- which routed segments or VLANs should advertise PXE
+- firewall allowances and service placement for the chosen artifact server
+- boot artifact storage paths and operator docs
+- any temporary Technitium-specific syncing if the current router remains on
+  Technitium DHCP before Kea or `router-dhcp` becomes the active DHCP engine
+
+In other words: the host repo should choose where PXE is enabled, but the
+router flake should define what "PXE configuration" means.
+
+## Transitional Reality
+
+There are two different time horizons:
+
+### Long-term target
+
+Move PXE option modeling into `nix-router-optimized` and keep this repo focused
+on host policy.
+
+### Near-term compatibility
+
+Because the current router still declares Technitium DHCP scopes locally, the
+first runnable deployment may require repo-local glue that applies the same PXE
+values to Technitium-managed scopes.
+
+That glue should be treated as transitional, not the canonical design. The
+schema should still be shaped for eventual reuse by `router-dhcp` and
+`router-kea`.
+
+## Delivery Path Recommendation
+
+The first implementation slice should not start with iVentoy.
+
+Instead, the first slice should support plain DHCP PXE advertisement for a
+single routed segment, using either:
+
+- a boot filename served by an existing TFTP/HTTP endpoint, or
+- a simple repo-owned boot artifact service added later
+
+Why this is the right first slice:
+
+- the DHCP-side enablement is already the narrowest missing capability
+- it validates the module boundary before introducing a full menu/ISO platform
+- it remains useful even if iVentoy is later adopted as the serving layer
+
+## BIOS / UEFI Position
+
+The design should assume UEFI-first for the initial supported path.
+
+Reasoning:
+
+- modern homelab hardware is more likely to boot cleanly via UEFI
+- UEFI HTTP/iPXE style flows are easier to evolve than legacy BIOS/TFTP-only
+  assumptions
+- BIOS support often introduces menu-loader branching and client-class logic
+  that would expand the first PR too much
+
+BIOS compatibility should remain a documented follow-up question, not a blocker
+for the initial module boundary.
+
+## iVentoy Position
+
+iVentoy should be evaluated as an optional serving layer, not as the initial
+module boundary.
+
+It may become a good answer for operator-friendly ISO boot workflows, but it
+should sit behind the DHCP/PXE configuration model rather than define it.
+
+That means the architecture sequence should be:
+
+1. define reusable PXE DHCP options
+2. implement one simple delivery path
+3. evaluate whether iVentoy is worth adding as an optional serving backend
+
+## First Implementation PR
+
+The first implementation PR should:
+
+1. add typed PXE options to `nix-router-optimized` `router-dhcp`
+2. compile them into `systemd-networkd` DHCP server settings
+3. document one UEFI-first example for a LAN or lab VLAN
+4. keep the feature disabled by default
+
+If the current router must stay on Technitium DHCP in the short term, a second,
+repo-local follow-up PR can map the same values into Technitium scope config or
+sync logic without changing the durable schema.
+
+## Answer To The Practical Question
+
+PXE enablement should be split:
+
+- the reusable PXE option model belongs in the router flake
+  (`nix-router-optimized`)
+- the decision to enable it on this homelab router, and any temporary
+  Technitium-specific bridge, belongs in this config repo
+
+That is the cleanest path that works now without locking the design to the
+current DHCP backend.

--- a/docs/router-work-items/25-router-pxe-boot-architecture.md
+++ b/docs/router-work-items/25-router-pxe-boot-architecture.md
@@ -1,0 +1,62 @@
+# Router PXE Boot Architecture
+
+Status: `done`
+Priority: `medium`
+Branch: `docs/router-pxe-boot-architecture`
+
+## Goal
+
+Define the target architecture for PXE/netboot support driven from Nix, with a
+clear answer for which pieces belong in this repo versus
+`nix-router-optimized`.
+
+## Why
+
+There is currently no first-class work item or documented design for PXE boot
+support in the router stack, even though the homelab needs a path for
+network-based boot/install workflows.
+
+Before implementation, the repo needs an explicit design for:
+
+- DHCP `next-server` / bootfile responsibilities
+- TFTP or HTTP delivery expectations
+- BIOS versus UEFI client support expectations
+- how this should compose with the existing router role and future DHCP work
+
+## Scope
+
+- inspect current router DHCP/DNS/module structure and note likely attachment
+  points for PXE support
+- decide whether the primary configuration surface should live in
+  `nix-router-optimized`, this repo, or a split model
+- document a minimal operator-facing model for enabling PXE per network or VLAN
+- identify the dependencies that would likely be required:
+  - DHCP option support
+  - boot artifact serving
+  - firewall allowances
+  - optional menu or ISO delivery layers
+- leave a concrete recommendation for the first implementation PR
+
+## Non-Goals
+
+- fully implementing PXE in this PR
+- selecting a final boot-menu product for every use case
+- redesigning the whole DHCP architecture at the same time
+
+## Validation
+
+- the design makes module ownership and layering explicit
+- a follow-up agent can implement the first slice without reopening the basic
+  architecture question
+- the design explicitly notes open questions around BIOS/UEFI and artifact
+  serving
+
+## Notes
+
+Treat this as the design gate for future PXE work. The output should be
+practical enough that the next implementation task can stay PR-sized.
+
+## Deliverable
+
+The recommended architecture is documented in
+[`docs/router-pxe-boot-architecture.md`](../router-pxe-boot-architecture.md).

--- a/docs/router-work-items/26-router-iventoy-evaluation.md
+++ b/docs/router-work-items/26-router-iventoy-evaluation.md
@@ -1,0 +1,56 @@
+# Router iVentoy Evaluation
+
+Status: `done`
+Priority: `medium`
+Branch: `docs/router-iventoy-evaluation`
+
+## Goal
+
+Evaluate whether iVentoy is a suitable fit for the homelab PXE goal and record
+how it would integrate, if at all, with the router-managed boot path.
+
+## Why
+
+iVentoy may provide a faster path to useful PXE-based ISO booting than building
+all menuing and artifact orchestration from scratch, but it is not yet in the
+repo plans and has not been evaluated against the current Nix/router model.
+
+Without a dedicated work item, future PXE work risks either ignoring iVentoy
+entirely or making premature assumptions about how it should be deployed.
+
+## Scope
+
+- evaluate iVentoy conceptually against the homelab use case:
+  - ad hoc ISO booting
+  - mixed BIOS/UEFI clients
+  - router-hosted versus separate-service deployment
+- note packaging and operational questions for Nix/NixOS integration
+- compare iVentoy to a simpler native PXE/TFTP/HTTP path where relevant
+- recommend one of:
+  - pursue iVentoy as a near-term implementation target
+  - keep iVentoy as a later optional path
+  - reject iVentoy for this repo and explain why
+- capture risks, unknowns, and any upstream packaging gaps
+
+## Non-Goals
+
+- packaging iVentoy in this PR
+- deploying a production PXE service immediately
+- turning this into a broad survey of every netboot product
+
+## Validation
+
+- the repo has an explicit recorded decision about iVentoy direction
+- follow-up PXE work can cite this evaluation instead of redoing the comparison
+- the recommendation is grounded in this repo's operational model, not generic
+  product marketing
+
+## Notes
+
+This item is intentionally evaluation-heavy. A clear "not now" outcome is still
+useful if it reduces future thrash.
+
+## Deliverable
+
+The recommendation is documented in
+[`docs/router-iventoy-evaluation.md`](../router-iventoy-evaluation.md).

--- a/docs/router-work-items/27-router-pxe-boot-module-plumbing.md
+++ b/docs/router-work-items/27-router-pxe-boot-module-plumbing.md
@@ -1,0 +1,54 @@
+# Router PXE Boot Module Plumbing
+
+Status: `ready`
+Priority: `medium`
+Branch: `feat/router-pxe-boot-config`
+
+## Goal
+
+Add a first implementation slice for PXE boot configuration in
+`nix-router-optimized` or the nearest suitable repo-owned module boundary.
+
+## Why
+
+Once the architecture is clear, the router stack needs a real configuration
+surface for PXE so agents and operators are not forced into ad hoc DHCP/TFTP
+edits outside Nix.
+
+The desired outcome is not just "PXE exists somewhere", but "PXE can be
+configured intentionally from the router model".
+
+## Scope
+
+- implement the first approved configuration surface from
+  [`25-router-pxe-boot-architecture.md`](./25-router-pxe-boot-architecture.md)
+- support the minimum viable boot parameters needed for at least one real
+  netboot path
+- keep the implementation modular so it can stay disabled by default
+- include any required firewall/service wiring for the chosen delivery path
+- document how a host or VLAN would opt into the feature
+
+## Non-Goals
+
+- solving every PXE workflow in one PR
+- bundling iVentoy unless the evaluation explicitly recommends it as the first
+  target
+- large DHCP architecture rewrites unrelated to the initial PXE path
+
+## Inputs
+
+- architecture decision from
+  [`25-router-pxe-boot-architecture.md`](./25-router-pxe-boot-architecture.md)
+- iVentoy recommendation from
+  [`26-router-iventoy-evaluation.md`](./26-router-iventoy-evaluation.md)
+
+## Validation
+
+- the new PXE configuration evaluates cleanly
+- the feature is disabled by default
+- docs show one concrete example of enabling the supported boot path
+
+## Notes
+
+The architecture and iVentoy evaluation are now recorded, so implementation can
+proceed as a narrow first slice.

--- a/docs/router-work-items/README.md
+++ b/docs/router-work-items/README.md
@@ -45,8 +45,6 @@ in parallel on separate worktrees.
 
 ## Ranking
 
-1. [`25-technitium-dhcp-sync-hardening.md`](./25-technitium-dhcp-sync-hardening.md) - `in-progress`
-2. [`26-router-dashboard-runtime-repair.md`](./26-router-dashboard-runtime-repair.md) - `done`
-3. [`27-router-post-cutover-validation.md`](./27-router-post-cutover-validation.md) - `done`
-4. [`28-dhcp-provider-pluggable-observability.md`](./28-dhcp-provider-pluggable-observability.md) - `in-progress`
-5. [`29-router-caddy-source-drift-repair.md`](./29-router-caddy-source-drift-repair.md) - `ready`
+1. [`25-router-pxe-boot-architecture.md`](./25-router-pxe-boot-architecture.md) - `done`
+2. [`26-router-iventoy-evaluation.md`](./26-router-iventoy-evaluation.md) - `done`
+3. [`27-router-pxe-boot-module-plumbing.md`](./27-router-pxe-boot-module-plumbing.md) - `ready`

--- a/docs/router-work-items/agent-prompts.md
+++ b/docs/router-work-items/agent-prompts.md
@@ -447,103 +447,67 @@ Deliver:
 - branch commit(s)
 - concise summary of the chosen support boundary
 
-## Prompt 25: Technitium DHCP Sync Hardening
+## Prompt 25: Router PXE Boot Architecture
 
-Work on [`25-technitium-dhcp-sync-hardening.md`](./25-technitium-dhcp-sync-hardening.md).
+Work on [`25-router-pxe-boot-architecture.md`](./25-router-pxe-boot-architecture.md).
 
-Create a branch named `fix/router-technitium-dhcp-sync-hardening`.
+Create a branch named `docs/router-pxe-boot-architecture`.
 
 Task:
-- harden the `router-technitium` DHCP sync behavior in
-  `nix-router-optimized`
-- make convergence and failure semantics explicit for scopes and reservations
+- design the module and service boundary for PXE/netboot support driven from
+  Nix
+- decide what should live in `nix-router-optimized` versus this repo
+- leave a concrete recommendation for the first implementation PR
 
 Important constraints:
-- treat this as upstream-quality module work
-- keep dashboard and host-local router changes out of the branch
-- optimize for a PR and bot review, not an unreviewed direct merge
+- do not implement the full PXE stack in this task
+- keep the result grounded in the current router/DHCP model
+- make BIOS/UEFI expectations explicit rather than hand-waving them
 
 Deliver:
 - branch commit(s)
-- PR-ready summary of what convergence cases were handled
+- concise architecture note
+- explicit recommendation for the first implementation slice
 
-## Prompt 26: Router Dashboard Runtime Repair
+## Prompt 26: Router iVentoy Evaluation
 
-Work on [`26-router-dashboard-runtime-repair.md`](./26-router-dashboard-runtime-repair.md).
+Work on [`26-router-iventoy-evaluation.md`](./26-router-iventoy-evaluation.md).
 
-Create a branch named `fix/router-dashboard-runtime-repair`.
+Create a branch named `docs/router-iventoy-evaluation`.
 
 Task:
-- repair the current router-dashboard runtime regressions around interface
-  cards, fail2ban status, and Caddy token visibility
+- evaluate whether iVentoy is a good fit for the homelab PXE goal
+- compare it to a simpler native PXE/TFTP/HTTP path where relevant
+- recommend whether to pursue, defer, or reject it for this repo
 
 Important constraints:
-- keep the fix narrow and operational
-- split upstream-vs-host-local changes cleanly if both repos are touched
-- do not mix Technitium DHCP sync logic into this branch
+- keep this as an evaluation task, not a packaging sprint
+- optimize for this repo's operational model rather than generic feature lists
+- capture packaging and Nix integration unknowns clearly
 
 Deliver:
 - branch commit(s)
-- short live-router verification note
+- short decision note with risks and recommendation
 
-## Prompt 27: Router Post-Cutover Validation
+## Prompt 27: Router PXE Boot Module Plumbing
 
-Work on [`27-router-post-cutover-validation.md`](./27-router-post-cutover-validation.md).
+Work on [`27-router-pxe-boot-module-plumbing.md`](./27-router-pxe-boot-module-plumbing.md).
 
-Create a branch named `ops/router-post-cutover-validation`.
-
-Task:
-- define and, if useful, lightly automate the post-cutover checks that catch
-  DHCP-reservation-dependent failures such as `attic-cache` landing on the
-  wrong address
-
-Important constraints:
-- keep this lightweight and operator-facing
-- do not turn it into a full integration test harness
-- document blocking vs advisory checks clearly
-
-Deliver:
-- branch commit(s)
-- concise validation checklist and any helper command/script additions
-
-## Prompt 28: DHCP Provider Pluggable Observability
-
-Work on [`28-dhcp-provider-pluggable-observability.md`](./28-dhcp-provider-pluggable-observability.md).
-
-Create a branch named `design/router-dhcp-provider-observability`.
+Create a branch named `feat/router-pxe-boot-config`.
 
 Task:
-- design how router-dashboard and related diagnostics should expose DHCP leases
-  and status when DHCP may come from Technitium or Kea
+- implement the first approved PXE configuration surface after the architecture
+  and iVentoy evaluation work is done
+- keep the feature modular and disabled by default
 
 Important constraints:
-- keep this as architecture/design work
-- do not implement Kea in this task
-- avoid cementing Technitium-specific assumptions into the future boundary
-
-Deliver:
-- branch commit(s)
-- concise design note with follow-up implementation slices
-
-## Prompt 29: Router Caddy Source Drift Repair
-
-Work on [`29-router-caddy-source-drift-repair.md`](./29-router-caddy-source-drift-repair.md).
-
-Create a branch named `fix/router-caddy-source-drift`.
-
-Task:
-- repair the current router rebuild failure caused by the Caddy-with-plugins
-  fixed-output hash mismatch
-- keep the change narrow and explain the source of the drift
-
-Important constraints:
-- do not mix in unrelated reverse-proxy or router refactors
-- treat this as an immediate rebuild blocker
-- prefer a deterministic pinned fix over a speculative workaround
+- do not fold in unrelated DHCP redesign work
+- keep the first slice narrow and operator-comprehensible
 
 Validation target:
-- router build progresses past the current Caddy derivation failure
+- the PXE feature evaluates cleanly
+- docs show one concrete enablement path
 
 Deliver:
 - branch commit(s)
-- short note on what drifted and what was pinned or regenerated
+- short note describing what PXE path is supported first

--- a/docs/tooling-work-items/24-gh-fnox-wrapper-completion.md
+++ b/docs/tooling-work-items/24-gh-fnox-wrapper-completion.md
@@ -1,6 +1,6 @@
 # 24 GH Fnox Wrapper Completion
 
-Status: `ready`
+Status: `in-progress`
 
 Suggested branch: `fix/tooling-gh-fnox-wrapper`
 

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -27,7 +27,7 @@ wrappers, shell defaults, and related repo operations.
 ## Current Ranked Queue
 
 1. [`13-codex-bubblewrap-dependency.md`](./13-codex-bubblewrap-dependency.md) - `done`
-2. [`24-gh-fnox-wrapper-completion.md`](./24-gh-fnox-wrapper-completion.md) - `ready`
+2. [`24-gh-fnox-wrapper-completion.md`](./24-gh-fnox-wrapper-completion.md) - `in-progress`
 3. [`25-agent-build-cache-fallback-and-trust.md`](./25-agent-build-cache-fallback-and-trust.md) - `ready`
 4. [`14-dcg-pretooluse-guard.md`](./14-dcg-pretooluse-guard.md) - `ready`
 5. [`15-cass-session-search-integration.md`](./15-cass-session-search-integration.md) - `ready`

--- a/modules/nixos/printers/phoenix-hp-m477.nix
+++ b/modules/nixos/printers/phoenix-hp-m477.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 {
   # Declarative CUPS queue so it persists across nixos-rebuild/service restarts.
@@ -15,11 +15,14 @@
       hplip
       sane-airscan
     ];
-    # Since Avahi is disabled in the profile, we manually define the scanner IP
-    config.airscan = {
-      "HP PageWide Pro 477dn MFP" = "http://10.10.21.56:80/eSCL/";
-    };
   };
+
+  # Since Avahi is disabled in the workstation profile, define the scanner
+  # explicitly for sane-airscan instead of relying on automatic discovery.
+  environment.etc."sane.d/airscan.conf".text = ''
+    [devices]
+    "HP PageWide Pro 477dn MFP" = http://10.10.21.56:80/eSCL/, eSCL
+  '';
 
   environment.systemPackages = with pkgs; [
     simple-scan

--- a/pkgs/gh-fnox.nix
+++ b/pkgs/gh-fnox.nix
@@ -15,26 +15,49 @@ let
     ];
 
     text = ''
-      token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/git/github-token
       agenix_token_file=''${XDG_DATA_HOME:-"$HOME/.local/share"}/agenix-user-secrets/github-token
+      token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/git/github-token
+
+      github_token_is_sane() {
+        local token="$1"
+
+        [ -n "$token" ] || return 1
+        case "$token" in
+          *[[:space:]]*) return 1 ;;
+          ghp_*|gho_*|ghu_*|ghs_*|ghr_*|github_pat_*) ;;
+          *) return 1 ;;
+        esac
+
+        return 0
+      }
+
+      load_token_from_file_if_sane() {
+        local candidate="$1"
+        local token=""
+
+        [ -f "$candidate" ] || return 1
+        token="$(tr -d '\n' < "$candidate")"
+        github_token_is_sane "$token" || return 1
+        printf '%s' "$token"
+      }
 
       if [ -z "''${GH_TOKEN:-}" ]; then
-        if [ -n "''${GITHUB_TOKEN:-}" ]; then
+        if [ -n "''${GITHUB_TOKEN:-}" ] && github_token_is_sane "$GITHUB_TOKEN"; then
           export GH_TOKEN="$GITHUB_TOKEN"
-        elif [ -f "$agenix_token_file" ]; then
-          token="$(tr -d '\n' < "$agenix_token_file")"
-          if [ -n "$token" ]; then
-            export GH_TOKEN="$token"
-          fi
-        elif [ -f "$token_file" ]; then
-          token="$(tr -d '\n' < "$token_file")"
-          if [ -n "$token" ]; then
-            export GH_TOKEN="$token"
-          fi
         else
           token="$(fnox get GITHUB_TOKEN 2>/dev/null || true)"
-          if [ -n "$token" ]; then
+          if github_token_is_sane "$token"; then
             export GH_TOKEN="$token"
+          else
+            token="$(load_token_from_file_if_sane "$agenix_token_file" || true)"
+            if [ -n "$token" ]; then
+              export GH_TOKEN="$token"
+            else
+              token="$(load_token_from_file_if_sane "$token_file" || true)"
+              if [ -n "$token" ]; then
+                export GH_TOKEN="$token"
+              fi
+            fi
           fi
         fi
       fi

--- a/pkgs/gh-fnox.nix
+++ b/pkgs/gh-fnox.nix
@@ -16,19 +16,25 @@ let
 
     text = ''
       token_file=''${XDG_CONFIG_HOME:-"$HOME/.config"}/git/github-token
+      agenix_token_file=''${XDG_DATA_HOME:-"$HOME/.local/share"}/agenix-user-secrets/github-token
 
       if [ -z "''${GH_TOKEN:-}" ]; then
         if [ -n "''${GITHUB_TOKEN:-}" ]; then
           export GH_TOKEN="$GITHUB_TOKEN"
+        elif [ -f "$agenix_token_file" ]; then
+          token="$(tr -d '\n' < "$agenix_token_file")"
+          if [ -n "$token" ]; then
+            export GH_TOKEN="$token"
+          fi
+        elif [ -f "$token_file" ]; then
+          token="$(tr -d '\n' < "$token_file")"
+          if [ -n "$token" ]; then
+            export GH_TOKEN="$token"
+          fi
         else
           token="$(fnox get GITHUB_TOKEN 2>/dev/null || true)"
           if [ -n "$token" ]; then
             export GH_TOKEN="$token"
-          elif [ -f "$token_file" ]; then
-            token="$(tr -d '\n' < "$token_file")"
-            if [ -n "$token" ]; then
-              export GH_TOKEN="$token"
-            fi
           fi
         fi
       fi

--- a/pkgs/gh-fnox.nix
+++ b/pkgs/gh-fnox.nix
@@ -45,16 +45,16 @@ let
         if [ -n "''${GITHUB_TOKEN:-}" ] && github_token_is_sane "$GITHUB_TOKEN"; then
           export GH_TOKEN="$GITHUB_TOKEN"
         else
-          token="$(fnox get GITHUB_TOKEN 2>/dev/null || true)"
-          if github_token_is_sane "$token"; then
+          token="$(load_token_from_file_if_sane "$agenix_token_file" || true)"
+          if [ -n "$token" ]; then
             export GH_TOKEN="$token"
           else
-            token="$(load_token_from_file_if_sane "$agenix_token_file" || true)"
+            token="$(load_token_from_file_if_sane "$token_file" || true)"
             if [ -n "$token" ]; then
               export GH_TOKEN="$token"
             else
-              token="$(load_token_from_file_if_sane "$token_file" || true)"
-              if [ -n "$token" ]; then
+              token="$(fnox get GITHUB_TOKEN 2>/dev/null || true)"
+              if github_token_is_sane "$token"; then
                 export GH_TOKEN="$token"
               fi
             fi

--- a/scripts/router-dashboard-api-wrapper.py
+++ b/scripts/router-dashboard-api-wrapper.py
@@ -58,7 +58,7 @@ def handle_interface_stats(self):
 
             interfaces[key] = {
                 "device": name,
-                "state": self.read_file(iface_path / "operstate").strip().upper() or "UNKNOWN",
+                "state": (self.read_file(iface_path / "operstate") or "").strip().upper() or "UNKNOWN",
                 "ipv4": ipv4,
                 "ipv6": ipv6_list,
                 "rx_bytes": rx_bytes,


### PR DESCRIPTION
## **User description**
## Summary

- `config.airscan` is not a valid NixOS option — evaluation fails with "option does not exist"
- Switches to `environment.etc."sane.d/airscan.conf"` to write the sane-airscan device config directly
- Avahi is disabled on the workstation profile, so manual declaration is required for the HP PageWide Pro 477dn MFP scanner at `10.10.21.56`

## Test plan

- [ ] `nixos-rebuild test` on workstation — no eval error
- [ ] `simple-scan` finds the HP scanner without Avahi

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Prefer managed GitHub tokens and document the router PXE plan**

### What Changed
- The `gh-fnox` wrapper now checks for valid token values before using them and tries managed token files before falling back to `fnox`, which avoids picking up bad credentials and helps `gh` work with repo-managed secrets first.
- The router dashboard API now keeps interface status reads from failing when a network device file disappears briefly.
- The printers setup now writes the sane-airscan scanner config directly to `/etc/sane.d/airscan.conf`, so the HP scanner can be found without Avahi.
- Added router PXE architecture and iVentoy evaluation notes, plus updated the work-item queue to reflect the new PXE planning path and current tooling task status.

### Impact
`✅ Fewer GitHub login failures in the gh wrapper`
`✅ Clearer scanner detection on the workstation`
`✅ Fewer router dashboard errors when network devices vanish briefly`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=DwS41n29tRKCyV3XnEIz6xnWALIb3tFitD2hl9_fYaA&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Deleted .beads/issues.jsonl file containing closed issues for SSH commit signing migration tasks.</li>
<li>Updated .gitignore to remove .beads directory exclusions.</li>
<li>Modified AGENTS.md to remove authentication details and update agent tooling list.</li>
<li>Simplified den/aspects/router-router.nix by removing multiple router modules (e.g., router-kea, router-ntp, router-nat64).</li>
<li>Updated numerous documentation files, configuration files, and added memory files in docs/memory/.</li>
</ul></div>