### PR TITLE
fix(vaglio): preserve dhcp landing on 25.11

### DIFF
--- a/den/aspects/default.nix
+++ b/den/aspects/default.nix
@@ -14,6 +14,7 @@
   homeserver-homebridge = context: import ./homeserver-homebridge.nix context;
   homeserver-semaphore = context: import ./homeserver-semaphore.nix context;
   homeserver-roundtable = context: import ./homeserver-roundtable.nix context;
+  vaglio-legacy-dhcp-transition = context: import ./vaglio-legacy-dhcp-transition.nix context;
   attic-cache-core = context: import ./attic-cache-core.nix context;
   attic-cache-build-server = context: import ./attic-cache-build-server.nix context;
   attic-cache-home-manager = context: import ./attic-cache-home-manager.nix context;

--- a/den/aspects/vaglio-legacy-dhcp-transition.nix
+++ b/den/aspects/vaglio-legacy-dhcp-transition.nix
@@ -1,0 +1,61 @@
+{ ... }:
+{ lib, ... }:
+{
+  # Temporary landing path for the existing Vaglio LXC.
+  #
+  # The live host is still on an older 26.05-era image that uses dhcpcd and
+  # the legacy network-setup service. A direct switch from that state to the
+  # standard homeserver-networking/systemd-networkd model currently hangs
+  # mid-activation and can strand the guest without IPv4. Preserve the legacy
+  # DHCP stack for one safe landing deploy, then migrate to networkd in a
+  # follow-up once the host is on the repo's 25.11 baseline.
+  networking.useNetworkd = lib.mkForce false;
+  networking.useDHCP = lib.mkForce true;
+  networking.useHostResolvConf = lib.mkForce false;
+  networking.dhcpcd = {
+    enable = lib.mkForce true;
+    persistent = lib.mkForce true;
+  };
+
+  # Keep the live broker-backed system bus implementation for the landing
+  # deploy so switch-to-configuration does not also need to swap D-Bus
+  # implementations mid-upgrade.
+  services.dbus.implementation = lib.mkForce "broker";
+
+  # The 26.05 -> 25.11 landing path currently wedges if switch-to-configuration
+  # tries to stop the live D-Bus / networking / roundtable stack and then wait
+  # for completion over the same bus connection. Keep these units in place for
+  # the landing deploy, then remove these overrides once Vaglio is on the
+  # stable 25.11 baseline and can be migrated cleanly.
+  systemd.services.dbus-broker = {
+    reloadIfChanged = lib.mkForce true;
+    restartIfChanged = lib.mkForce false;
+    stopIfChanged = lib.mkForce false;
+  };
+  systemd.services.dbus = {
+    reloadIfChanged = lib.mkForce true;
+    restartIfChanged = lib.mkForce false;
+    stopIfChanged = lib.mkForce false;
+  };
+  systemd.services.logrotate-checkconf = {
+    restartIfChanged = lib.mkForce false;
+    stopIfChanged = lib.mkForce false;
+  };
+  systemd.services.network-setup.stopIfChanged = lib.mkForce false;
+  systemd.services.resolvconf.stopIfChanged = lib.mkForce false;
+  systemd.services.nscd = {
+    restartIfChanged = lib.mkForce false;
+    stopIfChanged = lib.mkForce false;
+  };
+  systemd.services.roundtable = {
+    restartIfChanged = lib.mkForce false;
+    stopIfChanged = lib.mkForce false;
+  };
+  systemd.services.systemd-tmpfiles-resetup = {
+    restartIfChanged = lib.mkForce false;
+    stopIfChanged = lib.mkForce false;
+  };
+
+  systemd.network.enable = lib.mkForce false;
+  services.resolved.enable = lib.mkForce false;
+}

--- a/den/hosts/vaglio/default.nix
+++ b/den/hosts/vaglio/default.nix
@@ -8,7 +8,4 @@ let
 in
 denLib.mkInventoryHostModule {
   name = "vaglio";
-  extraImports = [
-    ../../../hosts/nixos/vaglio/default.nix
-  ];
 }

--- a/den/inventory/hosts.nix
+++ b/den/inventory/hosts.nix
@@ -178,8 +178,13 @@
     mode = "aspect";
     aspectsList = [
       "nixos-base"
-      "vm-core"
+      "lxc-core"
+      "attic-client"
       "github-token-client"
+      "nix-daemon-user-ssh"
+      "home-manager-users"
+      "homeserver-networking"
+      "vaglio-legacy-dhcp-transition"
       "homeserver-roundtable"
     ];
   };

--- a/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
+++ b/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
@@ -1,6 +1,6 @@
 # 30 Vaglio Roundtable Reactivation
 
