### PR TITLE
feat(services): add Guacamole NixOS module with agenix password injection

### DIFF
--- a/modules/nixos/services/guacamole.nix
+++ b/modules/nixos/services/guacamole.nix
@@ -1,0 +1,93 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.guacamole-module;
+in
+{
+  options.services.guacamole-module = {
+    enable = lib.mkEnableOption "Apache Guacamole with PostgreSQL and OIDC (Authentik) support";
+
+    domain = lib.mkOption {
+      type = lib.types.str;
+      default = "guacamole.deepwatercreature.com";
+      description = "Public domain for Guacamole.";
+    };
+
+    dbPasswordFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to a file containing the PostgreSQL password for guacamole_user (e.g. an agenix secret).";
+      example = "/run/agenix/guacamole-db-password";
+    };
+
+    oidc = {
+      enable = lib.mkEnableOption "OIDC authentication (e.g., via Authentik)";
+      issuer = lib.mkOption {
+        type = lib.types.str;
+        default = "https://authentik.deepwatercreature.com/application/o/guacamole/";
+        description = "OIDC Issuer URL.";
+      };
+      clientId = lib.mkOption {
+        type = lib.types.str;
+        description = "OIDC Client ID.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Guacamole daemon (guacd)
+    services.guacamole-server = {
+      enable = true;
+      host = "127.0.0.1";
+      port = 4822;
+    };
+
+    # Guacamole web client (Tomcat). The postgresql-password is injected at
+    # runtime by the pre-start script below so it never lands in the Nix store.
+    services.guacamole-client = {
+      enable = true;
+      settings = {
+        guacd-hostname = "127.0.0.1";
+        guacd-port = 4822;
+        postgresql-hostname = "localhost";
+        postgresql-port = 5432;
+        postgresql-database = "guacamole_db";
+        postgresql-username = "guacamole_user";
+        # Placeholder — overwritten at runtime by the ExecStartPre script.
+        postgresql-password = "";
+        extension-priority = "oidc,postgresql";
+      } // (lib.optionalAttrs cfg.oidc.enable {
+        oidc-issuer = cfg.oidc.issuer;
+        oidc-client-id = cfg.oidc.clientId;
+        oidc-redirect-uri = "https://${cfg.domain}/";
+        oidc-username-claim-type = "preferred_username";
+        oidc-groups-claim-type = "groups";
+      });
+    };
+
+    # Patch the generated guacamole.properties with the runtime password before
+    # Tomcat starts. The sed command replaces the placeholder empty value.
+    systemd.services.guacamole-client.serviceConfig.ExecStartPre =
+      let
+        script = pkgs.writeShellScript "guacamole-inject-password" ''
+          set -euo pipefail
+          PASS=$(cat ${cfg.dbPasswordFile})
+          PROPS=/etc/guacamole/guacamole.properties
+          sed -i "s|^postgresql-password:.*|postgresql-password: $PASS|" "$PROPS"
+        '';
+      in
+      [ "+${script}" ];
+
+    services.postgresql = {
+      enable = true;
+      ensureDatabases = [ "guacamole_db" ];
+      ensureUsers = [
+        {
+          name = "guacamole_user";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    networking.firewall.allowedTCPPorts = [ 8080 ];
+  };
+}

--- a/modules/nixos/services/guacamole.nix
+++ b/modules/nixos/services/guacamole.nix
@@ -41,8 +41,9 @@ in
       port = 4822;
     };
 
-    # Guacamole web client (Tomcat). The postgresql-password is injected at
-    # runtime by the pre-start script below so it never lands in the Nix store.
+    # Guacamole web client (Tomcat). The database credential is appended to
+    # guacamole.properties at runtime by the ExecStartPre script so it never
+    # lands in the Nix store as plaintext.
     services.guacamole-client = {
       enable = true;
       settings = {
@@ -52,8 +53,6 @@ in
         postgresql-port = 5432;
         postgresql-database = "guacamole_db";
         postgresql-username = "guacamole_user";
-        # Placeholder — overwritten at runtime by the ExecStartPre script.
-        postgresql-password = "";
         extension-priority = "oidc,postgresql";
       } // (lib.optionalAttrs cfg.oidc.enable {
         oidc-issuer = cfg.oidc.issuer;
@@ -64,15 +63,18 @@ in
       });
     };
 
-    # Patch the generated guacamole.properties with the runtime password before
-    # Tomcat starts. The sed command replaces the placeholder empty value.
+    # Append the database credential to guacamole.properties at start time.
+    # Running with '+' prefix so it executes as root before Tomcat drops privileges.
     systemd.services.guacamole-client.serviceConfig.ExecStartPre =
       let
-        script = pkgs.writeShellScript "guacamole-inject-password" ''
+        prop = "postgresql-password";
+        script = pkgs.writeShellScript "guacamole-inject-db-cred" ''
           set -euo pipefail
-          PASS=$(cat ${cfg.dbPasswordFile})
           PROPS=/etc/guacamole/guacamole.properties
-          sed -i "s|^postgresql-password:.*|postgresql-password: $PASS|" "$PROPS"
+          CRED=$(cat ${cfg.dbPasswordFile})
+          # Remove any existing line for this property, then append the live value.
+          grep -v "^${prop}:" "$PROPS" > "$PROPS.tmp" && mv "$PROPS.tmp" "$PROPS"
+          printf '%s: %s\n' "${prop}" "$CRED" >> "$PROPS"
         '';
       in
       [ "+${script}" ];


### PR DESCRIPTION
## **User description**
## Summary

- Adds `modules/nixos/services/guacamole.nix` — a wrapper module for Apache Guacamole with:
  - `guacd` (native protocol daemon) bound to localhost
  - Tomcat-based web client with PostgreSQL backend
  - Optional Authentik OIDC authentication
  - `dbPasswordFile` option: password is injected at runtime via `ExecStartPre` sed patch, so it never lands in the Nix store or the static `guacamole.properties`
- No host is importing this yet — module is ready for use once a `guacamole-db-password` agenix secret is provisioned

## Test plan

- [ ] `module-loading-eval` passes
- [ ] Import in a host config with `dbPasswordFile = config.age.secrets.guacamole-db-password.path`
- [ ] `nixos-rebuild test` — Tomcat starts, Guacamole UI accessible at `:8080`
- [ ] Verify `/etc/guacamole/guacamole.properties` has the injected password at runtime (not in store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Add a ready-to-enable Guacamole service with PostgreSQL and optional Authentik login**

### What Changed
- Adds a Guacamole NixOS service that starts the web app, daemon, and PostgreSQL with sensible defaults
- Supports optional OIDC login for Authentik, including issuer, client ID, and redirect settings
- Reads the database password from a file at start time, so it is not stored in the Nix store or written into the static config
- Creates the Guacamole database and user automatically and opens the web app on port 8080

### Impact
`✅ Easier Guacamole setup`
`✅ Safer database password handling`
`✅ Faster Authentik-backed login setup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=JvjyEArygiRHkWK-znbipfl0Ry9ZesSLlnX2-jAror4&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
