### PR TITLE
fix(router-dashboard): restore kea leases and interface addresses

### DIFF
--- a/modules/nixos/router-dashboard-runtime-repair.nix
+++ b/modules/nixos/router-dashboard-runtime-repair.nix
@@ -10,6 +10,7 @@ let
   hasRouterDashboard = lib.hasAttrByPath [ "services" "router-dashboard" ] options;
   cfg = if hasRouterDashboard then config.services.router-dashboard else { enable = false; };
   fail2banSnapshotFile = "/run/router-dashboard/fail2ban-status.json";
+  keaLeaseSnapshotFile = "/run/router-dashboard/kea-dhcp4.leases";
   routerDashboardApiWrapper = ../../scripts/router-dashboard-api-wrapper.py;
   fail2banSnapshotScript = ../../scripts/router-dashboard-fail2ban-snapshot.py;
 in
@@ -29,6 +30,7 @@ in
       DASHBOARD_UPSTREAM_SERVER = "${inputs.nix-router-optimized.outPath}/modules/router-dashboard/api/server.py";
       DASHBOARD_INTERFACES = builtins.toJSON cfg.interfaces;
       DASHBOARD_FAIL2BAN_STATUS_FILE = fail2banSnapshotFile;
+      DASHBOARD_KEA_LEASES_FILE = keaLeaseSnapshotFile;
       DASHBOARD_CLOUDFLARE_TOKEN_FILE = config.age.secrets.cloudflare-api-key.path;
     };
 
@@ -84,6 +86,62 @@ in
         OnBootSec = "30s";
         OnUnitActiveSec = "30s";
         Unit = "router-dashboard-fail2ban-snapshot.service";
+      };
+    };
+
+    systemd.services.router-dashboard-kea-lease-snapshot = lib.mkIf config.services.kea.dhcp4.enable {
+      description = "Refresh router dashboard Kea lease snapshot";
+      after = [ "kea-dhcp4-server.service" ];
+      wants = [ "kea-dhcp4-server.service" ];
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+        Group = "root";
+        UMask = "0027";
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [ "/run/router-dashboard" ];
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+      };
+      script = ''
+        set -euo pipefail
+        src=""
+        for candidate in /var/lib/private/kea/dhcp4.leases /var/lib/kea/dhcp4.leases; do
+          if [ -f "$candidate" ]; then
+            src="$candidate"
+            break
+          fi
+        done
+
+        if [ -z "$src" ]; then
+          echo "No Kea lease file found" >&2
+          exit 1
+        fi
+
+        install -m 0640 -o root -g router-dashboard "$src" "${keaLeaseSnapshotFile}"
+      '';
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    systemd.timers.router-dashboard-kea-lease-snapshot = lib.mkIf config.services.kea.dhcp4.enable {
+      description = "Refresh router dashboard Kea lease snapshot periodically";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "30s";
+        OnUnitActiveSec = "30s";
+        Unit = "router-dashboard-kea-lease-snapshot.service";
       };
     };
   };

--- a/scripts/router-dashboard-api-wrapper.py
+++ b/scripts/router-dashboard-api-wrapper.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 import importlib.util
+import csv
 import json
 import os
 import subprocess
 import sys
+import ipaddress
+from datetime import datetime, timezone
 
 
 def log_warning(message):
@@ -79,6 +82,7 @@ def read_interface_state(handler, path, interface_name):
 UPSTREAM_SERVER = get_required_env("DASHBOARD_UPSTREAM_SERVER")
 FAIL2BAN_STATUS_FILE = os.environ.get("DASHBOARD_FAIL2BAN_STATUS_FILE", "")
 CLOUDFLARE_TOKEN_FILE = os.environ.get("DASHBOARD_CLOUDFLARE_TOKEN_FILE", "")
+KEA_LEASES_FILE = os.environ.get("DASHBOARD_KEA_LEASES_FILE", "")
 
 if not os.path.exists(UPSTREAM_SERVER):
     raise SystemExit(f"DASHBOARD_UPSTREAM_SERVER does not exist: {UPSTREAM_SERVER}")
@@ -103,12 +107,86 @@ for interface in dashboard_interfaces:
         interface_role_map[device] = role
 
 original_handle_fail2ban_status = module.RouterAPIHandler.handle_fail2ban_status
+original_handle_dhcp_leases = module.RouterAPIHandler.handle_dhcp_leases
+
+
+def prefer_interface_alias(candidate, current):
+    if current == candidate:
+        return False
+    candidate_is_vlan = "." in candidate
+    current_is_vlan = "." in current
+    if candidate_is_vlan != current_is_vlan:
+        return not candidate_is_vlan
+    return candidate < current
+
+
+def format_kea_expiry(raw_value):
+    text = str(raw_value).strip()
+    if not text or text == "0":
+        return ""
+    try:
+        return datetime.fromtimestamp(int(text), tz=timezone.utc).isoformat()
+    except (ValueError, OSError):
+        return text
+
+
+def ip_sort_key(value):
+    try:
+        return (0, ipaddress.ip_address(value))
+    except ValueError:
+        return (1, value)
+
+
+def read_kea_leases_from_snapshot(path):
+    leases_by_ip = {}
+
+    with open(path, "r", encoding="utf-8") as handle:
+        reader = csv.reader(line for line in handle if line and not line.startswith("#"))
+        for row in reader:
+            if len(row) < 10:
+                continue
+
+            address = row[0].strip()
+            hardware_address = row[1].strip()
+            lease_expires = format_kea_expiry(row[4])
+            hostname = row[8].strip()
+            state = row[9].strip()
+
+            if not address:
+                continue
+
+            entry = {
+                "scope": "kea",
+                "interface": "",
+                "address": address,
+                "hostname": hostname,
+                "hardwareAddress": hardware_address,
+                "leaseExpires": lease_expires,
+                "type": "active" if state == "0" else state,
+                "_state": state,
+            }
+
+            current = leases_by_ip.get(address)
+            if current is None or (current.get("_state") != "0" and state == "0"):
+                leases_by_ip[address] = entry
+
+    leases = sorted(leases_by_ip.values(), key=lambda entry: ip_sort_key(entry["address"]))
+    for lease in leases:
+        lease.pop("_state", None)
+
+    return leases
 
 
 def handle_interface_stats(self):
     try:
         interfaces = {}
         net_path = module.Path("/sys/class/net")
