### PR TITLE
feat: harden ssh agent identity discovery

### DIFF
--- a/docs/tooling-work-items/36-ssh-agent-identity-loading-hardening.md
+++ b/docs/tooling-work-items/36-ssh-agent-identity-loading-hardening.md
@@ -1,0 +1,66 @@
+# 36 SSH Agent Identity Loading Hardening
+
+Status: `in-progress`
+
+Suggested branch: `feat/tooling-ssh-agent-identity-hardening`
+
+## Goal
+
+Make the SSH-based Git flow more reliable for interactive shells and agent CLIs
+by ensuring the expected SSH identity is discoverable early and consistently,
+instead of relying on ad hoc session state.
+
+## Why
+
+The SSH signing migration itself succeeded:
+
+- Git uses `gpg.format = "ssh"`
+- commit signing verifies successfully
+- GitHub SSH transport works non-interactively
+
+But the current Linux path still leaves room for agent confusion:
+
+- `SSH_AUTH_SOCK` is present
+- `ssh-agent` may be running with **no identities loaded**
+- agent tooling can misread that as “SSH is broken” even when signing still works
+
+This item should harden the agent/identity-loading path rather than redesign the
+signing model again.
+
+## Scope
+
+- Review `modules/home-manager/ssh-agent.nix` and related workstation/user config
+  for Linux hosts using the deepwatrcreatur SSH setup.
+- Decide on a safe default for making the expected key easier to discover, such
+  as:
+  - explicit SSH client defaults for the primary identity
+  - better `IdentityAgent` / `IdentitiesOnly` / `AddKeysToAgent` behavior where
+    appropriate
+  - session-safe key loading guidance or automation that does not regress
+    security expectations
+- Keep the signing path SSH-based; do not revert to GPG.
+- Preserve existing working GitHub SSH transport and commit signing behavior.
+- Prefer a fix that is usable by agent CLIs, not only by interactive humans.
+
+## Non-Goals
+
+- Replacing the SSH signing modules from items 24/25
+- Rotating keys
+- Broad redesign of all SSH host aliases or secret handling
+
+## Validation
+
+- On the target host, `ssh-add -l` or the chosen replacement signal clearly shows
+  the expected identity state after a normal session start.
+- `ssh -T -o BatchMode=yes git@github.com` still succeeds.
+- A signed test commit still verifies with `git log --show-signature`.
+- The result is documented well enough that future agents can distinguish
+  signing-state problems from transport/auth problems.
+
+## Dependencies
+
+- Items 24 and 25 already completed
+
+## Follow-up
+
+- Item 37: SSH/Git doctor command + agent-facing troubleshooting notes

--- a/modules/home-manager/ssh-agent.nix
+++ b/modules/home-manager/ssh-agent.nix
@@ -21,7 +21,7 @@
   programs.ssh = {
     # Prefer the expected GitHub signing/transport key explicitly so agents can
     # discover it from config even before the agent has loaded any identities.
-    matchBlocks = lib.mkIf pkgs.stdenv.isLinux {
+    matchBlocks = {
       "github.com" = {
         identitiesOnly = true;
         identityFile = "~/.ssh/id_ed25519";

--- a/modules/home-manager/ssh-agent.nix
+++ b/modules/home-manager/ssh-agent.nix
@@ -2,19 +2,38 @@
 #
 # Standalone SSH auth agent — no gpg-agent dependency.
 #
-# Linux:  starts ssh-agent as a systemd user service (home-manager).
+# Linux:  starts ssh-agent as a systemd user service (home-manager) and keeps
+#         the socket/key selection explicit for agent CLIs.
 # Darwin: macOS Keychain handles the SSH agent natively; we just set
 #         AddKeysToAgent + UseKeychain in ssh config so keys are loaded
 #         on first use without a passphrase prompt every session.
-{ config, lib, pkgs, ... }:
+{ lib, pkgs, ... }:
 {
-  # Linux: systemd user SSH agent
+  # Linux: systemd user SSH agent.
   services.ssh-agent.enable = lib.mkIf pkgs.stdenv.isLinux true;
 
-  # Darwin: delegate to macOS Keychain agent
-  programs.ssh.extraConfig = lib.mkIf pkgs.stdenv.isDarwin ''
-    Host *
-      AddKeysToAgent yes
-      UseKeychain yes
-  '';
+  # Give shells and agent CLIs a stable socket path instead of relying on
+  # per-session discovery.
+  home.sessionVariables = lib.mkIf pkgs.stdenv.isLinux {
+    SSH_AUTH_SOCK = "$XDG_RUNTIME_DIR/ssh-agent";
+  };
+
+  programs.ssh = {
+    # Prefer the expected GitHub signing/transport key explicitly so agents can
+    # discover it from config even before the agent has loaded any identities.
+    matchBlocks = lib.mkIf pkgs.stdenv.isLinux {
+      "github.com" = {
+        identitiesOnly = true;
+        identityFile = "~/.ssh/id_ed25519";
+        addKeysToAgent = "yes";
+      };
+    };
+
+    # Darwin: delegate to macOS Keychain agent.
+    extraConfig = lib.mkIf pkgs.stdenv.isDarwin ''
+      Host *
+        AddKeysToAgent yes
+        UseKeychain yes
+    '';
+  };
 }


### PR DESCRIPTION
## **User description**
## Summary
- export a stable Linux `SSH_AUTH_SOCK` for Home Manager sessions
- add an explicit `github.com` SSH config block that prefers `~/.ssh/id_ed25519`
- mark tooling work item 36 as `in-progress`

## Validation
- `nix eval --impure` confirmed `home.sessionVariables.SSH_AUTH_SOCK` on `workstation`
- `nix eval --impure` confirmed the rendered SSH config contains `Host github.com`, `IdentitiesOnly yes`, `AddKeysToAgent yes`, and `IdentityFile ~/.ssh/id_ed25519`

## Notes
- This keeps the SSH signing path SSH-based and makes identity discovery clearer for agent CLIs without forcing key loading at login.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a new work item document for SSH agent identity loading hardening.</li>
<li>Configured a stable SSH_AUTH_SOCK path for Linux sessions to improve agent discovery.</li>
<li>Updated SSH configuration to explicitly use the primary identity key for GitHub, enabling better agent discovery and automatic key loading.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Make SSH identity loading more reliable on Linux and document the work item**

### What Changed
- Linux sessions now use a fixed SSH socket path, so shells and SSH tools can find the agent consistently
- GitHub SSH use on Linux now prefers the expected `id_ed25519` key and loads it automatically when needed
- Added a new work item document describing the SSH agent identity-loading problem, its goal, and its validation steps

### Impact
`✅ Fewer SSH agent lookup failures`
`✅ Clearer GitHub SSH key selection`
`✅ Easier follow-up for SSH troubleshooting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
