### PR TITLE
feat(router): bind DNS service to HA VIP

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1299,11 +1299,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776862235,
-        "narHash": "sha256-ZNuYFxyuDzem1PvEOXzpi4G3rXvOm/4VQTuhdizG2s8=",
+        "lastModified": 1778988275,
+        "narHash": "sha256-PviDxrR66SIaK8JFhmis2A5w0RjLSylXwewvmjFAnUY=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "ba09d871f2bb2c2c730e466229da67e2bf91169c",
+        "rev": "30b5ad9f6fc1a3b4665b0dd816df23e1618ce465",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -1,15 +1,21 @@
 {
   config,
+  lib,
   ...
 }:
 let
   topology = config.router.topology;
   routerHost = topology.routerHost;
+  haVirtualIpAddress = builtins.head (lib.splitString "/" config.services.router-ha.virtualIp);
 in
 {
   services.router-dns-service = {
     enable = true;
     provider = "technitium";
+    serviceListenAddresses = [
+      "127.0.0.1"
+      haVirtualIpAddress
+    ];
     searchDomains = [ topology.domain ];
     # Advertise the router's chrony instance to LAN clients via DHCP option 42.
     # This remains the shared production identity; only the active owner should


### PR DESCRIPTION
## Summary
- pin `nix-router-optimized` to the HA DNS listener branch/commit
- configure the shared router DNS service to bind `127.0.0.1` and the VRRP VIP
- keep the consumer change small so review focuses on wiring and validation

## Depends on
- https://github.com/deepwatrcreatur/nix-router-optimized/pull/32

## Validation
- `nix build .#nixosConfigurations.router.config.system.build.toplevel`
- `nix build .#nixosConfigurations.router-backup.config.system.build.toplevel`