+        role_candidates = {}
+
+        for device, role in interface_role_map.items():
+            current = role_candidates.get(role)
+            if current is None or prefer_interface_alias(device, current):
+                role_candidates[role] = device
 
         for iface_path in net_path.iterdir():
             try:
@@ -125,9 +203,7 @@ def handle_interface_stats(self):
                 rx_rate, tx_rate = self.calculate_rates(name, rx_bytes, tx_bytes)
                 ipv4 = self.get_ipv4(name)
                 ipv6_list = self.get_ipv6(name)
-                key = interface_role_map.get(name, name)
-
-                interfaces[key] = {
+                stats = {
                     "device": name,
                     "state": read_interface_state(self, iface_path / "operstate", name),
                     "ipv4": ipv4,
@@ -141,12 +217,60 @@ def handle_interface_stats(self):
                     "rx_errors": read_int_file(self, stats_path / "rx_errors", f"{name} rx_errors"),
                     "tx_errors": read_int_file(self, stats_path / "tx_errors", f"{name} tx_errors"),
                 }
+                interfaces[name] = stats
             except Exception as exc:
                 log_warning(f"Failed to collect interface stats for {iface_path}: {exc}")
+
+        for role, device in role_candidates.items():
+            if device in interfaces:
+                interfaces[role] = interfaces[device]
 
         self.send_json(interfaces)
     except Exception as exc:
         self.send_error_json(500, str(exc))
+
+
+def handle_dhcp_leases(self):
+    if KEA_LEASES_FILE:
+        try:
+            if os.path.exists(KEA_LEASES_FILE):
+                leases = read_kea_leases_from_snapshot(KEA_LEASES_FILE)
+                section = {
+                    "id": "kea",
+                    "title": "Kea",
+                    "scope": "kea",
+                    "interface": "",
+                    "enabled": True,
+                    "startAddress": "",
+                    "endAddress": "",
+                    "leaseCount": len(leases),
+                    "leases": leases[:100],
+                }
+                self.send_json(
+                    {
+                        "available": True,
+                        "scopes": [
+                            {
+                                "name": "kea",
+                                "interface": "",
+                                "enabled": True,
+                                "startAddress": "",
+                                "endAddress": "",
+                                "leaseCount": len(leases),
+                            }
+                        ],
+                        "leases": leases[:100],
+                        "sections": [section],
+                        "totalLeases": len(leases),
+                        "displayedLeases": min(len(leases), 100),
+                    }
+                )
+                return
+            log_warning(f"Kea lease snapshot file not found at: {KEA_LEASES_FILE}")
+        except Exception as exc:
+            log_warning(f"Error reading Kea lease snapshot: {exc}")
+
+    return original_handle_dhcp_leases(self)
 
 
 def handle_firewall_stats(self):
@@ -360,6 +484,7 @@ def handle_fail2ban_status(self):
 
 
 module.RouterAPIHandler.handle_interface_stats = handle_interface_stats
+module.RouterAPIHandler.handle_dhcp_leases = handle_dhcp_leases
 module.RouterAPIHandler.handle_firewall_stats = handle_firewall_stats
 module.RouterAPIHandler.handle_caddy_status = handle_caddy_status
 module.RouterAPIHandler.handle_fail2ban_status = handle_fail2ban_status


### PR DESCRIPTION
## **User description**
## Summary
- restore device-keyed interface stats so the network panel shows IPv4 data again
- add a Kea lease snapshot for the dashboard and serve DHCP leases from it
- keep the existing upstream router-dashboard API for the remaining endpoints

## Verification
- python3 -m py_compile scripts/router-dashboard-api-wrapper.py
- nix-instantiate --parse modules/nixos/router-dashboard-runtime-repair.nix

## Notes
- full flake eval is currently blocked by the repo's agent-roundtable input path issue, so this PR is syntax-checked but not end-to-end switched yet


___

## **CodeAnt-AI Description**
**Restore Kea lease data and interface addresses in the router dashboard**

### What Changed
- The dashboard now shows DHCP leases from a local Kea snapshot again, so lease lists and counts appear even when the slower upstream path is not used.
- Interface stats now keep both the device name and the dashboard-friendly role name, which brings back IPv4 data for mapped interfaces.
- The Kea lease snapshot is refreshed automatically when DHCP is enabled, so the dashboard stays in sync without manual updates.

### Impact
`✅ Restored DHCP lease visibility`
`✅ Fewer missing interface addresses`
`✅ More reliable router dashboard data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Router dashboard API now exposes Kea DHCP4 lease information with structured data output when available
  * Automated Kea lease snapshot capture and periodic refresh via systemd service
  * Enhanced interface statistics aggregation with improved role-based device selection and aliasing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->