### PR TITLE
fix(router): harden cutover validation script

### DIFF
--- a/scripts/validate-router-cutover.sh
+++ b/scripts/validate-router-cutover.sh
@@ -2,14 +2,18 @@
 # scripts/validate-router-cutover.sh — Post-cutover validation for homelab router
 set -euo pipefail
 
-# Default to management plane for diagnostics
-ROUTER_SSH_TARGET="192.168.100.100"
-ROUTER_LAN_IP="10.10.10.1"
-DOMAIN="deepwatercreature.com"
+# Default fallbacks if repo data derivation is unavailable
+DEFAULT_ROUTER_SSH_TARGET="192.168.100.100"
+DEFAULT_ROUTER_LAN_IP="10.10.10.1"
+DEFAULT_DOMAIN="deepwatercreature.com"
 SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new"
 BLOCKING_FAILED=0
+ROUTER_SSH_TARGET="$DEFAULT_ROUTER_SSH_TARGET"
+ROUTER_LAN_IP="$DEFAULT_ROUTER_LAN_IP"
+DOMAIN="$DEFAULT_DOMAIN"
 
-# Critical hosts from lib/hosts.nix that depend on reserved leases
+# Critical hosts from lib/hosts.nix that depend on reserved leases.
+# This stays as a safe fallback if dynamic derivation is unavailable.
 declare -A CRITICAL_HOSTS=(
   ["attic-cache"]="10.10.11.39"
   ["authentik-host"]="10.10.11.70"
@@ -20,8 +24,52 @@ declare -A CRITICAL_HOSTS=(
   ["ap-nosheen-living"]="10.10.18.21"
   ["ap-nosheen-bedroom"]="10.10.18.22"
 )
+CRITICAL_HOST_KEYS=(
+  "attic-cache"
+  "authentik-host"
+  "inference1"
+  "homeserver"
+  "sw-main"
+  "ap-ruqayya"
+  "ap-nosheen-living"
+  "ap-nosheen-bedroom"
+)
+
+derive_router_metadata() {
+  local topology_json
+  local expected_ip
+
+  if ! command -v nix >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1 || [ ! -f "flake.nix" ]; then
+    return 0
+  fi
+
+  if ! topology_json=$(nix eval --json .#nixosConfigurations.router.config.router.topology 2>/dev/null); then
+    echo "WARNING: failed to derive router topology from flake; using fallback values." >&2
+    return 0
+  fi
+
+  ROUTER_SSH_TARGET=$(jq -r '.routerHost.sshHostname // empty' <<< "$topology_json")
+  ROUTER_LAN_IP=$(jq -r '.routerVip.ip // .routerHost.ip // empty' <<< "$topology_json")
+  DOMAIN=$(jq -r '.domain // empty' <<< "$topology_json")
+
+  ROUTER_SSH_TARGET=${ROUTER_SSH_TARGET:-$DEFAULT_ROUTER_SSH_TARGET}
+  ROUTER_LAN_IP=${ROUTER_LAN_IP:-$DEFAULT_ROUTER_LAN_IP}
+  DOMAIN=${DOMAIN:-$DEFAULT_DOMAIN}
+
+  for host in "${CRITICAL_HOST_KEYS[@]}"; do
+    expected_ip=$(jq -r --arg host "$host" '.hosts[$host].ip // empty' <<< "$topology_json")
+    if [ -n "$expected_ip" ]; then
+      CRITICAL_HOSTS["$host"]="$expected_ip"
+    fi
+  done
+}
+
+derive_router_metadata
 
 echo "=== Router Post-Cutover Validation ==="
+echo "Targeting Management Plane: $ROUTER_SSH_TARGET"
+echo "Targeting Router LAN IP: $ROUTER_LAN_IP"
+echo "Domain: $DOMAIN"
 
 # 1. Connectivity to Router Management Plane
 echo -n "Checking router management reachability ($ROUTER_SSH_TARGET)... "


### PR DESCRIPTION
## **User description**
Hardens the cutover validation script by targeting the management plane for diagnostics and ensuring blocking failures return a non-zero exit code. Also dynamically derives host metadata from the Nix configuration when possible.
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


___

## **CodeAnt-AI Description**
**Use the router’s current cutover settings when validating after a swap**

### What Changed
- The validation script now tries to read the router’s live management address, LAN IP, domain, and reserved host IPs from the current repository config before running checks
- If that data cannot be read, it falls back to the previous fixed values
- The script now prints the management target, LAN IP, and domain it is checking so it is clear which router configuration is being validated
- Reserved-host checks use the active configuration when available instead of only the old fixed list

### Impact
`✅ Fewer false router cutover failures`
`✅ Clearer cutover validation output`
`✅ Safer post-cutover checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced router validation script to dynamically derive connection parameters from configuration files instead of using hardcoded values, improving flexibility while maintaining existing validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->