### PR TITLE
feat(router): add active ownership gate for shared HA services

### DIFF
--- a/den/hosts/router-backup/default.nix
+++ b/den/hosts/router-backup/default.nix
@@ -11,10 +11,10 @@ let
       # hardware-configuration.nix — generated hardware config. Always keep separate.
       ../../../hosts/nixos/router-backup/hardware-configuration.nix
 
-      # router/networking.nix — shared DNS/NAT config; imported directly now that
-      # the thin hosts/nixos/router-backup/networking.nix wrapper has been inlined
-      # here. The hostname override below replaces that wrapper.
-      ../../../hosts/nixos/router/networking.nix
+      # service-capability.nix — shared router-service capability used by both
+      # router nodes. This keeps DNS/NTP/NAT wiring common without importing the
+      # primary hostname policy from router/networking.nix.
+      ../../../hosts/nixos/router/service-capability.nix
 
       # router/caddy.nix — full Caddy config shared with router; imported directly
       # now that the single-line hosts/nixos/router-backup/caddy.nix wrapper has been
@@ -32,6 +32,5 @@ in
 # now-deleted hosts/nixos/router-backup/networking.nix wrapper.
 {
   inherit (base) imports;
-  # router/networking.nix sets hostName = "router"; override for this host.
   networking.hostName = lib.mkForce "router-backup";
 }

--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -61,7 +61,7 @@ den/inventory/hosts.nix          ← entry point
             │    └─ users/deepwatrcreatur/hosts/router-backup/default.nix
             └─ extraImports  (legacy host-local files)
                  ├─ hosts/nixos/router-backup/hardware-configuration.nix
-                 ├─ hosts/nixos/router/networking.nix  (shared; hostName override applied below)
+                 ├─ hosts/nixos/router/service-capability.nix
                  ├─ hosts/nixos/router/caddy.nix  (shared; wrapper inlined into den leaf)
                  └─ hosts/nixos/router-backup/configuration.nix
                       ├─ inputs.disko.nixosModules.disko
@@ -77,14 +77,15 @@ den/inventory/hosts.nix          ← entry point
 |---------|-------------|-------|
 | Hardware config (router) | `hosts/nixos/router/hardware-configuration.nix` | Generated; never edit manually |
 | Hardware config (backup) | `hosts/nixos/router-backup/hardware-configuration.nix` | Generated; never edit manually |
-| Hostname | `hosts/nixos/router/networking.nix` | Sets `hostName = "router"`; backup wrapper overrides to `"router-backup"` |
-| DNS service (Technitium) | `hosts/nixos/router/networking.nix` | Config applies to both hosts via shared import |
-| NAT policy | `hosts/nixos/router/networking.nix` | `networking.nat.enable = false`; nftables handles NAT in role.nix |
+| Hostname | `hosts/nixos/router/networking.nix` and `den/hosts/router-backup/default.nix` | Primary hostname lives in `router/networking.nix`; backup hostname is forced in its den leaf |
+| Shared DNS/NTP capability | `hosts/nixos/router/service-capability.nix` | Shared router service capability imported by both hosts |
+| NAT policy | `hosts/nixos/router/service-capability.nix` | `networking.nat.enable = false`; nftables handles NAT in role.nix |
 | Disk layout (router) | `hosts/nixos/router/disko.nix` | Hardware-adjacent; keep separate |
 | Disk layout (backup) | `hosts/nixos/router-backup/disko.nix` | Imported by `configuration.nix`; hardware-adjacent, keep separate |
-| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly |
+| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public DDNS ownership is gated by `router.failover.activeOwner` |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
+| Active public identity ownership | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; used to gate single-owner identity such as public DDNS updates |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -94,9 +95,10 @@ den/inventory/hosts.nix          ← entry point
 
 ## Where to land fixes
 
