### PR TITLE
docs(tooling): recover and normalize vaglio work queue

### DIFF
--- a/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
+++ b/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
@@ -1,0 +1,61 @@
+# 30 Vaglio Roundtable Reactivation
+
+Status: `ready`
+Suggested branch: `feat/vaglio-roundtable-reactivation`
+Priority: `high`
+
+## Goal
+
+Restore the Roundtable service as an active host feature on `vaglio`, so the
+ repo once again has a concrete deployment target for `roundtable.deepwatercreature.com`.
+
+## Why
+
+- The `homeserver-roundtable` aspect exists, but it was detached from
+  inventory because its required secret was missing.
+- Current inventory no longer attaches Roundtable to `vaglio`, even though
+  prior agent discussion suggested the user should expect to see new work
+  appear at `roundtable.deepwatercreature.com/forgejo-shell`.
+- The repo currently lacks both of the concrete prerequisites needed to make
+  that reattachment real:
+  - `ssh-keys/agenix-machine-identities/vaglio.pub` does not exist
+  - `secrets-agenix/roundtable-secret-key-base.age` does not exist
+- A live Proxmox cluster inspection also shows no current LXC config for
+  `vaglio`; there is nothing to `pct enter` yet.
+- Any Forgejo-shell demo or code-analysis UI work is blocked until there is a
+  real Roundtable host path again.
+
+## Scope
+
+1. Provision or document the required agenix secret inputs for Roundtable,
+   especially `roundtable-secret-key-base.age` and the `vaglio` machine
+   identity public key.
+2. Create or recover the actual `vaglio` Proxmox LXC guest so there is a real
+   host to administer with `pct enter`.
+3. Reattach the `homeserver-roundtable` aspect to `vaglio` in inventory.
+4. Ensure the host evaluates cleanly in this repo with the Roundtable aspect
+   active again.
+5. Add a short note describing why `vaglio` is the chosen Roundtable host.
+
+## Non-Goals
+
+- Designing the Forgejo-shell feature itself
+- Building the code-analysis demo UI
+- Reworking OIDC or ingress architecture beyond what is needed to reactivate
+  the existing Roundtable service
+
+## Validation
+
+- `nix eval .#nixosConfigurations.vaglio.config.system.build.toplevel.drvPath`
+  succeeds with Roundtable reattached
+- Proxmox cluster config contains a real `vaglio` LXC definition that can be
+  entered with `pct enter`
+- the required Roundtable secrets are explicit and no longer hidden behind
+  silent config omission
+- `roundtable.deepwatercreature.com` is once again backed by an active host
+  configuration path in this repo
+
+## Notes
+
+This item exists because deployment reality needs to be restored before the
+demo-oriented Forgejo-shell work can be made credible.

--- a/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
+++ b/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
@@ -1,6 +1,6 @@
 # 30 Vaglio Roundtable Reactivation
 
-Status: `ready`
+Status: `in-progress`
 Suggested branch: `feat/vaglio-roundtable-reactivation`
 Priority: `high`
 
@@ -11,17 +11,12 @@ Restore the Roundtable service as an active host feature on `vaglio`, so the
 
 ## Why
 
-- The `homeserver-roundtable` aspect exists, but it was detached from
-  inventory because its required secret was missing.
-- Current inventory no longer attaches Roundtable to `vaglio`, even though
-  prior agent discussion suggested the user should expect to see new work
-  appear at `roundtable.deepwatercreature.com/forgejo-shell`.
+- The `homeserver-roundtable` aspect exists, but it was silently omitted at
+  eval time because its required secret was missing from the repo source.
 - The repo currently lacks both of the concrete prerequisites needed to make
   that reattachment real:
   - `ssh-keys/agenix-machine-identities/vaglio.pub` does not exist
   - `secrets-agenix/roundtable-secret-key-base.age` does not exist
-- A live Proxmox cluster inspection also shows no current LXC config for
-  `vaglio`; there is nothing to `pct enter` yet.
 - Any Forgejo-shell demo or code-analysis UI work is blocked until there is a
   real Roundtable host path again.
 
