### PR TITLE
feat(router): add PXE DHCP options for Kea

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1299,11 +1299,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776803338,
-        "narHash": "sha256-s3plv45T4JA7sEVPtXRwldKyVXulCIT//4gnJV16+1o=",
+        "lastModified": 1776862235,
+        "narHash": "sha256-ZNuYFxyuDzem1PvEOXzpi4G3rXvOm/4VQTuhdizG2s8=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "c81ad24c6992ca241f1abb2576de333d30c5f62d",
+        "rev": "ba09d871f2bb2c2c730e466229da67e2bf91169c",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -57,6 +57,7 @@ let
   };
 
   topology = config.router.topology;
+  iventoy = config.services.iventoy;
   lanNetwork = topology.networks.lan;
   managementNetwork = topology.networks.management;
   mkFqdn = label: "${label}.${topology.domain}";
@@ -194,6 +195,14 @@ in
         role = if isPrimaryRouter then "primary" else "secondary";
         peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1";
         peerName = if isPrimaryRouter then "router-backup" else "router";
+      };
+      pxe = {
+        enable = true;
+        bootServerAddress = topology.routerHost.ip;
+        bootServerName = mkFqdn "router";
+        # iVentoy external mode expects this loader name and serves the real
+        # BIOS/UEFI path after inspecting the DHCP request.
+        bootFilename = "iventoy_loader_${toString iventoy.httpPort}";
       };
       reservations = lib.mapAttrsToList (name: host: {
         hw-address = host.dhcpReservation.macAddress;


### PR DESCRIPTION
## **User description**
## Summary
- pin `nix-router-optimized` to the exact upstream commit that adds `router-kea` PXE options
- wire iVentoy-backed PXE advertisement into the router's `services.router-kea.dhcp4.pxe` config
- keep the branch scoped to the real PXE work instead of the old stale lock and queue churn

## Validation
- `nix eval --json /tmp/router-pxe-fix#nixosConfigurations.router.config.services.router-kea.dhcp4.pxe`
- `nix eval --json /tmp/router-pxe-fix#nixosConfigurations.router.config.services.kea.dhcp4.settings.subnet4`
- `nix build /tmp/router-pxe-fix#checks.x86_64-linux.module-loading-eval`


___

## **CodeAnt-AI Description**
**Advertise PXE boot details for the router's DHCP service**

### What Changed
- DHCP now advertises PXE boot information so network clients can discover the router as their boot server
- PXE requests are pointed at iVentoy using the router's hostname and the expected loader name for the service port
- BIOS and UEFI clients can be handed off through iVentoy for network boot setup

### Impact
`✅ Network boot is available from the router`
`✅ Fewer manual PXE setup steps`
`✅ Clearer boot routing for BIOS and UEFI clients`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PXE boot support to the router with configurable boot server address and filename settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->