### PR TITLE
fix(iventoy): preserve vendor binary and provide runtime libs

### DIFF
--- a/modules/nixos/services/iventoy.nix
+++ b/modules/nixos/services/iventoy.nix
@@ -7,6 +7,12 @@
 let
   cfg = config.services.iventoy;
   defaultPackage = pkgs.callPackage ../../../pkgs/iventoy-free.nix { };
+  runtimeLibraryPath = lib.makeLibraryPath [
+    pkgs.glib
+    pkgs.libevent
+    pkgs.wimlib
+    pkgs.hivex
+  ];
 in
 {
   options.services.iventoy = {
@@ -114,7 +120,7 @@ in
           "IVENTOY_AUTO_RUN=1"
           "IVENTOY_NO_DAEMON_MODE=1"
         ];
-        ExecStart = "${pkgs.glibc}/lib/ld-linux-x86-64.so.2 --library-path ${cfg.stateDir}/lib/lin64 ${cfg.stateDir}/lib/iventoy";
+        ExecStart = "${pkgs.glibc}/lib/ld-linux-x86-64.so.2 --library-path ${cfg.stateDir}/lib/lin64:${runtimeLibraryPath} ${cfg.stateDir}/lib/iventoy";
         Restart = "on-failure";
         RestartSec = "10s";
       };

--- a/pkgs/iventoy-free.nix
+++ b/pkgs/iventoy-free.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  patchelf,
 }:
 
 stdenv.mkDerivation rec {
@@ -14,16 +13,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-B/8JyTDHmw5OSCTAm34qYhlJh3e2vih+9NusgG8ofa8=";
   };
 
-  nativeBuildInputs = [ patchelf ];
+  dontFixup = true;
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p "$out/share/iventoy"
     cp -a . "$out/share/iventoy"
-
-    patchelf --set-interpreter "$(cat ${stdenv.cc}/nix-support/dynamic-linker)" \
-      "$out/share/iventoy/lib/iventoy"
 
     runHook postInstall
   '';


### PR DESCRIPTION
## **User description**
## Summary
- stop mutating the upstream iVentoy binary during packaging
- provide the required runtime library path in the iVentoy systemd service
- restore clean router activations by bringing `iventoy.service` back to active state

## Validation
- live `nixos-rebuild test` on `router` no longer fails on `iventoy.service`
- `systemctl is-active iventoy` returned `active`
- `systemctl status iventoy.service` showed `active (running)`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated AGENTS.md to recommend disabling GPG signing for commits to avoid agent-related pinentry issues.</li>
<li>Refactored den/aspects/homeserver-roundtable.nix to conditionally load secrets only if the secret key base file exists.</li>
<li>Removed vm-core and vaglio-legacy-dhcp-transition aspects from den/aspects/default.nix.</li>
<li>Updated various documentation files and work items related to tooling and agent workflows.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Stabilize router services and add SSH/SNMP diagnostics**

### What Changed
- Router failover now keeps standby units from taking over WAN, UPnP, and DHCP duties until the active router is promoted, which avoids unwanted network takeover during rebuilds or restarts
- Router inventory and validation now include the core switch and moved access points to the new LAN range
- SNMP is added for the router, with a secret-backed community string and a validation script for checking router visibility
- iVentoy now keeps its vendor binary intact while loading the runtime libraries it needs, so router activation no longer depends on patching the upstream binary
- Printer setup no longer blocks host rebuilds when the printer is offline or briefly unreachable
- SSH agent defaults now point shells at a stable socket and make the expected GitHub key easier to discover, and a new doctor script/docs help diagnose signing and transport issues

### Impact
`✅ Fewer router cutover failures`
`✅ Cleaner standby-router behavior`
`✅ Clearer SSH signing and GitHub auth troubleshooting`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