@@ -59,3 +54,15 @@ Restore the Roundtable service as an active host feature on `vaglio`, so the
 
 This item exists because deployment reality needs to be restored before the
 demo-oriented Forgejo-shell work can be made credible.
+
+Current progress as of May 10, 2026:
+
+- PR #143 (`fix/vaglio-forgejo-shell`) restores the missing
+  `roundtable-secret-key-base.age`, adds
+  `ssh-keys/agenix-machine-identities/vaglio.pub`, and bumps the pinned
+  `agent-roundtable` revision to one that contains the Forgejo-shell route.
+- With that branch checked out, both of these evals succeed:
+  - `nix eval .#nixosConfigurations.vaglio.config.services.roundtable.enable`
+  - `nix eval .#nixosConfigurations.homeserver.config.services.roundtable.enable`
+- The remaining work is merge and deployment onto a clean Vaglio branch, not
+  rediscovery of the missing prerequisites.

--- a/docs/tooling-work-items/31-forgejo-shell-vaglio-demo-surface.md
+++ b/docs/tooling-work-items/31-forgejo-shell-vaglio-demo-surface.md
@@ -1,0 +1,50 @@
+# 31 Forgejo-Shell Demo Surface On Vaglio
+
+Status: `ready`
+Suggested branch: `feat/forgejo-shell-vaglio-surface`
+Priority: `high`
+
+## Goal
+
+Expose a working `forgejo-shell` demo surface at
+`roundtable.deepwatercreature.com/forgejo-shell`, hosted on `vaglio`.
+
+## Why
+
+- The user was told to expect a visible Forgejo-shell surface soon, but the
+  repo currently has no Forgejo or Forgejo-shell deployment wiring.
+- A concrete route and service boundary are needed before higher-level demo
+  analysis work can be shown to other people.
+- This should be a visible, inspectable deployment step, not just internal
+  package plumbing.
+
+## Scope
+
+1. Decide the minimal deploy shape for `forgejo-shell` on `vaglio`:
+   - standalone app/service, or
+   - a narrowly scoped component behind Roundtable, or
+   - a thin shell around a Forgejo-derived service path
+2. Add the NixOS service/plumbing needed for that minimal shape.
+3. Add ingress/routing so `/forgejo-shell` resolves on
+   `roundtable.deepwatercreature.com`.
+4. Document the expected runtime dependencies and any placeholder auth model.
+
+## Non-Goals
+
+- Full Forgejo productization
+- JJ integration inside Forgejo internals
+- The full public-repo stress-analysis demo
+
+## Validation
+
+- `vaglio` evaluates cleanly with the new service and route
+- `/forgejo-shell` is represented explicitly in repo config, not implied by
+  chat history
+- a human can tell from the repo where the service starts, how it is routed,
+  and what runtime secrets or packages it needs
+
+## Notes
+
+Keep this item narrowly about getting a visible service path up. If deep app
+design questions appear, leave those to follow-up items instead of ballooning
+this PR.

--- a/docs/tooling-work-items/31-forgejo-shell-vaglio-demo-surface.md
+++ b/docs/tooling-work-items/31-forgejo-shell-vaglio-demo-surface.md
@@ -12,7 +12,7 @@ Expose a working `forgejo-shell` demo surface at
 ## Why
 
 - The user was told to expect a visible Forgejo-shell surface soon, but the
-  repo currently has no Forgejo or Forgejo-shell deployment wiring.
+  route is not yet deployed on the active Vaglio host.
 - A concrete route and service boundary are needed before higher-level demo
   analysis work can be shown to other people.
 - This should be a visible, inspectable deployment step, not just internal
@@ -48,3 +48,11 @@ Expose a working `forgejo-shell` demo surface at
 Keep this item narrowly about getting a visible service path up. If deep app
 design questions appear, leave those to follow-up items instead of ballooning
 this PR.
+
+Dependency note:
+
+- PR #143 restores the repo-side prerequisites and the upstream app revision
+  that contains `/forgejo-shell`, but it does not by itself deploy a working
+  surface on the live host.
+- Treat item 30 and item 35 as prerequisites for actually making the demo path
+  visible and stable.

