### PR TITLE
fix(home-manager): materialize ssh config for OpenSSH

### DIFF
--- a/modules/home-manager/common/ssh-config.nix
+++ b/modules/home-manager/common/ssh-config.nix
@@ -80,4 +80,25 @@ in {
     # Generated host configurations
     inherit matchBlocks;
   };
+
+  # OpenSSH rejects the Home Manager symlink at ~/.ssh/config on this host.
+  # Keep using programs.ssh for rendering, then materialize a real 0600 file
+  # after HM writes the generation links.
+  home.file.".ssh/config".force = true;
+
+  home.activation.materializeSshConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    config_path="$HOME/.ssh/config"
+
+    if [ -L "$config_path" ]; then
+      source_path="$(${pkgs.coreutils}/bin/readlink -f "$config_path")"
+      tmp_path="$HOME/.ssh/config.hm-tmp"
+
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/cp "$source_path" "$tmp_path"
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/chmod 600 "$tmp_path"
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/mv "$tmp_path" "$config_path"
+      echo "Materialized ~/.ssh/config as a regular file for OpenSSH"
+    elif [ -f "$config_path" ]; then
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/chmod 600 "$config_path"
+    fi
+  '';
 }


### PR DESCRIPTION
## **User description**
## Summary
- keep using `programs.ssh` to render the inventory-backed SSH config
- force the managed `~/.ssh/config` path so Home Manager can replace it on future activations
- materialize a regular `0600` `~/.ssh/config` after `writeBoundary` so OpenSSH no longer rejects the Home Manager symlink

## Problem
On `workstation`, plain `ssh` and `git push` were failing with:

```text
Bad owner or permissions on /home/deepwatrcreatur/.ssh/config
```

The active `~/.ssh/config` was a Home Manager symlink into the Nix store. OpenSSH on this host rejects that path even though the resolved target is read-only.

## Validation
- `nix build /tmp/unified-nix-configuration-ssh-fix#nixosConfigurations.workstation.config.system.build.toplevel --no-link`
- `nix eval --raw /tmp/unified-nix-configuration-ssh-fix#nixosConfigurations.workstation.config.home-manager.users.deepwatrcreatur.home.activation.materializeSshConfig.data`

<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/deepwatrcreatur/unified-nix-configuration/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a home activation script to materialize ~/.ssh/config as a regular file instead of a symlink, as OpenSSH rejects symlinks on this host.</li>
<li>Introduced home.file.".ssh/config".force = true to ensure the file is properly managed.</li>
<li>The activation script copies the config from the symlink source, sets permissions to 600, and replaces the symlink with the regular file.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home Manager now forcibly manages SSH configuration files with automatic permission enforcement (0600).
  * Symlinked SSH configs are automatically converted to regular files during activation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Make `~/.ssh/config` usable by OpenSSH**

### What Changed
- `~/.ssh/config` is now written as a regular file with `0600` permissions instead of a Home Manager symlink
- The SSH config still comes from the same managed source, but it is copied into place after activation so OpenSSH accepts it
- If the file already exists, its permissions are corrected to `0600`

### Impact
`✅ Working SSH logins`
`✅ Successful git pushes over SSH`
`✅ Fewer OpenSSH permission errors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=wHhEe7rchpNBYyqnkDnLS-6y1oTzvpOtNcHBwD-0Oks&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