-- **DNS / hostname changes**: `hosts/nixos/router/networking.nix`. Topology-derived
-  values (domain name, IP ranges) live in `config.router.topology`; see
-  `docs/network-source-of-truth.md` for that layer.
+- **DNS / NTP shared capability**: `hosts/nixos/router/service-capability.nix`.
+- **Primary hostname / domain defaults**: `hosts/nixos/router/networking.nix`.
+- **Active public identity ownership**: `modules/nixos/router/common.nix` via
+  `router.failover.activeOwner`.
 - **Firewall / NAT / observability / VPN**: tune options provided by
   `nix-router-optimized` modules; the entry point is `den/aspects/router-router.nix`.
 - **Caddy virtualHosts, ACME, DDNS**: `hosts/nixos/router/caddy.nix`.

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -29,6 +29,16 @@ To promote `router-backup` after a failure or bad rebuild:
 4. Move the LAN cable to `router-backup`.
 5. Verify clients can reach `10.10.10.1`, resolve DNS, and reach the internet.
 
+### Current config note
+
+- `router.failover.activeOwner` is the consumer-tree switch for single-owner
+  public identity. It currently defaults to `true` on `router` and `false` on
+  `router-backup`.
+- Today that switch gates Caddy's public DDNS ownership so both nodes can keep
+  service capability while only the active owner updates public DNS identity.
+- More failover-sensitive ownership should move behind this boundary as the HA
+  refactor continues.
+
 ## Technitium
 
 - Technitium clustering can help keep DNS/admin configuration aligned between