--- a/docs/tooling-work-items/32-public-repo-stress-analysis-demo.md
+++ b/docs/tooling-work-items/32-public-repo-stress-analysis-demo.md
@@ -1,0 +1,49 @@
+# 32 Public Repo Stress Analysis Demo
+
+Status: `ready`
+Suggested branch: `feat/public-repo-stress-analysis-demo`
+Priority: `high`
+
+## Goal
+
+Build a working demo that imports a small set of large public repositories and
+computes branch/history stress views using the project’s information-theoretic
+and active-inference framing.
+
+## Why
+
+- The user wants more than notes about lines added and deleted.
+- The point of the demo is to show branch stress, change heat over time, and
+  code-history pressure signals that can be discussed as a live artifact.
+- This is the most directly user-visible differentiator once a Forgejo-shell
+  demo surface exists.
+
+## Scope
+
+1. Choose a small initial corpus of large public repos to import.
+2. Define the first demo metrics clearly enough to implement and compare:
+   - branch stress
+   - change-history heat
+   - at least one active-inference-aligned score or visualization
+3. Build the import + analysis pipeline needed to produce those artifacts.
+4. Expose the output in a way the Forgejo-shell surface can consume, even if
+   the first version is read-only.
+
+## Non-Goals
+
+- Perfect theoretical completeness in the first pass
+- Supporting arbitrary private repos
+- Replacing Forgejo UI wholesale
+
+## Validation
+
+- at least a few public repos can be imported reproducibly
+- the demo emits outputs richer than added/deleted LOC counts
+- the resulting artifacts can be shown as branch/history heat or stress views
+- the metric definitions are written down well enough that another agent can
+  extend them without reverse-engineering the first implementation
+
+## Notes
+
+Prefer a narrow but honest first demo over a broad pseudo-platform. A small
+number of compelling repo examples is enough for the initial pass.

--- a/docs/tooling-work-items/33-jj-backed-forgejo-spike.md
+++ b/docs/tooling-work-items/33-jj-backed-forgejo-spike.md
@@ -1,0 +1,47 @@
+# 33 JJ-Backed Forgejo Spike
+
+Status: `ready`
+Suggested branch: `spike/jj-backed-forgejo`
+Priority: `medium`
+
+## Goal
+
+Prove a credible path for running a Forgejo fork with `jj` underneath or
+adjacent to its repository/change model, as groundwork for the
+Forgejo-shell-based analysis environment.
+
+## Why
+
+- The user explicitly wants `jj` involved under the hood of the Forgejo fork.
+- That is likely deeper than ordinary deployment plumbing and should be
+  treated as a spike first, not hidden inside a generic demo task.
+- A bounded spike can answer whether the right shape is:
+  - direct Forgejo fork changes,
+  - a sidecar/indexer approach, or
+  - a mirrored JJ-native analysis path behind a Forgejo-facing UI.
+
+## Scope
+
+1. Audit the minimal integration points between Forgejo semantics and JJ
+   semantics that matter for this repo’s intended demo.
+2. Identify whether a true Forgejo fork is required for the first demo.
+3. Produce a recommendation with one implementation path that is small enough
+   for a follow-up PR-sized item.
+4. If a low-risk prototype is possible, demonstrate one narrow JJ-backed flow.
+
+## Non-Goals
+
+- Shipping a complete production Forgejo fork in one item
+- Solving every Forgejo/JJ mismatch
+- Rewriting the demo surface before the architecture is understood
+
+## Validation
+
+- there is a written recommendation for the first viable JJ integration path
+- the recommendation distinguishes spike findings from long-term aspirations
+- if a prototype lands, it is narrow, reproducible, and clearly described
+
+## Notes
+
+This item should reduce architecture uncertainty, not multiply it. Prefer one
+strong recommendation over a catalog of possibilities.

--- a/docs/tooling-work-items/34-vaglio-proxmox-lxc-bring-up.md
+++ b/docs/tooling-work-items/34-vaglio-proxmox-lxc-bring-up.md
@@ -1,6 +1,6 @@
 # 34 Vaglio Proxmox LXC Bring-Up
 
-Status: `ready`
+Status: `done`
 Suggested branch: `feat/vaglio-proxmox-lxc-bring-up`
 Priority: `high`
 

