### PR TITLE
docs: record vaglio roundtable follow-up

### DIFF
--- a/docs/agenix-machine-identity-inventory.md
+++ b/docs/agenix-machine-identity-inventory.md
@@ -15,6 +15,7 @@ with mode `0400` and owner `root:root`.
 | podman | `agenix machine identity - podman` | `/var/lib/agenix/machine-identity` | `ssh-keys/agenix-machine-identities/podman.pub` | `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHCr6V3GOWCDJUKxnVAj+AZTUgGG7Vd51j/AQiMJ7SX1 agenix-machine-identity podman` |
 | router | `agenix machine identity - router` | `/var/lib/agenix/machine-identity` | `ssh-keys/agenix-machine-identities/router.pub` | `pending` |
 | rustdesk | `agenix machine identity - rustdesk` | `/var/lib/agenix/machine-identity` | `ssh-keys/agenix-machine-identities/rustdesk.pub` | `pending` |
+| vaglio | `agenix machine identity - vaglio` | `/var/lib/agenix/machine-identity` | `ssh-keys/agenix-machine-identities/vaglio.pub` | `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIKXMoOoPTkTuserag95iRpNjBENhxWmASHK1CNH48/p agenix-machine-identity vaglio` |
 | workstation | `agenix machine identity - workstation` | `/var/lib/agenix/machine-identity` | `ssh-keys/agenix-machine-identities/workstation.pub` | `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC22EvqG/w5v3w4TRwz4KajVwU5b19VXQJKbLKSQVlTy agenix-machine-identity workstation` |
 
 Suggested generation command per machine:

--- a/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
+++ b/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
@@ -55,7 +55,7 @@ Restore the Roundtable service as an active host feature on `vaglio`, so the
 This item exists because deployment reality needs to be restored before the
 demo-oriented Forgejo-shell work can be made credible.
 
-Current progress as of May 10, 2026:
+Current progress as of May 13, 2026:
 
 - PR #143 (`fix/vaglio-forgejo-shell`) restores the missing
   `roundtable-secret-key-base.age`, adds
@@ -69,3 +69,7 @@ Current progress as of May 10, 2026:
 - `roundtable.service` is active on the live host again, and
   `roundtable.deepwatercreature.com` is backed by an active repo-managed host
   path.
+- The live `vaglio` host now serves Roundtable and the public
+  `/forgejo-shell` route from the standalone `agent-roundtable` deployment.
+- The remaining work in this repo is to finish the inventory-backed
+  reattachment path cleanly, not to rediscover the live host prerequisites.

--- a/docs/tooling-work-items/31-forgejo-shell-vaglio-demo-surface.md
+++ b/docs/tooling-work-items/31-forgejo-shell-vaglio-demo-surface.md
@@ -11,8 +11,8 @@ Expose a working `forgejo-shell` demo surface at
 
 ## Why
 
-- The user was told to expect a visible Forgejo-shell surface soon, but the
-  route is not yet deployed on the active Vaglio host.
+- The user was told to expect a visible Forgejo-shell surface soon, and this
+  item tracks making that surface real on the active Vaglio host.
 - A concrete route and service boundary are needed before higher-level demo
   analysis work can be shown to other people.
 - This should be a visible, inspectable deployment step, not just internal
@@ -43,6 +43,17 @@ Expose a working `forgejo-shell` demo surface at
 - a human can tell from the repo where the service starts, how it is routed,
   and what runtime secrets or packages it needs
 
+## Outcome
+
+Completed on May 13, 2026.
+
+- `https://roundtable.deepwatercreature.com/forgejo-shell` now returns
+  `HTTP/2 200` publicly through the router Caddy proxy.
+- The live route is backed by the Roundtable app on `vaglio`, including the
+  `ForgejoShellLive` route in the upstream `agent-roundtable` repo.
+- The public surface is live even though the inventory-backed Roundtable
+  reattachment in this repo remains a separate follow-up.
+
 ## Notes
 
 Keep this item narrowly about getting a visible service path up. If deep app
@@ -58,3 +69,7 @@ Dependency note:
   `http://127.0.0.1:4000/forgejo-shell` returns `200`.
 - Follow-up demo work should build on this working route rather than treating
   the surface itself as still blocked.
+- Item 35 provided the standalone-service hardening needed to keep the live
+  Vaglio deployment stable.
+- Item 30 remains the follow-up for restoring the inventory-backed Roundtable
+  host path in this repo.

--- a/docs/tooling-work-items/32-public-repo-stress-analysis-demo.md
+++ b/docs/tooling-work-items/32-public-repo-stress-analysis-demo.md
@@ -7,7 +7,7 @@ Priority: `high`
 ## Goal
 
 Build a working demo that imports a small set of large public repositories and
-computes branch/history stress views using the project’s information-theoretic
+computes branch/history stress views using the project's information-theoretic
 and active-inference framing.
 
 ## Why

--- a/docs/tooling-work-items/33-jj-backed-forgejo-spike.md
+++ b/docs/tooling-work-items/33-jj-backed-forgejo-spike.md
@@ -23,7 +23,7 @@ Forgejo-shell-based analysis environment.
 ## Scope
 
 1. Audit the minimal integration points between Forgejo semantics and JJ
-   semantics that matter for this repo’s intended demo.
+   semantics that matter for this repo's intended demo.
 2. Identify whether a true Forgejo fork is required for the first demo.
 3. Produce a recommendation with one implementation path that is small enough
    for a follow-up PR-sized item.

