### PR TITLE
fix(router): SNAT DNS replies from static LAN IP to VIP

### DIFF
--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -20,7 +20,7 @@ in
       sshTarget = "ssh router-backup";
       wanDevice = "ens27";
       lanDevice = "ens19";
-      lanIpv4Address = "${routerHost.ip}/${toString lanNetwork.prefixLength}";
+      lanIpv4Address = "${backupHost.ip}/${toString lanNetwork.prefixLength}";
       managementIpv4Address = "${backupHost.sshHostname}/${toString managementNetwork.prefixLength}";
       grafanaDomain = mkFqdn "grafana";
       grafanaDataDir = "/var/log/router-backup/grafana";

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -62,6 +62,8 @@ let
   managementNetwork = topology.networks.management;
   mkFqdn = label: "${label}.${topology.domain}";
   isPrimaryRouter = config.networking.hostName == "router";
+  # Static LAN IP assigned to this router node, distinct from the shared VIP.
+  staticLanIp = builtins.head (lib.splitString "/" lanIpv4Address);
   reservableHosts = lib.filterAttrs (
     _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null
   ) topology.hosts;
@@ -614,6 +616,18 @@ in
   age.secrets = secrets.definitions;
 
   services.router-log-storage.enable = lib.mkForce enableLogStorage;
+
+  # UDP replies sourced from the node-local LAN address confuse clients that
+  # sent their DNS query to the shared VIP. Rewrite only DNS replies headed
+  # back onto the LAN so they appear to originate from the VIP.
+  networking.nftables.ruleset = lib.mkAfter ''
+    table ip nat {
+      chain dns-vip-snat {
+        type nat hook postrouting priority 100; policy accept;
+        oifname "${lanDevice}" ip saddr ${staticLanIp} udp sport 53 snat to ${topology.routerHost.ip}
+      }
+    }
+  '';
 
   # Explicit Health Model Services
   # These services exit with failure if the health invariant is violated,


### PR DESCRIPTION
## Summary
- fix `router-backup` to use its own LAN address instead of the primary router's LAN IP
- add a narrow nftables postrouting SNAT rule so UDP DNS replies sent from a node-local LAN IP are rewritten back to the shared VIP on LAN egress
- keep the branch scoped to the real router HA/DNS behavior fix instead of the old mixed homeserver, iVentoy, and secret churn

## Validation
- `nix build /tmp/router-dns-vip-fix#checks.x86_64-linux.module-loading-eval`
- `nix eval --json /tmp/router-dns-vip-fix#nixosConfigurations.router-backup.config.services.router-networking.routedInterfaces.lan.ipv4Address`