--- a/docs/tooling-work-items/34-vaglio-proxmox-lxc-bring-up.md
+++ b/docs/tooling-work-items/34-vaglio-proxmox-lxc-bring-up.md
@@ -1,0 +1,167 @@
+# 34 Vaglio Proxmox LXC Bring-Up
+
+Status: `ready`
+Suggested branch: `feat/vaglio-proxmox-lxc-bring-up`
+Priority: `high`
+
+## Goal
+
+Create or recover the actual Proxmox LXC guest for `vaglio` so there is a real
+host behind the repo inventory entry and a machine that can be administered with
+`pct enter`.
+
+## Why
+
+- Repo inventory models `vaglio` as a NixOS LXC host.
+- Proxmox cluster inspection on May 10, 2026 showed no current LXC definition
+  for `vaglio` in `/etc/pve/nodes/*/lxc/*.conf`.
+- Without a real guest, follow-on work is blocked:
+  - machine identity generation
+  - Roundtable secret rekeying
+  - `homeserver-roundtable` reattachment
+  - `/forgejo-shell` demo deployment
+
+## Scope
+
+1. Choose the Proxmox node that should host `vaglio`.
+   Current pragmatic default: `pve-tomahawk`, because it is reachable now and
+   already hosts the other active homelab LXCs.
+2. Create a fresh NixOS LXC guest named `vaglio` with DHCP on `vmbr0`.
+3. Bootstrap it to the point where SSH access works and `pct enter <vmid>` is
+   available from the owning node.
+4. Generate `/var/lib/agenix/machine-identity` in the guest and commit
+   `ssh-keys/agenix-machine-identities/vaglio.pub`.
+5. Record the chosen VMID/node and any one-time Proxmox details in repo docs.
+
+## Non-Goals
+
+- Attaching the Roundtable service itself
+- Creating `roundtable-secret-key-base.age`
+- Designing Forgejo-shell or the code-analysis demo
+
+## Proposed Bring-Up Path
+
+1. Use the standalone `vaglio` profile from the adjacent `agent-roundtable`
+   repo as the initial service shape.
+   It already provides:
+   - `services.roundtable.enable = true`
+   - `git`, `gh`, `dolt`, `jujutsu`, and `tmux`
+   - an LXC-oriented profile in `nix/modules/profiles/vaglio-lxc.nix`
+2. Prefer a fresh CT over trying to infer a deleted one from inventory alone.
+3. Start with the repo's existing NixOS LXC bootstrap pattern if the standalone
+   Vaglio profile is not used directly:
+   - `.#nixos_lxc_without_determinate` for initial bring-up
+   - then switch to the steady-state config
+4. Once the guest is reachable:
+   - create `/var/lib/agenix/machine-identity`
+   - copy back the public key
+   - proceed to work item 30 for Roundtable reactivation
+
+## Concrete Bring-Up Sequence
+
+As of May 10, 2026, `pve-tomahawk` is the best default host because:
+- it is reachable now
+- it already hosts the active NixOS LXCs
+- it already has a NixOS Proxmox LXC template cached at
+  `local:vztmpl/nixos-image-lxc-proxmox-25.11pre-git-x86_64-linux.tar.xz`
+
+Suggested values:
+- Proxmox node: `pve-tomahawk`
+- VMID: re-check with `pvesh get /cluster/nextid` before creation
+  - current observed next ID on May 10, 2026: `104`
+- MAC address: `BC:24:11:A4:02:7A`
+  - this matches the DHCP reservation already recorded for `vaglio`
+
+Create the CT on `pve-tomahawk`:
+
+```bash
+CTID=$(pvesh get /cluster/nextid)
+TEMPLATE='local:vztmpl/nixos-image-lxc-proxmox-25.11pre-git-x86_64-linux.tar.xz'
+
+pct create $CTID $TEMPLATE \
+  --hostname vaglio \
+  --ostype nixos \
+  --unprivileged 1 \
+  --features nesting=1 \
+  --cores 2 \
+  --memory 5512 \
+  --swap 512 \
+  --rootfs rpool-data:60 \
+  --net0 name=eth0,bridge=vmbr0,firewall=1,hwaddr=BC:24:11:A4:02:7A,ip=dhcp,ip6=auto,type=veth \
+  --onboot 1 \
+  --ssh-public-keys /root/.ssh/authorized_keys \
+  --start 1
+```
+
+Initial verification from the Proxmox node:
+
+```bash
+pct config $CTID
+pct exec $CTID -- sh -lc 'hostname; ip -4 addr show dev eth0'
+pct enter $CTID
+```
+
+Inside the container, bootstrap the standalone Vaglio profile first:
+
+```bash
+mkdir -p /root/flakes
+cd /root/flakes
+git clone https://github.com/deepwatrcreatur/agent-roundtable.git
+cd agent-roundtable
+nixos-rebuild switch --flake .#vaglio
+```
+
+Still inside the container, create the stable agenix machine identity:
+
+```bash
+install -d -m 700 /var/lib/agenix
+test -f /var/lib/agenix/machine-identity || \
+  ssh-keygen -t ed25519 -N '' -C 'agenix-machine-identity vaglio' -f /var/lib/agenix/machine-identity
+chmod 400 /var/lib/agenix/machine-identity
+cat /var/lib/agenix/machine-identity.pub
+```
+
+Then, back in this repo:
+
+```bash
+ssh root@10.10.11.71 'cat /var/lib/agenix/machine-identity.pub' > ssh-keys/agenix-machine-identities/vaglio.pub
+git add ssh-keys/agenix-machine-identities/vaglio.pub
+```
+
+After that, proceed to work item 30:
+- create and rekey `roundtable-secret-key-base.age`
+- reattach `homeserver-roundtable` to `vaglio`
+- switch from the standalone `agent-roundtable` profile to the inventory-backed
+  `unified-nix-configuration#vaglio` host path
+
+## Validation
+
+- Proxmox cluster config contains a `vaglio` LXC definition
+- `pct enter <vmid>` succeeds on the owning node
+- `ssh deepwatrcreatur@10.10.11.71` or the final assigned host address works
+- `ssh-keys/agenix-machine-identities/vaglio.pub` exists in this repo
+
+## Notes
+
+This item exists because the repo currently has a host definition without a
+corresponding live Proxmox guest. Fixing that mismatch is the cleanest next
+move and requires little design discussion.
+
+Execution notes from May 10, 2026:
+
+- `vaglio` was created on `pve-tomahawk` as CT `104`
+- the guest obtained the expected DHCP address `10.10.11.71`
+- `/var/lib/agenix/machine-identity` was generated in the guest
+- `ssh-keys/agenix-machine-identities/vaglio.pub` was copied back into this repo
+- the standalone `agent-roundtable` `#vaglio` profile switches successfully
+- `roundtable.service` does not work out of the box in that standalone profile:
+  - the generated start script assumes `CREDENTIALS_DIRECTORY` exists under `set -u`
+  - the packaged `roundtable-web` path runs Mix from a read-only `/nix/store`
+    source tree and fails during Hex dependency setup with `{:error, :erofs}`
+- a runtime-only systemd override on `vaglio` now points `roundtable.service`
+  at the writable checkout in `/root/flakes/agent-roundtable/roundtable`
+- with that runtime override, `roundtable.service` is active and `HEAD /`
+  returns `200 OK` on port `4000`
+- that override lives under `/run/systemd/system/roundtable.service.d/` and is
+  therefore not persistent across reboot; the proper fix belongs in the
+  `agent-roundtable` repo