-Status: `in-progress`
+Status: `done`
 Suggested branch: `feat/vaglio-roundtable-reactivation`
 Priority: `high`
 
@@ -64,5 +64,8 @@ Current progress as of May 10, 2026:
 - With that branch checked out, both of these evals succeed:
   - `nix eval .#nixosConfigurations.vaglio.config.services.roundtable.enable`
   - `nix eval .#nixosConfigurations.homeserver.config.services.roundtable.enable`
-- The remaining work is merge and deployment onto a clean Vaglio branch, not
-  rediscovery of the missing prerequisites.
+- Item 36 is now complete as well: `vaglio` landed successfully onto the repo
+  `25.11` baseline without losing reachability.
+- `roundtable.service` is active on the live host again, and
+  `roundtable.deepwatercreature.com` is backed by an active repo-managed host
+  path.

--- a/docs/tooling-work-items/31-forgejo-shell-vaglio-demo-surface.md
+++ b/docs/tooling-work-items/31-forgejo-shell-vaglio-demo-surface.md
@@ -1,6 +1,6 @@
 # 31 Forgejo-Shell Demo Surface On Vaglio
 
-Status: `ready`
+Status: `done`
 Suggested branch: `feat/forgejo-shell-vaglio-surface`
 Priority: `high`
 
@@ -51,8 +51,10 @@ this PR.
 
 Dependency note:
 
-- PR #143 restores the repo-side prerequisites and the upstream app revision
-  that contains `/forgejo-shell`, but it does not by itself deploy a working
-  surface on the live host.
-- Treat item 30 and item 35 as prerequisites for actually making the demo path
-  visible and stable.
+- PR #143 restored the repo-side prerequisites and the upstream app revision
+  that contains `/forgejo-shell`.
+- Agent-roundtable PR #85 fixed the standalone runtime issues upstream.
+- The live `vaglio` host is now landed on the repo `25.11` baseline, and
+  `http://127.0.0.1:4000/forgejo-shell` returns `200`.
+- Follow-up demo work should build on this working route rather than treating
+  the surface itself as still blocked.

--- a/docs/tooling-work-items/36-vaglio-25-11-landing-transition.md
+++ b/docs/tooling-work-items/36-vaglio-25-11-landing-transition.md
@@ -1,0 +1,62 @@
+# 36 Vaglio 25.11 Landing Transition
+
+Status: `done`
+Suggested branch: `fix/vaglio-switch-hang`
+Priority: `high`
+
+## Goal
+
+Land `vaglio` onto the repo's current `25.11` baseline without losing network
+reachability during activation.
+
+## Why
+
+- `main` is intentionally pinned to `nixos-25.11`.
+- The live `vaglio` LXC was still on `26.05.20260505.549bd84`.
+- Direct `switch-to-configuration test/switch` from current `main` hung
+  mid-activation after stopping `dbus-broker`, `roundtable`, and the old DHCP
+  stack.
+- The guest then lost IPv4 until `dhcpcd` was restarted from Proxmox.
+
+## Scope
+
+1. Add a temporary host-specific landing path that preserves the legacy
+   `dhcpcd`/`network-setup` networking model for `vaglio`.
+2. Validate that the resulting `25.11` closure keeps the host reachable after
+   activation.
+3. Leave a follow-up path to migrate `vaglio` to the shared LXC
+   `systemd-networkd` model after the base release transition is complete.
+
+## Validation
+
+- `nix eval .#nixosConfigurations.vaglio.config.networking.useNetworkd` returns
+  `false`
+- `nix eval .#nixosConfigurations.vaglio.config.networking.dhcpcd.enable`
+  returns `true`
+- a persistent switch to the `25.11` closure completes without dropping SSH
+  reachability
+- `roundtable.service` remains active and `/forgejo-shell` returns `200`
+
+## Notes
+
+Landing result from May 14, 2026:
+
+- The missing piece was not just `stopIfChanged`; the target `25.11` closure
+  was also silently downgrading `services.dbus.implementation` from
+  `dbus-broker` to classic `dbus`.
+- For the landing path, forcing `services.dbus.implementation = "broker"` on
+  `vaglio` removed `dbus-broker.service` from the `dry-activate` stop set.
+- A live `switch-to-configuration test` then completed without dropping IPv4 or
+  breaking Roundtable.
+- A persistent `nixos-rebuild switch` from the same landing closure completed
+  the actual release transition; `vaglio` is now running
+  `/nix/store/x4xarb45cgf9h8b3y4qz6cw2mpd653nx-nixos-system-vaglio-lxc-25.11.20260318.fea3b36`
+  as `/run/current-system`.
+- Post-switch health checks succeeded:
+  `eth0` stayed on `10.10.11.71/16`, `dbus-broker`, `dhcpcd`,
+  `network-setup`, and `roundtable` remained active, and
+  `http://127.0.0.1:4000/forgejo-shell` returned `200`.
+- The host is still `degraded`, but only because of unrelated follow-on units:
+  `ensure-printers.service` cannot reach `10.10.21.56:631`, and
+  `snapper-cleanup.service` fails because the LXC filesystem is not a Btrfs
+  subvolume.

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -26,15 +26,13 @@ wrappers, shell defaults, and related repo operations.
 
 ## Current Ranked Queue
 
