### PR TITLE
docs(router): mark queue as exhausted

### DIFF
--- a/docs/router-work-items/README.md
+++ b/docs/router-work-items/README.md
@@ -43,19 +43,30 @@ in parallel on separate worktrees.
 4. For autonomous agent selection, use the rules in
    [`START-HERE.md`](./START-HERE.md).
 
-## Ranking
+## Active Ranking
 
-1. [`25-technitium-dhcp-sync-hardening.md`](./25-technitium-dhcp-sync-hardening.md) - `done`
-2. [`26-router-dashboard-runtime-repair.md`](./26-router-dashboard-runtime-repair.md) - `done`
-3. [`27-router-post-cutover-validation.md`](./27-router-post-cutover-validation.md) - `done`
-4. [`28-dhcp-provider-pluggable-observability.md`](./28-dhcp-provider-pluggable-observability.md) - `done`
-5. [`29-router-caddy-source-drift-repair.md`](./29-router-caddy-source-drift-repair.md) - `done`
-6. [`28-router-dashboard-review-hardening.md`](./28-router-dashboard-review-hardening.md) - `done`
-7. [`33-router-iventoy-runtime-repair.md`](./33-router-iventoy-runtime-repair.md) - `done`
-8. [`34-router-miniupnpd-interface-repair.md`](./34-router-miniupnpd-interface-repair.md) - `done`
+There are currently no `ready` or `in-progress` router work items in this
+folder.
 
-9. [`29-router-cutover-validation-hardening.md`](./29-router-cutover-validation-hardening.md) - `done`
-10. [`27-router-pxe-boot-module-plumbing.md`](./27-router-pxe-boot-module-plumbing.md) - `done`
-11. [`30-kea-tsig-key-provisioning.md`](./30-kea-tsig-key-provisioning.md) - `done`
-12. [`31-router-kea-module.md`](./31-router-kea-module.md) - `done`
-13. [`32-kea-dhcp-cutover.md`](./32-kea-dhcp-cutover.md) - `done`
+If new router work appears:
+
+1. add a new task file with `Status: ready`
+2. insert it into the active ranking here
+3. do not revive `done` items unless a human explicitly reopens them as a new
+   follow-up task
+
+## Recently Completed
+
+- [`25-technitium-dhcp-sync-hardening.md`](./25-technitium-dhcp-sync-hardening.md)
+- [`26-router-dashboard-runtime-repair.md`](./26-router-dashboard-runtime-repair.md)
+- [`27-router-post-cutover-validation.md`](./27-router-post-cutover-validation.md)
+- [`28-dhcp-provider-pluggable-observability.md`](./28-dhcp-provider-pluggable-observability.md)
+- [`29-router-caddy-source-drift-repair.md`](./29-router-caddy-source-drift-repair.md)
+- [`28-router-dashboard-review-hardening.md`](./28-router-dashboard-review-hardening.md)
+- [`33-router-iventoy-runtime-repair.md`](./33-router-iventoy-runtime-repair.md)
+- [`34-router-miniupnpd-interface-repair.md`](./34-router-miniupnpd-interface-repair.md)
+- [`29-router-cutover-validation-hardening.md`](./29-router-cutover-validation-hardening.md)
+- [`27-router-pxe-boot-module-plumbing.md`](./27-router-pxe-boot-module-plumbing.md)
+- [`30-kea-tsig-key-provisioning.md`](./30-kea-tsig-key-provisioning.md)
+- [`31-router-kea-module.md`](./31-router-kea-module.md)
+- [`32-kea-dhcp-cutover.md`](./32-kea-dhcp-cutover.md)

--- a/docs/router-work-items/START-HERE.md
+++ b/docs/router-work-items/START-HERE.md
@@ -23,17 +23,19 @@ fall back to the ordered list in [`README.md`](./README.md).
 
 0. Refresh remote state first if multiple agents may be active (`git fetch origin`).
 1. Start with the ordered list in [`README.md`](./README.md).
-2. Find the first item whose header says `Status: ready`.
-3. Before taking it, check whether the suggested branch/worktree already
+2. If the active ranking is empty, stop and report that the router queue is
+   exhausted rather than reviving a `done` item.
+3. Find the first item whose header says `Status: ready`.
+4. Before taking it, check whether the suggested branch/worktree already
    appears to exist.
-4. If the suggested branch/worktree exists, do not treat that alone as active
+5. If the suggested branch/worktree exists, do not treat that alone as active
    ownership. Check for evidence such as:
    - a recent commit on the branch
    - an open PR tied to the task
    - the task file already marked `in-progress`
-5. If the branch/worktree exists but there is no clear evidence of active
+6. If the branch/worktree exists but there is no clear evidence of active
    ownership, treat it as stale and continue with the task.
-6. Once you take an item:
+7. Once you take an item:
    - create/switch to the suggested branch
    - update that work-item file header from `ready` to `in-progress`
    - commit and push that claim promptly if the queue is shared through git
@@ -74,6 +76,7 @@ second ranked list in this file; `README.md` is the authoritative queue.
 If you want the shortest path:
 
 - pick the next available item from the ordered list
+- if there is no available item, stop and report queue exhaustion
 - use the matching prompt from [`agent-prompts.md`](./agent-prompts.md)
 - update the selected file to `Status: in-progress`
 - implement and validate

--- a/docs/router-work-items/agent-prompts.md
+++ b/docs/router-work-items/agent-prompts.md
@@ -20,6 +20,9 @@ If `beads-rust` is available, prefer
 `beads-rust ready --label router --json` to discover unblocked work;
 otherwise, follow the README-ranked queue.
 
+If the queue has no `ready` item, stop and report exhaustion instead of
+reopening a `done` task from this folder.
+
 Important:
 
 - task-file status is authoritative


### PR DESCRIPTION
## **User description**
## Summary
- replace the stale router active ranking with an explicit exhausted-queue state
- tell agents to stop when no router work item is ready
- keep recently completed router tasks listed as reference only

## Validation
- docs-only change; reviewed rendered diffs locally


___

## **CodeAnt-AI Description**
**Mark the router work queue as exhausted when no ready items remain**

### What Changed
- The router work-item guide now tells agents to stop when there are no ready items instead of reopening completed tasks
- The main queue page now shows that there are currently no active router work items and moves finished tasks into a separate “Recently Completed” list
- The agent prompt now repeats the stop-and-report behavior when the queue is empty

### Impact
`✅ Fewer mistaken restarts of completed router tasks`
`✅ Clearer queue status for autonomous agents`
`✅ Less confusion when no router work is available`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