--- a/docs/tooling-work-items/35-agent-roundtable-standalone-service-fix.md
+++ b/docs/tooling-work-items/35-agent-roundtable-standalone-service-fix.md
@@ -1,0 +1,56 @@
+# 35 Agent-Roundtable Standalone Service Fix
+
+Status: `ready`
+Suggested branch: `fix/agent-roundtable-standalone-service`
+Priority: `high`
+
+## Goal
+
+Fix the standalone `agent-roundtable` `#vaglio` profile so its
+`roundtable.service` starts cleanly on a fresh host without any runtime-only
+systemd overrides.
+
+## Why
+
+- `vaglio` now exists as a real Proxmox LXC guest and can host the demo stack.
+- The standalone profile switches successfully, but the service implementation
+  has two runtime bugs:
+  - the generated start script assumes `CREDENTIALS_DIRECTORY` is always set
+  - the packaged `roundtable-web` wrapper runs Mix from a read-only
+    `/nix/store` source tree, causing Hex dependency setup to fail with
+    `{:error, :erofs}`
+- A temporary runtime override on `vaglio` works around this by running from
+  `/root/flakes/agent-roundtable/roundtable`, but that fix disappears on reboot.
+
+## Scope
+
+1. Patch the standalone service/startup logic in the `agent-roundtable` repo.
+2. Make the service safe when no systemd credentials are configured.
+3. Make the runtime path use a writable project directory or otherwise avoid
+   Mix writes into `/nix/store`.
+4. Rebuild `vaglio` without the runtime override and confirm the service starts
+   cleanly.
+
+## Non-Goals
+
+- Roundtable secret rekeying in this repo
+- Reattaching the inventory-backed `homeserver-roundtable` aspect
+- Forgejo-shell UI work
+
+## Validation
+
+- `nixos-rebuild switch --flake .#vaglio` in the `agent-roundtable` repo
+  produces a working `roundtable.service`
+- no `/run/systemd/system/roundtable.service.d/local-dev-override.conf` is
+  required
+- `systemctl status roundtable` is `active (running)`
+- `curl -I http://127.0.0.1:4000` returns `200 OK`
+
+## Notes
+
+On May 10, 2026, `vaglio` was made live with a runtime-only override that:
+- cleared the `CREDENTIALS_DIRECTORY` assumption
+- replaced `ExecStart` with a writable-checkout Mix launch
+
+That proved the host and app can run, but the proper fix belongs upstream in
+`/home/deepwatrcreatur/flakes/agent-roundtable`.

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -26,6 +26,16 @@ wrappers, shell defaults, and related repo operations.
 
 ## Current Ranked Queue
 
