### PR TITLE
fix: inline systemd ssh proxy config on workstation

### DIFF
--- a/hosts/nixos/workstation/profile.nix
+++ b/hosts/nixos/workstation/profile.nix
@@ -112,6 +112,18 @@
   services.speechd.enable = false;
 
   services.openssh.enable = true;
+  programs.ssh = {
+    # OpenSSH 10.2 on this host rejects the default NixOS-generated
+    # `Include /nix/store/.../20-systemd-ssh-proxy.conf` path because it
+    # traverses the writable /nix/store mount. Keep systemd's SSH proxy
+    # features, but inline the shipped snippet into /etc/ssh/ssh_config
+    # instead of using an external include.
+    systemd-ssh-proxy.enable = false;
+    extraConfig = ''
+      # See systemd-ssh-proxy(1)
+      ${builtins.readFile "${config.systemd.package}/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf"}
+    '';
+  };
   services.avahi = {
     enable = lib.mkForce false;
     nssmdns4 = lib.mkForce false;


### PR DESCRIPTION
## **User description**
Summary:
- keep systemd ssh proxy support on workstation without using the failing Nix store Include path
- inline the shipped systemd ssh proxy ssh_config snippet into /etc/ssh/ssh_config
- preserve .host, machine/*, unix/*, and vsock/* support while avoiding the OpenSSH 10.2 permission rejection on this host

Why:
OpenSSH on workstation was rejecting the generated system SSH config because /etc/ssh/ssh_config included a snippet from the Nix store. The include path traverses the writable /nix/store mount, which this host OpenSSH treats as insecure.

Validation:
- workstation eval shows programs.ssh.systemd-ssh-proxy.enable is false
- workstation eval renders the proxy stanza inline at the top of /etc/ssh/ssh_config
- no rebuild was run in this PR branch

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated SSH configuration on NixOS workstation to inline systemd-ssh-proxy settings, bypassing issues with external include paths in OpenSSH 10.2.</li>
<li>Reverted the status of 'SSH Agent Identity Loading Hardening' from 'done' to 'in-progress'.</li>
<li>Updated the tooling work items README to reflect completed tasks, removing the SSH hardening item and adding the Vaglio Proxmox LXC bring-up task.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Keep systemd SSH proxy support working on the workstation**

### What Changed
- The workstation now loads the systemd SSH proxy settings directly in `/etc/ssh/ssh_config` instead of relying on an external include file
- This avoids the OpenSSH 10.2 permission rejection caused by the generated Nix store include path
- SSH proxy support for `.host`, `machine/*`, `unix/*`, and `vsock/*` connections remains available

### Impact
`✅ Fewer SSH config load failures`
`✅ Restored workstation SSH proxy support`
`✅ Fewer connection issues for systemd-managed targets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