--- a/flake.lock
+++ b/flake.lock
@@ -31,14 +31,19 @@
         ]
       },
       "locked": {
-        "lastModified": 1777651417,
-        "narHash": "sha256-knzAu5f9SUZEibNM7hQq/DaZfmbHssX0IOrX44chml8=",
-        "path": "/home/deepwatrcreatur/flakes/agent-roundtable/roundtable",
-        "type": "path"
+        "dir": "roundtable",
+        "lastModified": 1778269266,
+        "narHash": "sha256-vkV8IrIeurLt85oHPc5CKcrocvRU6wlB+BXHTvZ4ezA=",
+        "owner": "deepwatrcreatur",
+        "repo": "agent-roundtable",
+        "rev": "ae93bd7208f7ce9e5f78337045ae463de71d8413",
+        "type": "github"
       },
       "original": {
-        "path": "/home/deepwatrcreatur/flakes/agent-roundtable/roundtable",
-        "type": "path"
+        "dir": "roundtable",
+        "owner": "deepwatrcreatur",
+        "repo": "agent-roundtable",
+        "type": "github"
       }
     },
     "agents-status-tray": {

--- a/flake.nix
+++ b/flake.nix
@@ -170,7 +170,7 @@
     };
 
     agent-roundtable = {
-      url = "path:../agent-roundtable";
+      url = "github:deepwatrcreatur/agent-roundtable?dir=roundtable";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -198,7 +198,7 @@ in
       ${lib.optionalString (!activeOwner || !cfSecret.exists) ''
         # In standby mode or without the Cloudflare secret, keep an empty env
         # file so Caddy can still start without public DDNS ownership.
-        touch /run/caddy/caddy.env
+        : > /run/caddy/caddy.env
         chown caddy:caddy /run/caddy/caddy.env
         chmod 0400 /run/caddy/caddy.env
       ''}

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -19,6 +19,21 @@ let
   cfSecret = optSec.mkSecret "cloudflare-api-key" {
     file = ../../../secrets-agenix/cloudflare_ddns_API_token.age;
   };
+  activeOwner = config.router.failover.activeOwner;
+  dynamicDnsConfig = lib.optionalString activeOwner ''
+    dynamic_dns {
+      provider cloudflare {$CLOUDFLARE_API_TOKEN}
+      domains {
+        # `home-assistant` is intentionally excluded here. We publish it as a
+        # Cloudflare CNAME to another DDNS-managed hostname so Caddy's DDNS
+        # updater does not fight Cloudflare over the same record name.
+        ${ddnsDomainsLine}
+      }
+      check_interval 5m
+      versions ipv4 ipv6
+      ttl 1h
+    }
+  '';
 in
 {
   services.caddy = {
@@ -37,18 +52,7 @@ in
     globalConfig = ''
       # ACME/Let's Encrypt configuration
       email deepwatrcreatur@gmail.com
-      dynamic_dns {
-        provider cloudflare {$CLOUDFLARE_API_TOKEN}
-        domains {
-          # `home-assistant` is intentionally excluded here. We publish it as a
-          # Cloudflare CNAME to another DDNS-managed hostname so Caddy's DDNS
-          # updater does not fight Cloudflare over the same record name.
-          ${ddnsDomainsLine}
-        }
-        check_interval 5m
-        versions ipv4 ipv6
-        ttl 1h
-      }
+      ${dynamicDnsConfig}
 
       # Use staging for testing, comment out for production
       # acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
@@ -184,15 +188,16 @@ in
     wants = [ "network-online.target" ];
     preStart = ''
       install -d -m 0750 -o caddy -g caddy /run/caddy
-      ${lib.optionalString cfSecret.exists ''
+      ${lib.optionalString (activeOwner && cfSecret.exists) ''
         token="$(tr -d '\n' < ${config.age.secrets.cloudflare-api-key.path})"
         test -n "$token"
         printf 'CLOUDFLARE_API_TOKEN=%s\n' "$token" > /run/caddy/caddy.env
         chown caddy:caddy /run/caddy/caddy.env
         chmod 0400 /run/caddy/caddy.env
       ''}
-      ${lib.optionalString (!cfSecret.exists) ''
-        # No Cloudflare secret available - create empty env file
+      ${lib.optionalString (!activeOwner || !cfSecret.exists) ''
+        # In standby mode or without the Cloudflare secret, keep an empty env
+        # file so Caddy can still start without public DDNS ownership.
         touch /run/caddy/caddy.env
         chown caddy:caddy /run/caddy/caddy.env
         chmod 0400 /run/caddy/caddy.env

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -4,35 +4,22 @@
 }:
 let
   topology = config.router.topology;
-  routerHost = topology.routerHost;
   lanDevice = config.services.router-networking.routedInterfaces.lan.device;
 in
 {
+  imports = [
+    ./service-capability.nix
+  ];
+
   networking.hostName = "router";
   networking.domain = topology.domain;
-
-  services.router-dns-service = {
-    enable = true;
-    provider = "technitium";
-    searchDomains = [ topology.domain ];
-    # Advertise the router's chrony instance to all LAN clients via DHCP option 42.
-    ntpServers = [ routerHost.ip ];
-    technitium = {
-      blockListPresets = [
-        "hagezi-normal"
-        "hagezi-nrd-14d"
-      ];
-      extraBlockListUrls = [ ];
-      blockListUpdateIntervalHours = 24;
-    };
-  };
 
   services.router-kea = {
     enable = true;
     dhcp4 = {
       subnet = topology.networks.lan.cidr;
-      gatewayAddress = routerHost.ip;
-      dnsServers = [ routerHost.ip ];
+      gatewayAddress = topology.routerHost.ip;
+      dnsServers = [ topology.routerHost.ip ];
       poolRanges = [ { start = "10.10.10.100"; end = "10.10.10.250"; } ];
     };
     ddns = {
@@ -44,16 +31,7 @@ in
     };
   };
 
-  # NTP server — serves LAN clients (advertised via DHCP option 42 above).
-  services.router-ntp = {
-    enable = true;
-    lanSubnets = [ topology.networks.lan.cidr ];
-  };
-
   # UPnP/NAT-PMP for game consoles and P2P clients.
   # externalInterface and internalIPs are auto-derived.
   services.router-upnp.enable = true;
-
-  # NAT is handled by nftables (see nftables.nix)
-  networking.nat.enable = false;
 }

--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -31,7 +31,4 @@ in
     };
   };
 
-  # UPnP/NAT-PMP for game consoles and P2P clients.
-  # externalInterface and internalIPs are auto-derived.
-  services.router-upnp.enable = true;
 }

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -30,6 +30,10 @@ in
     lanSubnets = [ topology.networks.lan.cidr ];
   };
 
+  # UPnP/NAT-PMP should remain available on whichever router currently owns
+  # the LAN path so failover does not silently drop port mapping support.
+  services.router-upnp.enable = true;
+
   # NAT is handled by nftables (see role.nix).
   networking.nat.enable = false;
 }

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  ...
+}:
+let
+  topology = config.router.topology;
+  routerHost = topology.routerHost;
+in
+{
+  services.router-dns-service = {
+    enable = true;
+    provider = "technitium";
+    searchDomains = [ topology.domain ];
+    # Advertise the router's chrony instance to LAN clients via DHCP option 42.
+    # This remains the shared production identity; only the active owner should
+    # actually present that identity on the production LAN.
+    ntpServers = [ routerHost.ip ];
+    technitium = {
+      blockListPresets = [
+        "hagezi-normal"
+        "hagezi-nrd-14d"
+      ];
+      extraBlockListUrls = [ ];
+      blockListUpdateIntervalHours = 24;
+    };
+  };
+
+  services.router-ntp = {
+    enable = true;
+    lanSubnets = [ topology.networks.lan.cidr ];
+  };
+
+  # NAT is handled by nftables (see role.nix).
+  networking.nat.enable = false;
+}

