### PR TITLE
docs: lock Vaglio deploys to one agent

### DIFF
--- a/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
+++ b/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
@@ -3,6 +3,8 @@
 Status: `done`
 Suggested branch: `feat/vaglio-roundtable-reactivation`
 Priority: `high`
+Deployment target: `vaglio`
+Deployment coordination: `exclusive single-writer host lock while live deploy work is active`
 
 ## Goal
 
@@ -73,3 +75,10 @@ Current progress as of May 13, 2026:
   `/forgejo-shell` route from the standalone `agent-roundtable` deployment.
 - The remaining work in this repo is to finish the inventory-backed
   reattachment path cleanly, not to rediscover the live host prerequisites.
+
+Operational note from May 14, 2026:
+
+- `vaglio` should be treated as a single-writer deployment target.
+- Parallel agent rebuilds or service restarts on the same CT can cause
+  avoidable runtime contention and make `roundtable.deepwatercreature.com`
+  appear flaky even when the code changes are individually valid.

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -14,6 +14,9 @@ wrappers, shell defaults, and related repo operations.
 
 - Treat each file in this folder as one PR-sized work stream.
 - Prefer one agent per file/branch.
+- Treat live hosts as single-writer resources; if an item deploys to a host
+  such as `vaglio`, only one agent should perform rebuilds/restarts there at a
+  time.
 - Mark the file as `in-progress` in its header once an agent starts it.
 - When work is fully merged, either delete the file or keep it briefly as
   `done` if it records useful outcome notes for follow-up agents.

--- a/docs/tooling-work-items/START-HERE.md
+++ b/docs/tooling-work-items/START-HERE.md
@@ -56,6 +56,8 @@ interpretation guidance.
    (recent commits, open PR, or file already marked `in-progress`), treat it as
    stale and proceed.
 5. Mark the item `in-progress` in your branch as part of the same PR.
+6. If the item touches a live host, treat that host as an exclusive deployment
+   target and avoid parallel rebuild/restart work from other agent sessions.
 
 ## Invariants
 


### PR DESCRIPTION
## **User description**
## Summary
- make `vaglio` an explicit single-writer deployment target in the tooling queue
- clarify that parallel branch work is still fine when it stays off the same live host
- add the coordination note directly to the Vaglio reactivation item

## Why
Recent contention on `vaglio` showed that multiple agents can do useful branch work in parallel, but rebuild/restart actions on the same live CT need serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SNMP monitoring capability to router with configurable parameters and authentication support.

* **Infrastructure**
  * Reorganized access point network assignments to updated subnet addressing scheme.
  * Enhanced router failover configuration and network service orchestration.
  * Updated network equipment inventory and management.

* **Documentation**
  * Emphasized exclusive host coordination requirements during live deployment work.
  * Completed network service validation documentation updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/149)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Migrated vaglio host from VM to LXC container by removing vm-core aspect, deleting VM-specific files, and adding LXC-related aspects like lxc-core and homeserver-networking.</li>
<li>Made roundtable service conditional on the existence of the secret key base file, simplifying the configuration and removing optional null handling.</li>
<li>Added SNMP support to the router with a new module, secret, and integration into router role, including conditional UPnP and WAN management.</li>
<li>Updated network configurations including new IP assignments for switch and access points, modified DHCP ranges, and added backup router synchronization logic.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Lock live deployments on vaglio to one agent at a time**

### What Changed
- Added a clear rule that live hosts, including `vaglio`, must be treated as exclusive deployment targets while rebuilds or restarts are running
- Updated the startup guidance so agents avoid parallel work on the same live host
- Added the `vaglio` deployment target and coordination note directly to the reactivation work item, including the warning about contention on the live host

### Impact
`✅ Safer live deployments on vaglio`
`✅ Fewer conflicting rebuilds and restarts`
`✅ Less flakiness during active host changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