-1. [30 Vaglio Roundtable Reactivation](./30-vaglio-roundtable-reactivation.md) — `in-progress`
-2. [35 Agent-Roundtable Standalone Service Fix](./35-agent-roundtable-standalone-service-fix.md) — `ready`
-3. [31 Forgejo-Shell Demo Surface On Vaglio](./31-forgejo-shell-vaglio-demo-surface.md) — `ready`
-4. [32 Public Repo Stress Analysis Demo](./32-public-repo-stress-analysis-demo.md) — `ready`
-5. [33 JJ-Backed Forgejo Spike](./33-jj-backed-forgejo-spike.md) — `ready`
+1. [32 Public Repo Stress Analysis Demo](./32-public-repo-stress-analysis-demo.md) — `ready`
+2. [33 JJ-Backed Forgejo Spike](./33-jj-backed-forgejo-spike.md) — `ready`
 
 ## Recently Completed
 
-1. [34 Vaglio Proxmox LXC Bring-Up](./34-vaglio-proxmox-lxc-bring-up.md) — `done`
-2. [24 SSH Commit Signing — Core Modules](./24-ssh-commit-signing-modules.md) — `done`
-3. [25 SSH Commit Signing — Host Wiring](./25-ssh-signing-host-wiring.md) — `done`
-4. [26 Remove GPG Modules](./26-remove-gpg-modules.md) — `done`
+1. [31 Forgejo-Shell Demo Surface On Vaglio](./31-forgejo-shell-vaglio-demo-surface.md) — `done`
+2. [30 Vaglio Roundtable Reactivation](./30-vaglio-roundtable-reactivation.md) — `done`
+3. [36 Vaglio 25.11 Landing Transition](./36-vaglio-25-11-landing-transition.md) — `done`
+4. [35 Agent-Roundtable Standalone Service Fix](./35-agent-roundtable-standalone-service-fix.md) — `done`
+5. [34 Vaglio Proxmox LXC Bring-Up](./34-vaglio-proxmox-lxc-bring-up.md) — `done`


### PR DESCRIPTION
## **User description**
## Summary
- restore the landed Vaglio inventory shape and temporary DHCP-based landing aspect on top of current `main`
- keep `dbus-broker` during the 25.11 landing path so activation does not swap D-Bus implementations mid-upgrade
- mark Vaglio work items 30, 31, and 36 complete now that the host is landed and `/forgejo-shell` is live

## Validation
- `nix eval` from this branch reports `useNetworkd = false`, `dhcpcd = true`, `services.roundtable.enable = true`, and `services.dbus.implementation = "broker"`
- `nix build path:/home/deepwatrcreatur/flakes/fix-vaglio-25-11-landing-clean#nixosConfigurations.vaglio.config.system.build.toplevel`
- live `vaglio` is already on the landed 25.11 closure and `http://127.0.0.1:4000/forgejo-shell` returns `200`

## Follow-ups
- `ensure-printers.service` still fails if `10.10.21.56:631` is down
- `snapper-cleanup.service` still fails in this LXC because the filesystem is not Btrfs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the Vaglio 25.11 baseline transition work item, including scoping, validation checks, and post-landing notes.
  * Updated tooling work queue status, marking the Vaglio transition as complete with network reachability successfully maintained.
  * Documented completion of related work items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/151)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new 'vaglio-legacy-dhcp-transition' aspect to preserve legacy DHCP and D-Bus settings for safe transition of vaglio host to 25.11 baseline.</li>
<li>Updated vaglio host configuration to include the new aspect and removed old extra imports.</li>
<li>Marked tooling work items 30, 31, and 36 as done, updating documentation with completion notes.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Keep Vaglio reachable during the 25.11 landing**

### What Changed
- Vaglio now uses a temporary landing path that keeps its existing DHCP-based network setup during the upgrade, preventing it from losing IPv4 or SSH access mid-switch.
- The landing path also keeps the current D-Bus setup in place so the host can finish the release transition without dropping live services like Roundtable.
- Related work items were marked complete and the tooling queue was updated to reflect that Vaglio, Roundtable, and the Forgejo shell surface are now live.

### Impact
`✅ Fewer upgrade lockups`
`✅ Fewer lost-connection deploys`
`✅ Clearer host rollout status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
