### PR TITLE
fix(printer): use stable IP and avoid blocking activation

### DIFF
--- a/hosts/nixos/workstation/profile.nix
+++ b/hosts/nixos/workstation/profile.nix
@@ -118,10 +118,6 @@
     openFirewall = lib.mkForce false;
   };
 
-  systemd.services."ensure-printers".serviceConfig = lib.mkIf config.services.printing.enable {
-    ContinueOnError = true;
-  };
-
   services.logind.settings.Login.HandleLidSwitch = "ignore";
   security.sudo.wheelNeedsPassword = false;
 

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -245,6 +245,17 @@
       description = "Home Assistant VM";
     };
 
+    phoenix-hp-m477 = {
+      ip = "10.10.11.56";
+      includeSsh = false;
+      includeDns = false;
+      dhcpReservation = {
+        macAddress = "10:62:e5:26:58:c2";
+        scope = "LAN";
+      };
+      description = "HP PageWide Pro 477dn MFP printer/scanner";
+    };
+
     podman = {
       ip = "10.10.11.84";
       sshUser = "deepwatrcreatur";

--- a/modules/nixos/printers/phoenix-hp-m477.nix
+++ b/modules/nixos/printers/phoenix-hp-m477.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   # Declarative CUPS queue so it persists across nixos-rebuild/service restarts.
@@ -7,6 +7,10 @@
   # NixOS manages printers via `hardware.printers.ensurePrinters`.
 
   services.printing.enable = lib.mkDefault true;
+  systemd.services."ensure-printers".serviceConfig = lib.mkIf config.services.printing.enable {
+    # Printer reachability should not block system activation.
+    ContinueOnError = true;
+  };
 
   # Ensure scanning support for this MFP
   hardware.sane = {
@@ -21,7 +25,7 @@
   # explicitly for sane-airscan instead of relying on automatic discovery.
   environment.etc."sane.d/airscan.conf".text = ''
     [devices]
-    "HP PageWide Pro 477dn MFP" = http://10.10.21.56:80/eSCL/, eSCL
+    "HP PageWide Pro 477dn MFP" = http://10.10.11.56:80/eSCL/, eSCL
   '';
 
   environment.systemPackages = with pkgs; [
@@ -38,8 +42,8 @@
 
         # Prefer a stable URI over dnssd:// so we don't depend on browsing state.
         # If you get a "Host is down" error from `ensure-printers.service`,
-        # check that the printer is online and reachable from this host, e.g., `ping 10.10.21.56`.
-        deviceUri = "ipp://10.10.21.56/ipp/print";
+        # check that the printer is online and reachable from this host, e.g., `ping 10.10.11.56`.
+        deviceUri = "ipp://10.10.11.56/ipp/print";
 
         # Driverless printing for IPP Everywhere/AirPrint devices.
         # `lpinfo -m | rg -n 'everywhere'` should show the exact available model.


### PR DESCRIPTION
## Summary
- move the HP PageWide printer/scanner definition to the planned stable IP 10.10.11.56
- add an inventory-backed DHCP reservation for printer MAC 10:62:e5:26:58:c2 at 10.10.11.56
- keep ensure-printers from blocking activation inside the printer module itself
- remove the now-duplicated workstation-only override

## Why
The printer has moved and should live at a stable address outside the dynamic pool. Also, printer reachability should not decide whether a host activation succeeds.

## Notes
- current observed printer MAC on the router: 10:62:e5:26:58:c2
- 10.10.11.56 did not appear anywhere in checked-in config and was absent from the router neighbor table during this pass
- the reservation is declared through shared host inventory, which the router already maps into Technitium DHCP reservations for scope LAN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated printer and scanner discovery and device IPs to the new network address (10.10.11.56).
  * Added a new networked printer/scanner entry with a fixed IP and DHCP reservation; SSH and DNS inclusion disabled for that device.

* **Bug Fixes**
  * Adjusted printer service startup behavior: some service locations now allow startup to continue if devices are unreachable, while one profile reverted to stricter error handling for failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->