+1. [34 Vaglio Proxmox LXC Bring-Up](./34-vaglio-proxmox-lxc-bring-up.md) — `ready`
+2. [35 Agent-Roundtable Standalone Service Fix](./35-agent-roundtable-standalone-service-fix.md) — `ready`
+3. [30 Vaglio Roundtable Reactivation](./30-vaglio-roundtable-reactivation.md) — `ready`
+4. [31 Forgejo-Shell Demo Surface On Vaglio](./31-forgejo-shell-vaglio-demo-surface.md) — `ready`
+5. [32 Public Repo Stress Analysis Demo](./32-public-repo-stress-analysis-demo.md) — `ready`
+6. [33 JJ-Backed Forgejo Spike](./33-jj-backed-forgejo-spike.md) — `ready`
+7. [29 Shared Agent Guide Source of Truth](./29-shared-agent-guide-source-of-truth.md) — `in-progress`
+
+## Recently Completed
+
 1. [24 SSH Commit Signing — Core Modules](./24-ssh-commit-signing-modules.md) — `done`
 2. [25 SSH Commit Signing — Host Wiring](./25-ssh-signing-host-wiring.md) — `done`
 3. [26 Remove GPG Modules](./26-remove-gpg-modules.md) — `done`

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -26,16 +26,15 @@ wrappers, shell defaults, and related repo operations.
 
 ## Current Ranked Queue
 
-1. [34 Vaglio Proxmox LXC Bring-Up](./34-vaglio-proxmox-lxc-bring-up.md) — `ready`
+1. [30 Vaglio Roundtable Reactivation](./30-vaglio-roundtable-reactivation.md) — `in-progress`
 2. [35 Agent-Roundtable Standalone Service Fix](./35-agent-roundtable-standalone-service-fix.md) — `ready`