--- a/docs/tooling-work-items/34-vaglio-proxmox-lxc-bring-up.md
+++ b/docs/tooling-work-items/34-vaglio-proxmox-lxc-bring-up.md
@@ -147,7 +147,7 @@ This item exists because the repo currently has a host definition without a
 corresponding live Proxmox guest. Fixing that mismatch is the cleanest next
 move and requires little design discussion.
 
-Execution notes from May 10, 2026:
+Execution notes from May 10-13, 2026:
 
 - `vaglio` was created on `pve-tomahawk` as CT `104`
 - the guest obtained the expected DHCP address `10.10.11.71`
@@ -158,10 +158,11 @@ Execution notes from May 10, 2026:
   - the generated start script assumes `CREDENTIALS_DIRECTORY` exists under `set -u`
   - the packaged `roundtable-web` path runs Mix from a read-only `/nix/store`
     source tree and fails during Hex dependency setup with `{:error, :erofs}`
-- a runtime-only systemd override on `vaglio` now points `roundtable.service`
-  at the writable checkout in `/root/flakes/agent-roundtable/roundtable`
-- with that runtime override, `roundtable.service` is active and `HEAD /`
-  returns `200 OK` on port `4000`
-- that override lives under `/run/systemd/system/roundtable.service.d/` and is
-  therefore not persistent across reboot; the proper fix belongs in the
-  `agent-roundtable` repo
+- the standalone `agent-roundtable` service bugs were fixed upstream:
+  - optional `CREDENTIALS_DIRECTORY` handling under `set -u`
+  - writable runtime project copy instead of Mix writes into `/nix/store`
+  - public `PHX_HOST` alignment for `roundtable.deepwatercreature.com`
+- `roundtable.service` is now active on `vaglio` without any runtime override
+- `HEAD /` returns `200 OK` on port `4000`
+- `https://roundtable.deepwatercreature.com` returns `HTTP/2 200` through the
+  router Caddy proxy

--- a/docs/tooling-work-items/35-agent-roundtable-standalone-service-fix.md
+++ b/docs/tooling-work-items/35-agent-roundtable-standalone-service-fix.md
@@ -1,6 +1,6 @@
 # 35 Agent-Roundtable Standalone Service Fix
 
-Status: `ready`
+Status: `done`
 Suggested branch: `fix/agent-roundtable-standalone-service`
 Priority: `high`
 
@@ -46,11 +46,28 @@ systemd overrides.
 - `systemctl status roundtable` is `active (running)`
 - `curl -I http://127.0.0.1:4000` returns `200 OK`
 
+## Outcome
+
+Completed on May 13, 2026.
+
+- `agent-roundtable` now treats `CREDENTIALS_DIRECTORY` as optional in the
+  service startup path.
+- The standalone wrapper now copies the Roundtable project into writable
+  runtime state before running Mix, so Hex/deps/build writes stay out of
+  `/nix/store`.
+- The `vaglio` standalone profile now sets
+  `PHX_HOST=roundtable.deepwatercreature.com`, which fixes public LiveView
+  websocket origin handling.
+- `roundtable.service` is active on `vaglio` without a runtime-only override,
+  and the public route is live through the router.
+- The remaining Proxmox LXC `sys-kernel-debug.mount` switch noise is separate
+  from the Roundtable service result.
+
 ## Notes
 
 On May 10, 2026, `vaglio` was made live with a runtime-only override that:
 - cleared the `CREDENTIALS_DIRECTORY` assumption
 - replaced `ExecStart` with a writable-checkout Mix launch
 
-That proved the host and app can run, but the proper fix belongs upstream in
+That proved the host and app can run, and the upstream fix now lives in
 `/home/deepwatrcreatur/flakes/agent-roundtable`.


### PR DESCRIPTION
## **User description**
## Summary
- record the live vaglio machine identity in inventory
- update the vaglio bring-up and standalone-service work items with the real deployment outcome
- keep the tooling queue aligned with the current forgejo-shell and demo follow-ups

## Verification
- verified vaglio machine identity was generated and copied into the repo
- verified roundtable on vaglio is serving and the public route returns HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added machine identity inventory entry for vaglio
  * Marked agent-roundtable standalone service fix as done and expanded outcome/notes
  * Updated Forgejo-shell and Vaglio Roundtable work items to reflect live routes now serving (HTTP/2 200) and progress notes
  * Corrected apostrophe formatting across multiple docs
  * Updated Vaglio Proxmox LXC execution timeframe and service status notes
  * Reordered tooling work-items README queue and recently completed list

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/146)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new machine identity entry for 'vaglio' in the agenix inventory with SSH key details.</li>
<li>Updated execution notes and status in work item 34 for vaglio Proxmox LXC bring-up, including fixes for agent-roundtable service.</li>
<li>Marked work item 35 as 'done' and added outcome details on fixes for agent-roundtable standalone service.</li>
<li>Updated the tooling work items README with queue reordering and newly completed items.</li>
<li>Modified secrets.nix to remove 'vaglio' from certain host lists and add it to roundtable hosts, and deleted the roundtable-secret-key-base.age file.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Record the Vaglio Roundtable rollout and follow-up status**

### What Changed
- Marked the standalone Roundtable service fix as complete and noted that Vaglio now runs it without a temporary override
- Recorded that both the main Roundtable page and the `/forgejo-shell` route return public `200` responses through the router
- Added the Vaglio machine identity to the inventory and updated the related work items to show the completed and remaining follow-up tasks

### Impact
`✅ Clearer deployment status`
`✅ Easier handoff for Vaglio follow-up work`
`✅ Up-to-date machine identity records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
