### PR TITLE
fix(router): use interface names for miniupnpd LAN bindings

### DIFF
--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -212,7 +212,10 @@ in
   };
 
   services.router-upnp = {
+    # Bind miniupnpd to explicit interface names so the generated config does
+    # not fall back to invalid address-based guesses.
     enable = true;
+    externalInterface = wanDevice;
     internalIPs = [ lanDevice ];
   };
 


### PR DESCRIPTION
## **User description**
Fixes the miniupnpd failure where it was trying to bind to the VIP address instead of the interface name. Also explicitly sets externalInterface to avoid empty value.
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated the status of the '34 Router miniupnpd Interface Repair' issue from 'ready' to 'in_progress' in .beads/issues.jsonl and its corresponding documentation file.</li>
<li>Added 'externalInterface = config.services.router-networking.wan.device;' to the services.router-upnp configuration in hosts/nixos/router/networking.nix.</li>
<li>Deleted the entire modules/nixos/services/guacamole.nix file, which contained the NixOS module for Apache Guacamole with PostgreSQL and OIDC support.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Fix router UPnP bindings so it starts with the right network interfaces**

### What Changed
- Router UPnP now uses the configured WAN interface explicitly instead of relying on an empty or guessed value.
- The LAN side continues to use the router’s interface name, avoiding address-based binding mistakes that could stop UPnP from starting.

### Impact
`✅ Fewer router UPnP startup failures`
`✅ Reliable port mapping for consoles and P2P apps`
`✅ Less manual router network setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
