### PR TITLE
fix(router): harden dashboard review follow-ups

### DIFF
--- a/docs/router-work-items/28-router-dashboard-review-hardening.md
+++ b/docs/router-work-items/28-router-dashboard-review-hardening.md
@@ -1,6 +1,6 @@
 # Router Dashboard Review Hardening
 
-Status: `ready`
+Status: `in-progress`
 Priority: `high`
 Branch: `fix/router-dashboard-review-hardening`
 

--- a/modules/nixos/router-dashboard-runtime-repair.nix
+++ b/modules/nixos/router-dashboard-runtime-repair.nix
@@ -13,6 +13,16 @@ let
 in
 {
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = builtins.hasAttr "router-dashboard" config.users.groups;
+        message = ''
+          router-dashboard-runtime-repair expects a router-dashboard group so
+          /run/router-dashboard and the Cloudflare token can be shared safely.
+        '';
+      }
+    ];
+
     systemd.services.router-dashboard.environment = {
       DASHBOARD_UPSTREAM_SERVER = "${inputs.nix-router-optimized.outPath}/modules/router-dashboard/api/server.py";
       DASHBOARD_INTERFACES = builtins.toJSON cfg.interfaces;
@@ -36,13 +46,31 @@ in
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${pkgs.python3}/bin/python3 ${fail2banSnapshotScript}";
+        # Keep root because fail2ban-client needs access to the control socket,
+        # but tighten the sandbox around the snapshot writer itself.
         User = "root";
         Group = "root";
-        PrivateTmp = false;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [ "/run/router-dashboard" ];
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
       };
       environment = {
         DASHBOARD_FAIL2BAN_CLIENT = "${pkgs.fail2ban}/bin/fail2ban-client";
         DASHBOARD_FAIL2BAN_STATUS_FILE = fail2banSnapshotFile;
+        DASHBOARD_FAIL2BAN_STATUS_GROUP = "router-dashboard";
       };
       wantedBy = [ "multi-user.target" ];
     };

--- a/scripts/router-dashboard-api-wrapper.py
+++ b/scripts/router-dashboard-api-wrapper.py
@@ -2,30 +2,100 @@
 import importlib.util
 import json
 import os
+import subprocess
+import sys
 