-3. [30 Vaglio Roundtable Reactivation](./30-vaglio-roundtable-reactivation.md) — `ready`
-4. [31 Forgejo-Shell Demo Surface On Vaglio](./31-forgejo-shell-vaglio-demo-surface.md) — `ready`
-5. [32 Public Repo Stress Analysis Demo](./32-public-repo-stress-analysis-demo.md) — `ready`
-6. [33 JJ-Backed Forgejo Spike](./33-jj-backed-forgejo-spike.md) — `ready`
-7. [29 Shared Agent Guide Source of Truth](./29-shared-agent-guide-source-of-truth.md) — `in-progress`
+3. [31 Forgejo-Shell Demo Surface On Vaglio](./31-forgejo-shell-vaglio-demo-surface.md) — `ready`
+4. [32 Public Repo Stress Analysis Demo](./32-public-repo-stress-analysis-demo.md) — `ready`
+5. [33 JJ-Backed Forgejo Spike](./33-jj-backed-forgejo-spike.md) — `ready`
 
 ## Recently Completed
 
-1. [24 SSH Commit Signing — Core Modules](./24-ssh-commit-signing-modules.md) — `done`
-2. [25 SSH Commit Signing — Host Wiring](./25-ssh-signing-host-wiring.md) — `done`
-3. [26 Remove GPG Modules](./26-remove-gpg-modules.md) — `done`
+1. [34 Vaglio Proxmox LXC Bring-Up](./34-vaglio-proxmox-lxc-bring-up.md) — `done`
+2. [24 SSH Commit Signing — Core Modules](./24-ssh-commit-signing-modules.md) — `done`
+3. [25 SSH Commit Signing — Host Wiring](./25-ssh-signing-host-wiring.md) — `done`
+4. [26 Remove GPG Modules](./26-remove-gpg-modules.md) — `done`

--- a/ssh-keys/agenix-machine-identities/vaglio.pub
+++ b/ssh-keys/agenix-machine-identities/vaglio.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIKXMoOoPTkTuserag95iRpNjBENhxWmASHK1CNH48/p agenix-machine-identity vaglio


### PR DESCRIPTION
## **User description**
Summary:
- recover the untracked Vaglio and Roundtable tooling work-item files into version control
- add the recovered Vaglio agenix machine identity public key
- normalize queue state so completed and active items reflect current repo reality

What changed:
- add tooling work items 30 through 35
- mark 34 Vaglio Proxmox LXC Bring-Up as done
- mark 30 Vaglio Roundtable Reactivation as in-progress
- note that PR #143 already covers the repo-side secret and source-revision recovery for item 30
- update the tooling work-items README ranking to match the real dependency order

Queue interpretation after this PR:
1. 30 Vaglio Roundtable Reactivation is in progress
2. 35 Agent-Roundtable Standalone Service Fix is the next concrete blocker
3. 31 Forgejo-Shell Demo Surface On Vaglio stays as a follow-on after 30 and 35
4. 32 and 33 remain future work

Operational note:
This PR is documentation and queue recovery only. It does not deploy or modify the live Vaglio host.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added documentation for five new tooling work items covering vaglio roundtable reactivation, forgejo-shell demo surface, public repo stress analysis demo, jj-backed forgejo spike, and agent-roundtable standalone service fix.</li>
<li>Added documentation for vaglio proxmox LXC bring-up work item, marked as done.</li>
<li>Updated the tooling work items README to reflect the current ranked queue and recently completed items.</li>
<li>Added the SSH public key for vaglio's agenix machine identity.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Recover the Vaglio work queue and record the live host prerequisites**

### What Changed
- Updates the tooling queue so the active work order reflects the current path: Vaglio Roundtable reactivation is in progress, the standalone service fix is next, and the remaining Forgejo-shell and demo tasks are marked as upcoming
- Adds the missing work-item docs for Vaglio bring-up, Roundtable reactivation, the standalone service fix, the Forgejo-shell demo surface, and the JJ-backed Forgejo spike
- Records the recovered Vaglio machine identity public key in the repo so Roundtable setup can proceed against a real host

### Impact
`✅ Clearer demo task order`
`✅ Fewer missing prereqs for Vaglio reactivation`
`✅ Faster handoff from host bring-up to Roundtable setup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=H6QuWJEJH82SnX-nCdQveOX39wZWZ-t94VwJC47tFNI&org=deepwatrcreatur)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive tooling work item documentation outlining planned infrastructure tasks including Roundtable service reactivation, demo surface deployment, stress analysis, integration exploration, and service fixes.
  * Updated work item queue tracking with current status and recent progress.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/144)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->