### PR TITLE
feat(router): SNMP support and network inventory consolidation

### DIFF
--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -69,6 +69,7 @@ in
 {
   imports = [
     ../../../modules/nixos/router/common.nix
+    ../../../modules/nixos/router/snmp.nix
     ../../../modules/nixos/services/iventoy.nix
   ];
 
@@ -371,6 +372,15 @@ in
 
   services.router-observability.enable = true;
 
+  services.router-snmp = {
+    enable = true;
+    listenAddresses = [
+      "127.0.0.1"
+      "10.10.10.1"
+      managementListenAddress
+    ];
+  };
+
   services.router-homelab.sshTarget = sshTarget;
   services.router-homelab.listenAddress = "0.0.0.0";
 
@@ -388,6 +398,7 @@ in
       "technitium-dns-server"
       "kea-dhcp4-server"
       "kea-dhcp-ddns-server"
+      "snmpd"
       "miniupnpd"
       "tailscaled"
       "fail2ban"

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -376,9 +376,8 @@ in
     enable = true;
     listenAddresses = [
       "127.0.0.1"
-      "10.10.10.1"
       managementListenAddress
-    ];
+    ] ++ lib.optionals isPrimaryRouter [ "10.10.10.1" ];
   };
 
   services.router-homelab.sshTarget = sshTarget;

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -71,6 +71,7 @@
         "firewall"
         "router-management"
       ];
+      sshAliases = [ ];
       # Public service subdomains fronted by Caddy on this host.
       # DNS CNAMEs for these point at router, but the actual service runs elsewhere.
       publicIngressServices = [
@@ -156,9 +157,20 @@
       description = "Proxmox node - ASRock Z170 ITX/AC";
     };
 