-UPSTREAM_SERVER = os.environ["DASHBOARD_UPSTREAM_SERVER"]
+
+def log_warning(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def get_required_env(name):
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def load_optional_secret(path, env_name):
+    if not path:
+        return
+
+    if not os.path.exists(path):
+        log_warning(f"Optional secret file not found for {env_name}: {path}")
+        return
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            os.environ[env_name] = handle.read().strip()
+    except OSError as exc:
+        log_warning(f"Failed reading optional secret file for {env_name}: {exc}")
+
+
+def parse_interfaces_env():
+    raw = os.environ.get("DASHBOARD_INTERFACES", "[]")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        log_warning(f"Invalid DASHBOARD_INTERFACES JSON: {exc}")
+        return []
+
+    if not isinstance(parsed, list):
+        log_warning("DASHBOARD_INTERFACES must decode to a list; ignoring malformed value")
+        return []
+
+    return parsed
+
+
+def read_int_file(handler, path, context):
+    raw = handler.read_file(path)
+    if raw is None:
+        return 0
+
+    text = str(raw).strip()
+    if not text:
+        return 0
+
+    try:
+        return int(text)
+    except ValueError:
+        log_warning(f"Invalid integer in {path} for {context}: {text!r}")
+        return 0
+
+
+def read_interface_state(handler, path, interface_name):
+    raw = handler.read_file(path)
+    if raw is None:
+        return "UNKNOWN"
+
+    state = str(raw).strip().upper()
+    if not state:
+        log_warning(f"Missing operstate value for interface {interface_name}")
+        return "UNKNOWN"
+
+    return state
+
+
+UPSTREAM_SERVER = get_required_env("DASHBOARD_UPSTREAM_SERVER")
 FAIL2BAN_STATUS_FILE = os.environ.get("DASHBOARD_FAIL2BAN_STATUS_FILE", "")
 CLOUDFLARE_TOKEN_FILE = os.environ.get("DASHBOARD_CLOUDFLARE_TOKEN_FILE", "")
 
-if CLOUDFLARE_TOKEN_FILE and os.path.exists(CLOUDFLARE_TOKEN_FILE):
-    try:
-        with open(CLOUDFLARE_TOKEN_FILE, "r", encoding="utf-8") as handle:
-            os.environ["CLOUDFLARE_API_TOKEN"] = handle.read().strip()
-    except Exception:
-        pass
+if not os.path.exists(UPSTREAM_SERVER):
+    raise SystemExit(f"DASHBOARD_UPSTREAM_SERVER does not exist: {UPSTREAM_SERVER}")
 
+load_optional_secret(CLOUDFLARE_TOKEN_FILE, "CLOUDFLARE_API_TOKEN")
 spec = importlib.util.spec_from_file_location("router_dashboard_upstream", UPSTREAM_SERVER)
+if spec is None or spec.loader is None:
+    raise SystemExit(f"Unable to load dashboard upstream module from {UPSTREAM_SERVER}")
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
-try:
-    dashboard_interfaces = json.loads(os.environ.get("DASHBOARD_INTERFACES", "[]"))
-except json.JSONDecodeError:
-    dashboard_interfaces = []
+dashboard_interfaces = parse_interfaces_env()
 
 interface_role_map = {}
 for interface in dashboard_interfaces:
     if not isinstance(interface, dict):
+        log_warning(f"Ignoring malformed dashboard interface entry: {interface!r}")
         continue
     device = interface.get("device")
     role = interface.get("role") or device
@@ -41,35 +111,38 @@ def handle_interface_stats(self):
         net_path = module.Path("/sys/class/net")
 
         for iface_path in net_path.iterdir():
-            name = iface_path.name
-            if name.startswith(("lo", "docker", "veth", "br-", "virbr")):
-                continue
+            try:
+                name = iface_path.name
+                if name.startswith(("lo", "docker", "veth", "br-", "virbr")):
+                    continue
 
-            stats_path = iface_path / "statistics"
-            if not stats_path.exists():
-                continue
+                stats_path = iface_path / "statistics"
+                if not stats_path.exists():
+                    continue
 
-            rx_bytes = int(self.read_file(stats_path / "rx_bytes") or 0)
-            tx_bytes = int(self.read_file(stats_path / "tx_bytes") or 0)
-            rx_rate, tx_rate = self.calculate_rates(name, rx_bytes, tx_bytes)
-            ipv4 = self.get_ipv4(name)
-            ipv6_list = self.get_ipv6(name)
-            key = interface_role_map.get(name, name)
+                rx_bytes = read_int_file(self, stats_path / "rx_bytes", f"{name} rx_bytes")
+                tx_bytes = read_int_file(self, stats_path / "tx_bytes", f"{name} tx_bytes")
+                rx_rate, tx_rate = self.calculate_rates(name, rx_bytes, tx_bytes)
+                ipv4 = self.get_ipv4(name)
+                ipv6_list = self.get_ipv6(name)
+                key = interface_role_map.get(name, name)
 
-            interfaces[key] = {
-                "device": name,
-                "state": (self.read_file(iface_path / "operstate") or "").strip().upper() or "UNKNOWN",
-                "ipv4": ipv4,
-                "ipv6": ipv6_list,
-                "rx_bytes": rx_bytes,
-                "tx_bytes": tx_bytes,
-                "rx_rate": rx_rate,
-                "tx_rate": tx_rate,
-                "rx_packets": int(self.read_file(stats_path / "rx_packets") or 0),
-                "tx_packets": int(self.read_file(stats_path / "tx_packets") or 0),
-                "rx_errors": int(self.read_file(stats_path / "rx_errors") or 0),
-                "tx_errors": int(self.read_file(stats_path / "tx_errors") or 0),
-            }
+                interfaces[key] = {
+                    "device": name,
+                    "state": read_interface_state(self, iface_path / "operstate", name),
+                    "ipv4": ipv4,
+                    "ipv6": ipv6_list,
+                    "rx_bytes": rx_bytes,
+                    "tx_bytes": tx_bytes,
+                    "rx_rate": rx_rate,
+                    "tx_rate": tx_rate,
+                    "rx_packets": read_int_file(self, stats_path / "rx_packets", f"{name} rx_packets"),
+                    "tx_packets": read_int_file(self, stats_path / "tx_packets", f"{name} tx_packets"),
+                    "rx_errors": read_int_file(self, stats_path / "rx_errors", f"{name} rx_errors"),
+                    "tx_errors": read_int_file(self, stats_path / "tx_errors", f"{name} tx_errors"),
+                }
+            except Exception as exc:
+                log_warning(f"Failed to collect interface stats for {iface_path}: {exc}")
 
         self.send_json(interfaces)
     except Exception as exc:
@@ -128,8 +201,7 @@ def handle_firewall_stats(self):
             )
             offloaded_flows = ft_result.stdout.count("[OFFLOAD]")
         except Exception as exc:
-            print(f"Error running conntrack: {exc}")
-            pass
+            log_warning(f"Error running conntrack: {exc}")
 
         # Get packet counters from ALL configured interfaces
         packets_in = 0
@@ -147,8 +219,7 @@ def handle_firewall_stats(self):
                     if tx:
                         packets_out += int(tx)
         except Exception as exc:
-            print(f"Error getting packet counters: {exc}")
-            pass
+            log_warning(f"Error getting packet counters: {exc}")
 
         self.send_json(
             {
@@ -278,14 +349,13 @@ def handle_fail2ban_status(self):
                 self.send_json(payload)
                 return
             else:
-                print(f"Fail2ban snapshot file NOT FOUND at: {FAIL2BAN_STATUS_FILE}")
+                log_warning(f"Fail2ban snapshot file not found at: {FAIL2BAN_STATUS_FILE}")
         except FileNotFoundError:
-            pass
+            log_warning(f"Fail2ban snapshot file disappeared before read: {FAIL2BAN_STATUS_FILE}")
         except Exception as exc:
-            print(f"Error reading fail2ban snapshot: {exc}")
-            pass
+            log_warning(f"Error reading fail2ban snapshot: {exc}")
 
-    print("Falling back to original handle_fail2ban_status (sudo)")
+    log_warning("Falling back to original handle_fail2ban_status (sudo)")
     return original_handle_fail2ban_status(self)
 
 

--- a/scripts/router-dashboard-fail2ban-snapshot.py
+++ b/scripts/router-dashboard-fail2ban-snapshot.py
@@ -3,19 +3,39 @@ import grp
 import json
 import os
 import subprocess
+import sys
 import tempfile
 
-FAIL2BAN_CLIENT = os.environ["DASHBOARD_FAIL2BAN_CLIENT"]
-OUTPUT_PATH = os.environ["DASHBOARD_FAIL2BAN_STATUS_FILE"]
+
+def log_warning(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def get_required_env(name):
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+FAIL2BAN_CLIENT = get_required_env("DASHBOARD_FAIL2BAN_CLIENT")
+OUTPUT_PATH = get_required_env("DASHBOARD_FAIL2BAN_STATUS_FILE")
+OUTPUT_GROUP = os.environ.get("DASHBOARD_FAIL2BAN_STATUS_GROUP", "router-dashboard").strip() or "router-dashboard"
 
 
 def build_payload():
-    result = subprocess.run(
-        [FAIL2BAN_CLIENT, "status"],
-        capture_output=True,
-        text=True,
-        timeout=5,
-    )
+    try:
+        result = subprocess.run(
+            [FAIL2BAN_CLIENT, "status"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {
+            "available": False,
+            "message": f"Failed to execute fail2ban-client: {exc}",
+        }
 
     if result.returncode != 0:
         return {
@@ -35,13 +55,18 @@ def build_payload():
     all_banned_ips = []
 
     for jail in jails:
-        jail_result = subprocess.run(
-            [FAIL2BAN_CLIENT, "status", jail],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
+        try:
+            jail_result = subprocess.run(
+                [FAIL2BAN_CLIENT, "status", jail],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            log_warning(f"Failed to query fail2ban jail {jail}: {exc}")
+            continue
         if jail_result.returncode != 0:
+            log_warning(f"fail2ban-client status {jail} failed: {jail_result.stderr.strip() or jail_result.stdout.strip()}")
             continue
 
         stats = {
@@ -90,7 +115,7 @@ def main():
         handle.write("\n")
         temp_path = handle.name
 
-    gid = grp.getgrnam("router-dashboard").gr_gid
+    gid = grp.getgrnam(OUTPUT_GROUP).gr_gid
     os.chown(temp_path, 0, gid)
     os.chmod(temp_path, 0o640)
     os.replace(temp_path, OUTPUT_PATH)


### PR DESCRIPTION
## **User description**
Implements `docs/router-work-items/28-router-dashboard-review-hardening.md`.

Changes:
- mark the router dashboard hardening work item `in-progress`
- harden `router-dashboard-api-wrapper.py` with explicit required env handling, stderr logging, safe integer parsing, per-interface degradation, and a missing `subprocess` import for firewall stats
- harden `router-dashboard-fail2ban-snapshot.py` so missing env/subprocess failures degrade to structured unavailable payloads instead of crashing
- make the fail2ban snapshot group assumption explicit via `DASHBOARD_FAIL2BAN_STATUS_GROUP`
- add a Nix assertion that the `router-dashboard` group exists when the runtime repair module is enabled
- keep the snapshot helper on `root` for `fail2ban-client`, but tighten the unit sandbox substantially

Validation:
- `python -m py_compile scripts/router-dashboard-api-wrapper.py scripts/router-dashboard-fail2ban-snapshot.py`
- malformed `DASHBOARD_INTERFACES` now logs and degrades to `[]` during import
- missing snapshot env now exits with a clear message instead of traceback
- `nix eval .#checks.x86_64-linux.module-loading-eval.outPath`
- `nix eval .#nixosConfigurations.router.config.users.groups --apply groups: builtins.hasAttr "router-dashboard" groups`
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Router dashboard keeps working when inputs or snapshot data are missing**

### What Changed
- Dashboard status now skips broken interface entries and bad counter values instead of failing the whole page
- Fail2ban status now returns an unavailable result when the snapshot cannot be read or generated, instead of crashing
- Missing or unreadable optional token files now produce a warning and the dashboard continues with the remaining data
- The fail2ban snapshot job now writes only to its output directory while keeping the required access to fail2ban itself

### Impact
`✅ Fewer dashboard outages`
`✅ Clearer status when fail2ban data is unavailable`
`✅ Safer router status refreshes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=_2nGsZBbqRF0OYk8fBW6g9ckrOE91OqrBfgDYfK7rP4&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