--- a/modules/nixos/router/common.nix
+++ b/modules/nixos/router/common.nix
@@ -11,6 +11,15 @@ in
     description = "Shared router inventory and network topology derived from lib/hosts.nix.";
   };
 
+  options.router.failover.activeOwner = lib.mkOption {
+    type = lib.types.bool;
+    description = ''
+      Whether this node should currently own the production router identity.
+      Shared service capability can exist on both routers, but only the active
+      owner should advertise or update single-owner identity such as public DDNS.
+    '';
+  };
+
   config.router.topology = {
     domain = hostsData.domain;
     hosts = hostsData.hosts;
@@ -18,6 +27,8 @@ in
     backupHost = backupHost;
     networks = hostsData.networks;
   };
+
+  config.router.failover.activeOwner = lib.mkDefault (config.networking.hostName == "router");
 
   # Shared defaults for router and router-backup.
   config.services.router-homelab = {


### PR DESCRIPTION
## Summary
- add a shared `router/service-capability.nix` module for DNS, NTP, NAT-disable, and UPnP wiring used by both router nodes
- add `router.failover.activeOwner` to separate shared service capability from single-owner public identity
- gate Caddy public DDNS ownership and Cloudflare token provisioning behind `router.failover.activeOwner`
- update router source-of-truth and spare cutover docs to describe the new boundary

## Follow-up Fixes
- keep `services.router-upnp.enable = true` available on `router-backup` after the service-capability split
- ensure standby Caddy truncates `/run/caddy/caddy.env` so an old Cloudflare token cannot survive an ownership flip within the same boot

## Validation
- `nix eval .#nixosConfigurations.router.config.router.failover.activeOwner`
- `nix eval .#nixosConfigurations.router-backup.config.router.failover.activeOwner`
- `nix eval .#nixosConfigurations.router.config.services.router-upnp.enable`
- `nix eval .#nixosConfigurations.router-backup.config.services.router-upnp.enable`
- `nix eval --raw .#nixosConfigurations.router-backup.config.systemd.services.caddy.preStart`

## Notes
- this PR intentionally leaves out the mixed runtime and behavior changes from the preserved recovery branch
- omitted items include iVentoy toggles, VLAN availability changes, Kea healing logic, and dashboard lease snapshot work; those should be reviewed separately or folded in after human review
