### PR TITLE
fix(router): restore safe DHCP rebuild behavior

### DIFF
--- a/hosts/nixos/router/networking.nix
+++ b/hosts/nixos/router/networking.nix
@@ -4,7 +4,6 @@
 }:
 let
   topology = config.router.topology;
-  lanDevice = config.services.router-networking.routedInterfaces.lan.device;
 in
 {
   imports = [
@@ -13,22 +12,4 @@ in
 
   networking.hostName = "router";
   networking.domain = topology.domain;
-
-  services.router-kea = {
-    enable = true;
-    dhcp4 = {
-      subnet = topology.networks.lan.cidr;
-      gatewayAddress = topology.routerHost.ip;
-      dnsServers = [ topology.routerHost.ip ];
-      poolRanges = [ { start = "10.10.10.100"; end = "10.10.10.250"; } ];
-    };
-    ddns = {
-      enable = true;
-      tsigKeyFile = config.age.secrets.kea-ddns-tsig-key.path;
-      tsigKeyName = "kea-ddns";
-      forwardZone = topology.domain;
-      reverseZone = "10.10.in-addr.arpa";
-    };
-  };
-
 }

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -59,14 +59,6 @@ let
   topology = config.router.topology;
   lanNetwork = topology.networks.lan;
   managementNetwork = topology.networks.management;
-  optionalDhcpInterfaces = lib.optionals enableExtraRoutedNetworks [
-    "${lanDevice}.20"
-    "${lanDevice}.30"
-  ];
-  optionalUpnpInterfaces = lib.optionals enableExtraRoutedNetworks [
-    "${lanDevice}.20"
-    "${lanDevice}.30"
-  ];
   mkFqdn = label: "${label}.${topology.domain}";
   isPrimaryRouter = config.networking.hostName == "router";
   reservableHosts = lib.filterAttrs (
@@ -181,9 +173,7 @@ in
   services.router-kea = {
     enable = true;
     dhcp4 = {
-      interfaces = [
-        lanDevice
-      ] ++ optionalDhcpInterfaces;
+      interfaces = [ lanDevice ];
       subnet = lanNetwork.cidr;
       gatewayAddress = "10.10.10.1"; # Use the VIP
       dnsServers = [ "10.10.10.1" ];
@@ -222,7 +212,7 @@ in
 
   services.router-upnp = {
     enable = true;
-    internalIPs = [ lanDevice ] ++ optionalUpnpInterfaces;
+    internalIPs = [ lanDevice ];
   };
 
   systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -27,6 +27,14 @@ let
   operatorStableSshKey = lib.strings.trim (
     builtins.readFile ../../../ssh-keys/deepwatrcreatur-stable-identity.pub
   );
+  ensureKeaLeaseState = pkgs.writeShellScript "router-kea-ensure-state" ''
+    set -euo pipefail
+
+    install -d -m 0750 -o kea -g kea /var/lib/private/kea
+    touch /var/lib/private/kea/dhcp4.leases /var/lib/private/kea/dhcp4.leases.2
+    chown kea:kea /var/lib/private/kea/dhcp4.leases /var/lib/private/kea/dhcp4.leases.2
+    chmod 0640 /var/lib/private/kea/dhcp4.leases /var/lib/private/kea/dhcp4.leases.2
+  '';
 
   secrets = optSec.mkSecrets {
     cloudflare-api-key = {
@@ -51,10 +59,20 @@ let
   topology = config.router.topology;
   lanNetwork = topology.networks.lan;
   managementNetwork = topology.networks.management;
+  optionalDhcpInterfaces = lib.optionals enableExtraRoutedNetworks [
+    "${lanDevice}.20"
+    "${lanDevice}.30"
+  ];
+  optionalUpnpInterfaces = lib.optionals enableExtraRoutedNetworks [
+    "${lanDevice}.20"
+    "${lanDevice}.30"
+  ];
   mkFqdn = label: "${label}.${topology.domain}";
+  isPrimaryRouter = config.networking.hostName == "router";
   reservableHosts = lib.filterAttrs (
     _name: host: (host.dhcpReservation or null) != null && (host.ip or null) != null
   ) topology.hosts;
+  poolRangeKeys = map (pool: "${pool.start}-${pool.end}") config.services.router-kea.dhcp4.poolRanges;
 in
 {
   imports = [
@@ -79,6 +97,14 @@ in
         Router invariant violated: 20-router-lan must have ConfigureWithoutCarrier = true.
         Without this, the LAN static IP disappears when the data-plane cable is unplugged,
         causing monitoring (Prometheus, Grafana, Netdata) to cascade into failure on standby/dev boxes.
+      '';
+    }
+    {
+      assertion = lib.length poolRangeKeys == lib.length (lib.unique poolRangeKeys);
+      message = ''
+        Router invariant violated: services.router-kea.dhcp4.poolRanges contains duplicate ranges.
+        This usually means more than one module is defining the same LAN DHCP pool, which causes
+        Kea to fail at startup with an overlapping-pool parser error.
       '';
     }
     {
@@ -134,14 +160,19 @@ in
   };
 
   services.router-ha = {
-    enable = true;
-    role = if config.networking.hostName == "router" then "master" else "backup";
+    # Keep the family-facing router as the sole HA participant while the
+    # backup node is used as a development and recovery target.
+    enable = isPrimaryRouter;
+    role = if isPrimaryRouter then "master" else "backup";
     virtualIp = "10.10.10.1/16";
     vrrpInterface = lanDevice;
-    keaSync.enable = true;
-    keaSync.peerAddress = if config.networking.hostName == "router" then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
+    keaSync.enable = isPrimaryRouter;
+    keaSync.peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
     wan = {
-      enable = true;
+      # Keepalived-driven WAN link/MAC manipulation regressed the router's own
+      # internet recovery on newer generations. Keep the LAN VIP logic, but let
+      # systemd-networkd own WAN DHCP lifecycle directly on the primary router.
+      enable = false;
       interface = wanDevice;
       clonedMac = "02:76:c6:01:2a:b0";
     };
@@ -150,21 +181,28 @@ in
   services.router-kea = {
     enable = true;
     dhcp4 = {
+      interfaces = [
+        lanDevice
+      ] ++ optionalDhcpInterfaces;
       subnet = lanNetwork.cidr;
       gatewayAddress = "10.10.10.1"; # Use the VIP
       dnsServers = [ "10.10.10.1" ];
       poolRanges = [
         {
-          start = "10.10.10.100";
-          end = "10.10.10.250";
+          # Keep dynamic leases away from the low/static part of the /16 and
+          # avoid .0/.255 boundaries in each /24-sized slice.
+          start = "10.10.200.1";
+          end = "10.10.222.254";
         }
       ];
       ha = {
-        enable = true;
+        # DHCP HA is still a client-path regression: the primary can come up in
+        # WAITING with local DHCP disabled until the backup peer times out.
+        enable = false;
         thisServerName = config.networking.hostName;
-        role = if config.networking.hostName == "router" then "primary" else "secondary";
-        peerAddress = if config.networking.hostName == "router" then "10.10.11.213" else "10.10.11.1";
-        peerName = if config.networking.hostName == "router" then "router-backup" else "router";
+        role = if isPrimaryRouter then "primary" else "secondary";
+        peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1";
+        peerName = if isPrimaryRouter then "router-backup" else "router";
       };
       reservations = lib.mapAttrsToList (name: host: {
         hw-address = host.dhcpReservation.macAddress;
@@ -181,6 +219,15 @@ in
       reverseZone = "10.10.in-addr.arpa";
     };
   };
+
+  services.router-upnp = {
+    enable = true;
+    internalIPs = [ lanDevice ] ++ optionalUpnpInterfaces;
+  };
+
+  systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [
+    "+${ensureKeaLeaseState}"
+  ];
 
   services.router-networking = {
     enable = true;


### PR DESCRIPTION
## **User description**
## Summary
- remove the duplicate router-level Kea definition from router networking
- restore the router role guardrail that fails eval on duplicate DHCP pool ranges
- restore the previously safe primary-router behavior for WAN HA hooks and Kea HA
- restore Kea lease-state prep and explicit LAN/UPnP interface handling

## Why
A live router rebuild dropped homelab connectivity because the current merged config evaluated to duplicate Kea pool ranges, producing an overlapping-pool parser failure during activation. The same merged router role had also regressed earlier WAN/HA safety fixes.

## Verification
- [{"end":"10.10.222.254","start":"10.10.200.1"}]
- [{"id":1,"option-data":[{"data":"10.10.10.1","name":"routers"},{"data":"10.10.10.1","name":"domain-name-servers"}],"pools":[{"pool":"10.10.200.1 - 10.10.222.254"}],"reservations":[{"hostname":"ap-nosheen-bedroom","hw-address":"FC:7F:F1:CC:E1:CA","ip-address":"10.10.11.22"},{"hostname":"ap-nosheen-living","hw-address":"A8:5B:F7:C2:0A:42","ip-address":"10.10.11.21"},{"hostname":"ap-ruqayya","hw-address":"54:D7:E3:C7:51:80","ip-address":"10.10.11.20"},{"hostname":"attic-cache","hw-address":"BC:24:11:CE:9D:D6","ip-address":"10.10.11.39"},{"hostname":"authentik-host","hw-address":"BC:24:11:A4:01:6F","ip-address":"10.10.11.70"},{"hostname":"homeserver","hw-address":"BC:24:11:A9:BB:ED","ip-address":"10.10.11.69"},{"hostname":"inference1","hw-address":"BC:24:11:E4:45:B0","ip-address":"10.10.11.131"},{"hostname":"phoenix-hp-m477","hw-address":"10:62:e5:26:58:c2","ip-address":"10.10.11.56"},{"hostname":"vaglio","hw-address":"BC:24:11:A4:02:7A","ip-address":"10.10.11.71"}],"subnet":"10.10.0.0/16"}]
- 

No live router apply was attempted after the outage.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored router HA and DHCP configuration, disabling DHCP HA and WAN link manipulation via Keepalived to improve stability.</li>
<li>Updated Kea DHCP server configuration to include additional interfaces and adjusted the dynamic lease pool range.</li>
<li>Added a systemd service pre-start script to ensure Kea lease file state and permissions.</li>
<li>Added a Nix assertion to prevent duplicate DHCP pool ranges in Kea configuration.</li>
<li>Enabled UPnP service with support for additional routed network interfaces.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Restore safe router rebuilds and keep home network services coming up**

### What Changed
- Removed the duplicate DHCP setup from the router networking layer so the LAN lease range is defined in one place again.
- Added a check that stops the build when the router would end up with overlapping DHCP pool ranges, preventing a broken rebuild from reaching activation.
- Kept the primary router as the only HA participant, disabled WAN failover handling that was interfering with internet recovery, and turned off DHCP HA to avoid the primary getting stuck waiting on the backup.
- Restored DHCP lease-file preparation before startup so the DHCP service can start cleanly after rebuilds.
- Limited extra LAN and UPnP handling to the intended routed subnets on systems that use them.

### Impact
`✅ Fewer broken router rebuilds`
`✅ Clearer DHCP startup failures`
`✅ More reliable internet recovery after router updates`
`✅ Cleaner home network restore after reboot`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled UPnP support on LAN interface for improved device discovery.

* **Changes**
  * DHCP pool range updated to a new non-overlapping interval.
  * High Availability configuration now depends on router role designation.
  * Improved lease state management for DHCP server startup.
  * Removed DHCP/DDNS configuration from networking module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->