### PR TITLE
docs: update ssh signing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,13 +207,16 @@ Before pushing changes that affect remote hosts:
 2. **Pull remote changes first** with `git pull` to avoid conflicts
 3. **Test locally** (rebuild/switch) before committing when possible
 4. **Split commits into logical parts**: keep commits narrowly scoped (e.g., "secrets refactor" separate from "GNOME tweaks")
-5. **Commit WITHOUT GPG signing** (agents cannot reliably handle pinentry prompts):
+5. **Commit with the normal SSH-signing flow**:
+   ```bash
+   git commit -m "feat: ..."
+   ```
+   If SSH signing is temporarily broken in a specific checkout, treat that as a
+   local config or agent issue first. Only fall back to:
    ```bash
    git commit --no-gpg-sign -m "feat: ..."
    ```
-   If you need to disable signing for multiple commits in this repo:
-   ```bash
-   git config commit.gpgsign false
-   ```
+   when you have confirmed the signing path itself is unavailable and the work
+   should not be blocked on fixing it first.
 5. **Then push** with `git push`
 ```

--- a/docs/agenix-workflow.md
+++ b/docs/agenix-workflow.md
@@ -132,8 +132,8 @@ git add secrets-agenix/paperless-db-password.age
 git add secrets.nix
 git add hosts/nixos-lxc/podman/default.nix  # Or wherever you configured usage
 
-# Commit (without GPG signing for agents)
-git commit --no-gpg-sign -m "feat: add paperless database password secret"
+# Commit
+git commit -m "feat: add paperless database password secret"
 
 # Push to remote
 git push

--- a/docs/improvements.md
+++ b/docs/improvements.md
@@ -37,7 +37,7 @@ The `inventory-consistency` check now surfaces these as a non-fatal notice.
 
 - Run `nix build .#checks.x86_64-linux.inventory-consistency` after every
   structural change.
-- Commit without GPG signing: `git commit --no-gpg-sign`.
+- Commit with the normal SSH-signing flow: `git commit -m "..."`
 - Keep changes build-tested.  Prefer narrow commits by concern.
 - Do not modify staged `authentik-host` files unless continuing that thread.
 - Do not rekey secrets casually — recipients must be correct before rekeying.

--- a/docs/memory/README.md
+++ b/docs/memory/README.md
@@ -57,5 +57,5 @@ If you find a committed file with sensitive data, remove it with:
 
 ```bash
 git rm docs/memory/<file>
-git commit --no-gpg-sign -m "security: remove sensitive memory archive file"
+git commit -m "security: remove sensitive memory archive file"
 ```


### PR DESCRIPTION
## **User description**
## Summary
- remove stale guidance telling agents to disable signing by default
- update docs to use the normal SSH commit-signing flow
- keep no-signing fallback only as a break-glass path when signing is actually unavailable

## Verification
- repo checkout now resolves commit.gpgsign=true from global git config
- gpg.format resolves to ssh with the configured SSH signing key


___

## **CodeAnt-AI Description**
**Update commit signing guidance to use the normal SSH flow**

### What Changed
- Docs now tell contributors and agents to commit with the usual SSH-signing flow instead of turning signing off by default
- The no-signing command is kept only as a fallback when signing is genuinely unavailable
- Related workflow examples were updated to remove the old “commit without signing” instruction

### Impact
`✅ Fewer unsigned commits`
`✅ Clearer signing instructions`
`✅ Less confusion when SSH signing is available`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated commit instructions in multiple documentation files to use SSH signing instead of disabling GPG signing.</li>
<li>Modified flake inputs to reference a subdirectory in the agent-roundtable repository.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Git commit workflow guidance across documentation files to prefer SSH-signed commits by default, with unsigned commits available only as a fallback option when signing is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/148)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->