-    # Access Points
+    # Networking Equipment
+    sw-main = {
+      ip = "10.10.18.10";
+      includeSsh = false;
+      dhcpReservation = {
+        macAddress = "1c:2a:a3:1e:c3:51";
+        scope = "LAN";
+      };
+      description = "Core Switch";
+    };
+
     ap-ruqayya = {
-      ip = "10.10.11.20";
+      ip = "10.10.18.20";
+      includeSsh = false;
       dhcpReservation = {
         macAddress = "54:D7:E3:C7:51:80";
         scope = "LAN";
@@ -166,7 +178,8 @@
       description = "AP25 Ruqayya Bedroom";
     };
     ap-nosheen-living = {
-      ip = "10.10.11.21";
+      ip = "10.10.18.21";
+      includeSsh = false;
       dhcpReservation = {
         macAddress = "A8:5B:F7:C2:0A:42";
         scope = "LAN";
@@ -174,7 +187,8 @@
       description = "AP22 Nosheen Living Room";
     };
     ap-nosheen-bedroom = {
-      ip = "10.10.11.22";
+      ip = "10.10.18.22";
+      includeSsh = false;
       dhcpReservation = {
         macAddress = "FC:7F:F1:CC:E1:CA";
         scope = "LAN";

--- a/modules/nixos/router/snmp.nix
+++ b/modules/nixos/router/snmp.nix
@@ -51,7 +51,11 @@ in
 
     systemd.services.snmpd = {
       description = "Simple Network Management Protocol (SNMP) daemon";
-      after = [ "network.target" ];
+      after = [
+        "network.target"
+        "agenix.service"
+      ];
+      wants = [ "agenix.service" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
         set -euo pipefail

--- a/modules/nixos/router/snmp.nix
+++ b/modules/nixos/router/snmp.nix
@@ -1,0 +1,88 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.router-snmp;
+  optSec = import ../../../lib/optional-secrets.nix { inherit lib; };
+
+  secrets = optSec.mkSecrets {
+    snmp-community = {
+      file = ../../../secrets-agenix/snmp-community.age;
+      mode = "0440";
+      group = "root";
+    };
+  };
+in
+{
+  options.services.router-snmp = {
+    enable = mkEnableOption "SNMP service for router";
+
+    listenAddresses = mkOption {
+      type = types.listOf types.str;
+      default = [ "127.0.0.1" "10.10.10.1" ];
+      description = "Addresses to listen on for SNMP requests";
+    };
+
+    allowedNetworks = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "10.10.0.0/16"
+        "192.168.100.0/24"
+      ];
+      description = "Source networks allowed to query the SNMPv2c community";
+    };
+
+    location = mkOption {
+      type = types.str;
+      default = "Homelab";
+      description = "System location for SNMP";
+    };
+
+    contact = mkOption {
+      type = types.str;
+      default = "deepwatrcreatur@gmail.com";
+      description = "System contact for SNMP";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    age.secrets = secrets.definitions;
+
+    systemd.services.snmpd = {
+      description = "Simple Network Management Protocol (SNMP) daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        set -euo pipefail
+        umask 077
+
+        if [ ! -r "${secrets.path "snmp-community"}" ]; then
+          echo "Missing SNMP community secret: ${secrets.path "snmp-community"}" >&2
+          exit 1
+        fi
+
+        community="$(${pkgs.coreutils}/bin/cat "${secrets.path "snmp-community"}")"
+
+        cat > /run/snmpd/snmpd.conf <<'EOF'
+        # Listen on the router-local addresses configured by Nix.
+        ${concatMapStringsSep "\n" (addr: "agentAddress udp:${addr}:161") cfg.listenAddresses}
+
+        sysLocation ${cfg.location}
+        sysContact ${cfg.contact}
+        EOF
+
+        ${concatMapStringsSep "\n" (cidr: ''
+          printf 'rocommunity %s %s\n' "$community" "${cidr}" >> /run/snmpd/snmpd.conf
+        '') cfg.allowedNetworks}
+      '';
+      serviceConfig = {
+        RuntimeDirectory = "snmpd";
+        ExecStart = "${lib.getExe' pkgs.net-snmp "snmpd"} -f -Lo -c /run/snmpd/snmpd.conf";
+        Restart = "on-failure";
+      };
+    };
+
+    services.router-firewall.trustedUdpPorts = [ 161 ];
+  };
+}

--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -66,6 +66,7 @@ let
     "apt-cache"
     "homeassistant"
     "infisical"
+    "sw-main"
   ];
 
   missingDenInventoryHosts =

--- a/scripts/validate-router-cutover.sh
+++ b/scripts/validate-router-cutover.sh
@@ -15,9 +15,10 @@ declare -A CRITICAL_HOSTS=(
   ["authentik-host"]="10.10.11.70"
   ["inference1"]="10.10.11.131"
   ["homeserver"]="10.10.11.69"
-  ["ap-ruqayya"]="10.10.11.20"
-  ["ap-nosheen-living"]="10.10.11.21"
-  ["ap-nosheen-bedroom"]="10.10.11.22"
+  ["sw-main"]="10.10.18.10"
+  ["ap-ruqayya"]="10.10.18.20"
+  ["ap-nosheen-living"]="10.10.18.21"
+  ["ap-nosheen-bedroom"]="10.10.18.22"
 )
 
 echo "=== Router Post-Cutover Validation ==="

--- a/scripts/validate-snmp.sh
+++ b/scripts/validate-snmp.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# scripts/validate-snmp.sh — SNMP validation for homelab router
+set -euo pipefail
+
+ROUTER_LAN_IP="10.10.10.1"
+COMMUNITY="${SNMP_COMMUNITY:-}"
+TIMEOUT=2
+
+if [ -z "$COMMUNITY" ]; then
+  echo "Set SNMP_COMMUNITY to the router's SNMPv2c community string." >&2
+  exit 2
+fi
+
+echo "=== SNMP Validation Check ==="
+
+if ! command -v snmpwalk >/dev/null 2>&1; then
+  echo "ERROR: snmpwalk not found. Please install net-snmp packages."
+  exit 1
+fi
+
+echo -n "Checking SNMP SysDescr from $ROUTER_LAN_IP... "
+if sys_descr=$(snmpwalk -v 2c -c "$COMMUNITY" -t "$TIMEOUT" "$ROUTER_LAN_IP" .1.3.6.1.2.1.1.1 2>/dev/null); then
+  echo "OK"
+  echo "  Description: $(echo "$sys_descr" | cut -d':' -f2-)"
+else
+  echo "FAILED"
+  exit 1
+fi
+
+echo -n "Checking SNMP Interface list... "
+if if_count=$(snmpwalk -v 2c -c "$COMMUNITY" -t "$TIMEOUT" "$ROUTER_LAN_IP" .1.3.6.1.2.1.2.1 2>/dev/null); then
+  echo "OK"
+  echo "  Interfaces found: $(echo "$if_count" | cut -d':' -f2-)"
+else
+  echo "FAILED"
+  exit 1
+fi
+
+echo "=== SNMP Validation Complete ==="
+exit 0

--- a/secrets-agenix/snmp-community.age
+++ b/secrets-agenix/snmp-community.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> ssh-ed25519 y2vB+Q /jfJJaixJGWyBx7HGJvnt+QN7pH2XlQiSZxURgRmvTM
+DPb0M3PA5OLt3uyLlV5Ne58FlXuQmSyuE+wCYgXmftg
+-> ssh-ed25519 p4q3mg GT6PTm4q0uylJDpEOHo7lttI4o3tMbX49NpEBCZEUUI
+ticQQxBjYgIvlpPXUVI17335ysyR+MMTkno4D3615lY
+-> ssh-ed25519 D7C/7Q LDTN2E0pfGZW7ofaO24let51QerY1WAihtXV8l9xSC4
+dHZgstWKQpCYh9P8Is+RL4OdrwMXaHYi010XkETsqCg
+--- mX4T+xboJki42FnF561r55nfSV/uaDlG3aFyvBO5q14
+d�0��9[{v@��@-��|����i� e2C�a~S?yF�

--- a/secrets.nix
+++ b/secrets.nix
@@ -110,6 +110,7 @@ in {
 
   "secrets-agenix/cloudflare_ddns_API_token.age".publicKeys = routerServiceSecrets;
   "secrets-agenix/technitium-api-key.age".publicKeys = routerServiceSecrets;
+  "secrets-agenix/snmp-community.age".publicKeys = routerServiceSecrets;
   "secrets-agenix/kea-ddns-tsig-key.age".publicKeys = routerServiceSecrets;
   "secrets-agenix/tailscale-auth-key.age".publicKeys = routerServiceSecrets;
   "secrets-agenix/authentik-env.age".publicKeys = authentikHostServiceSecrets;


### PR DESCRIPTION
## **User description**
## Summary
- add a router-local SNMP module that renders `snmpd.conf` at runtime from an encrypted community secret
- expose SNMP on loopback, the router LAN VIP, and the management address
- add `snmpd` to the router dashboard service list and open UDP/161 on trusted networks
- move the core switch and AP inventory entries into the `10.10.18.x` block and keep them out of SSH inventory
- update router validation scripts for the new network-equipment addresses and add an SNMP validation helper

## Scope
This is intentionally limited to SNMPv2c plus inventory consolidation.

It does **not** include the unrelated standby-router DHCP/HA churn that was present in the earlier branch version, and it does **not** ship placeholder SNMPv3 credentials.

## Validation
- `nix build /tmp/router-snmp-clean#checks.x86_64-linux.inventory-consistency`
- `nix build /tmp/router-snmp-clean#checks.x86_64-linux.module-loading-eval`
- `nix build /tmp/router-snmp-clean#checks.x86_64-linux.ssh-keys-manager-eval`
- `nix eval --json /tmp/router-snmp-clean#nixosConfigurations.router.config.services.router-snmp.listenAddresses`
- `nix eval --json /tmp/router-snmp-clean#nixosConfigurations.router.config.services.router-dashboard.services`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Router SNMP monitoring enabled; dashboard now shows snmpd status.
  * New configurable router SNMP service with sensible defaults.

* **Chores**
  * Network inventory updated (main switch added; AP addresses changed).
  * SSH inclusion settings adjusted for several hosts.
  * SNMP community secret added and wired into router service.

* **Tools**
  * Added SNMP validation script and updated router cutover validation to new IPs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add SNMP monitoring to the router and update network equipment addresses**

### What Changed
- The router now exposes SNMP on the loopback address, LAN address, and management address so monitoring tools can query it.
- SNMP access is limited to trusted networks, and the router dashboard now shows the SNMP service as part of the router service list.
- Core switch and access point entries moved to the `10.10.18.x` network, and these devices are kept out of SSH inventory.
- Router cutover checks and network inventory validation were updated to match the new switch and access point addresses.

### Impact
`✅ Router SNMP monitoring`
`✅ Fewer inventory mismatches during cutover`
`✅ Clearer service visibility on the router dashboard`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
