### PR TITLE
fix(vaglio): use agent-roundtable root flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,16 +31,14 @@
         ]
       },
       "locked": {
-        "dir": "roundtable",
-        "lastModified": 1778668364,
-        "narHash": "sha256-dsu3EwjsTlf9MvuvixN8c/+xpMUdT524/iytf7hP4AQ=",
+        "lastModified": 1778686902,
+        "narHash": "sha256-w9KKP+0llMsZyEQqVI/OPXoZv+9LQlejvHYF6mUhiHQ=",
         "owner": "deepwatrcreatur",
         "repo": "agent-roundtable",
-        "rev": "4b4742bb5cc631757fdd43da1c5bd0cb106f5fb8",
+        "rev": "f62f417fecb7edb61990c6687df7f4c2b68f09d5",
         "type": "github"
       },
       "original": {
-        "dir": "roundtable",
         "owner": "deepwatrcreatur",
         "repo": "agent-roundtable",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -170,7 +170,7 @@
     };
 
     agent-roundtable = {
-      url = "github:deepwatrcreatur/agent-roundtable?dir=roundtable";
+      url = "github:deepwatrcreatur/agent-roundtable";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## **User description**
Summary:
- switch the agent-roundtable input from the roundtable/ subflake to the repo root flake
- pick up the exported roundtable and roundtable-web packages used by the vaglio module wiring
- unblock clean vaglio toplevel evaluation from current main

Why:
- the previous input used ?dir=roundtable, whose flake only exports packages.default
- unified-nix-configuration expects packages.<system>.roundtable-web in overlays/flake-inputs.nix
- this caused nixosConfigurations.vaglio.config.system.build.toplevel.drvPath evaluation to fail on current main

Validation:
- nix eval .#nixosConfigurations.vaglio.config.services.roundtable.enable
- nix eval .#nixosConfigurations.vaglio.config.services.roundtable.phoenixHost
- nix eval .#nixosConfigurations.vaglio.config.system.build.toplevel.drvPath


___

## **CodeAnt-AI Description**
**Use the agent-roundtable root flake for vaglio**

### What Changed
- Vaglio now pulls agent-roundtable from the repository root instead of the nested roundtable input
- This lets vaglio pick up the exported roundtable-web package it needs for its service wiring
- Clean evaluation of the vaglio NixOS configuration is unblocked

### Impact
`✅ Fewer vaglio evaluation failures`
`✅ Reliable roundtable service wiring`
`✅ Faster validation of vaglio configuration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated the agent-roundtable input URL in flake.nix by removing the '?dir=roundtable' parameter.</li>
<li>Modified flake.lock to reflect the new revision, hash, and timestamp for the agent-roundtable dependency, and removed the 'dir' field.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external dependency configuration reference

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/147)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->