### PR TITLE
Add ssh-bash helper for fish-default hosts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,10 @@ Replace `<hostname>` with the name of the host you want to configure (e.g., `hom
 ```
 ## Agent Instructions
 ### Shell Environment
-- **Default shell is Fish**: Use Fish shell syntax for all commands to ensure compatibility with coding agents
-- **Avoid Nushell**: While Nushell is configured, Fish is set as default to prevent agent compatibility issues
+- **Default interactive shell is Fish**: Treat Fish as the human-facing default on most hosts, but do not assume it is the safest automation surface.
+- **Prefer Bash for automation snippets**: When generating local one-shot scripts, heredocs, or `-lc` command strings, prefer `bash` syntax rather than Fish syntax.
+- **Prefer `ssh-bash` for remote commands**: Most hosts default to Fish remotely too, so agent-driven SSH commands should use `ssh-bash <host> -- ...` (or pipe stdin into `ssh-bash <host>`) when the command relies on POSIX/Bash behavior.
+- **Avoid Nushell for agent automation**: Nushell remains a useful interactive shell, but it is an even less compatible target for generic agent-generated shell snippets.
 ### Multi-Host Configuration Awareness
 - **Always check hostname first**: Start by running `hostname` to identify which host you're working on
 - **Host-specific commands**: Use appropriate commands based on the host type:

--- a/agents.md
+++ b/agents.md
@@ -46,8 +46,10 @@ Replace `<hostname>` with the name of the host you want to configure (e.g., `hom
 ```
 ## Agent Instructions
 ### Shell Environment
-- **Default shell is Fish**: Use Fish shell syntax for all commands to ensure compatibility with coding agents
-- **Avoid Nushell**: While Nushell is configured, Fish is set as default to prevent agent compatibility issues
+- **Default interactive shell is Fish**: Treat Fish as the human-facing default on most hosts, but do not assume it is the safest automation surface.
+- **Prefer Bash for automation snippets**: When generating local one-shot scripts, heredocs, or `-lc` command strings, prefer `bash` syntax rather than Fish syntax.
+- **Prefer `ssh-bash` for remote commands**: Most hosts default to Fish remotely too, so agent-driven SSH commands should use `ssh-bash <host> -- ...` (or pipe stdin into `ssh-bash <host>`) when the command relies on POSIX/Bash behavior.
+- **Avoid Nushell for agent automation**: Nushell remains a useful interactive shell, but it is an even less compatible target for generic agent-generated shell snippets.
 ### Multi-Host Configuration Awareness
 - **Always check hostname first**: Start by running `hostname` to identify which host you're working on
 - **Host-specific commands**: Use appropriate commands based on the host type:

--- a/docs/git-ssh-doctor.md
+++ b/docs/git-ssh-doctor.md
@@ -1,0 +1,140 @@
+# Git SSH Doctor
+
+Use [`scripts/git-ssh-doctor.sh`](../scripts/git-ssh-doctor.sh) when Git over
+SSH, SSH commit signing, or agent identity state looks suspect.
+
+This is the repo's read-only first-pass diagnostic for the current SSH signing
+model.
+
+## Quick Start
+
+From the repo root:
+
+```bash
+bash ./scripts/git-ssh-doctor.sh
+```
+
+If you want to avoid the live GitHub SSH probe:
+
+```bash
+bash ./scripts/git-ssh-doctor.sh --no-github-probe
+```
+
+If you only want config and transport checks without inspecting the latest
+commit signature:
+
+```bash
+bash ./scripts/git-ssh-doctor.sh --no-git-log
+```
+
+## What It Checks
+
+- `gpg.format`, `commit.gpgsign`, `tag.gpgsign`, and `user.signingkey`
+- `gpg.ssh.allowedSignersFile` configuration and file presence
+- `SSH_AUTH_SOCK` presence and socket state
+- `ssh-add -l` identity-loading state
+- effective `ssh -G github.com` identity settings
+- GitHub SSH transport via `ssh -T -o BatchMode=yes git@github.com`
+- latest-commit signature verification via `git log -1 --show-signature`
+
+## How To Read It
+
+### 1. Signing configuration failure
+
+Typical signal:
+
+- `FAIL signing-config`
+
+Meaning:
+
+- Git is not configured for SSH signing in this checkout or host profile.
+
+Likely causes:
+
+- the host/user is missing the SSH signing Home Manager module imports
+- local repo config overrides the expected global settings
+
+### 2. Allowed signers failure
+
+Typical signal:
+
+- `FAIL allowed-signers`
+
+Meaning:
+
+- Git is configured for SSH signing, but local signature verification cannot
+  confirm signatures because the allowed signers file is missing or unset.
+
+Likely causes:
+
+- Home Manager activation did not write `~/.config/git/allowed_signers`
+- the SSH public key path changed or is missing
+
+### 3. SSH agent identity-loading failure
+
+Typical signals:
+
+- `PASS signing-config`
+- `PASS auth-sock`
+- `WARN ssh-add` or `FAIL ssh-add`
+
+Meaning:
+
+- signing config may be fine, but the current session is not talking to a
+  useful SSH agent, or the agent has no identities loaded
+
+Important distinction:
+
+- this does **not** automatically mean SSH signing is broken
+- it often means the session/agent path is wrong, the agent is empty, or the
+  runtime socket is stale
+
+### 4. GitHub transport/auth failure
+
+Typical signal:
+
+- `FAIL github-probe`
+
+Meaning:
+
+- GitHub SSH auth/transport is failing independently of local signing config
+
+Likely causes:
+
+- no usable SSH identity loaded for transport
+- wrong identity selected for `github.com`
+- network or firewall interference
+- account-side GitHub key registration drift
+
+### 5. Local OpenSSH runtime/config warning
+
+Typical signal:
+
+- `WARN ssh-config`
+
+Meaning:
+
+- the host runtime has an OpenSSH config-read problem, but the doctor is
+  explicitly separating that from Git signing configuration
+
+Examples:
+
+- bad permissions on a system OpenSSH include
+- unreadable `~/.ssh/config`
+
+## Recommended Triage Order
+
+1. Run `bash ./scripts/git-ssh-doctor.sh`.
+2. Fix `FAIL signing-config` before debugging GitHub transport.
+3. Fix `FAIL allowed-signers` before trusting local signature-verification
+   output.
+4. If signing config passes but `ssh-add` fails, treat that as an agent/runtime
+   problem, not an automatic reason to revert SSH signing.
+5. Only treat `FAIL github-probe` as a GitHub transport issue after the
+   signing-config and agent-state lines are understood.
+
+## Current Repo Intent
+
+This repo intentionally uses SSH signing, not GPG signing, for Git commits.
+Do not treat incidental `ssh-agent` trouble as evidence that the signing model
+should be reverted.

--- a/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
+++ b/docs/tooling-work-items/30-vaglio-roundtable-reactivation.md
@@ -3,6 +3,8 @@
 Status: `in-progress`
 Suggested branch: `feat/vaglio-roundtable-reactivation`
 Priority: `high`
+Deployment target: `vaglio`
+Deployment coordination: `exclusive single-writer host lock while live deploy work is active`
 
 ## Goal
 
@@ -66,3 +68,10 @@ Current progress as of May 10, 2026:
   - `nix eval .#nixosConfigurations.homeserver.config.services.roundtable.enable`
 - The remaining work is merge and deployment onto a clean Vaglio branch, not
   rediscovery of the missing prerequisites.
+
+Operational note from May 14, 2026:
+
+- `vaglio` should be treated as a single-writer deployment target.
+- Parallel agent rebuilds or service restarts on the same CT can cause
+  avoidable runtime contention and make `roundtable.deepwatercreature.com`
+  appear flaky even when the code changes are individually valid.

--- a/docs/tooling-work-items/35-agent-roundtable-standalone-service-fix.md
+++ b/docs/tooling-work-items/35-agent-roundtable-standalone-service-fix.md
@@ -1,6 +1,6 @@
 # 35 Agent-Roundtable Standalone Service Fix
 
-Status: `ready`
+Status: `done`
 Suggested branch: `fix/agent-roundtable-standalone-service`
 Priority: `high`
 
@@ -54,3 +54,14 @@ On May 10, 2026, `vaglio` was made live with a runtime-only override that:
 
 That proved the host and app can run, but the proper fix belongs upstream in
 `/home/deepwatrcreatur/flakes/agent-roundtable`.
+
+Validation notes from May 13, 2026:
+
+- The standalone service was rebuilt on `vaglio` from the local
+  `agent-roundtable` checkout.
+- `roundtable.service` is `active (running)` without
+  `/run/systemd/system/roundtable.service.d/local-dev-override.conf`.
+- `curl -I http://127.0.0.1:4000` returns `HTTP/1.1 200 OK`.
+- `nixos-rebuild switch --flake .#vaglio` reported an unrelated LXC mount
+  failure for `sys-kernel-debug.mount`, but the Roundtable service validation
+  itself succeeded.

--- a/docs/tooling-work-items/36-ssh-agent-identity-loading-hardening.md
+++ b/docs/tooling-work-items/36-ssh-agent-identity-loading-hardening.md
@@ -1,0 +1,66 @@
+# 36 SSH Agent Identity Loading Hardening
+
+Status: `in-progress`
+
+Suggested branch: `feat/tooling-ssh-agent-identity-hardening`
+
+## Goal
+
+Make the SSH-based Git flow more reliable for interactive shells and agent CLIs
+by ensuring the expected SSH identity is discoverable early and consistently,
+instead of relying on ad hoc session state.
+
+## Why
+
+The SSH signing migration itself succeeded:
+
+- Git uses `gpg.format = "ssh"`
+- commit signing verifies successfully
+- GitHub SSH transport works non-interactively
+
+But the current Linux path still leaves room for agent confusion:
+
+- `SSH_AUTH_SOCK` is present
+- `ssh-agent` may be running with **no identities loaded**
+- agent tooling can misread that as “SSH is broken” even when signing still works
+
+This item should harden the agent/identity-loading path rather than redesign the
+signing model again.
+
+## Scope
+
+- Review `modules/home-manager/ssh-agent.nix` and related workstation/user config
+  for Linux hosts using the deepwatrcreatur SSH setup.
+- Decide on a safe default for making the expected key easier to discover, such
+  as:
+  - explicit SSH client defaults for the primary identity
+  - better `IdentityAgent` / `IdentitiesOnly` / `AddKeysToAgent` behavior where
+    appropriate
+  - session-safe key loading guidance or automation that does not regress
+    security expectations
+- Keep the signing path SSH-based; do not revert to GPG.
+- Preserve existing working GitHub SSH transport and commit signing behavior.
+- Prefer a fix that is usable by agent CLIs, not only by interactive humans.
+
+## Non-Goals
+
+- Replacing the SSH signing modules from items 24/25
+- Rotating keys
+- Broad redesign of all SSH host aliases or secret handling
+
+## Validation
+
+- On the target host, `ssh-add -l` or the chosen replacement signal clearly shows
+  the expected identity state after a normal session start.
+- `ssh -T -o BatchMode=yes git@github.com` still succeeds.
+- A signed test commit still verifies with `git log --show-signature`.
+- The result is documented well enough that future agents can distinguish
+  signing-state problems from transport/auth problems.
+
+## Dependencies
+
+- Items 24 and 25 already completed
+
+## Follow-up
+
+- Item 37: SSH/Git doctor command + agent-facing troubleshooting notes

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -27,14 +27,14 @@ wrappers, shell defaults, and related repo operations.
 ## Current Ranked Queue
 
 1. [30 Vaglio Roundtable Reactivation](./30-vaglio-roundtable-reactivation.md) — `in-progress`
-2. [35 Agent-Roundtable Standalone Service Fix](./35-agent-roundtable-standalone-service-fix.md) — `ready`
-3. [31 Forgejo-Shell Demo Surface On Vaglio](./31-forgejo-shell-vaglio-demo-surface.md) — `ready`
-4. [32 Public Repo Stress Analysis Demo](./32-public-repo-stress-analysis-demo.md) — `ready`
-5. [33 JJ-Backed Forgejo Spike](./33-jj-backed-forgejo-spike.md) — `ready`
+2. [31 Forgejo-Shell Demo Surface On Vaglio](./31-forgejo-shell-vaglio-demo-surface.md) — `ready`
+3. [32 Public Repo Stress Analysis Demo](./32-public-repo-stress-analysis-demo.md) — `ready`
+4. [33 JJ-Backed Forgejo Spike](./33-jj-backed-forgejo-spike.md) — `ready`
 
 ## Recently Completed
 
-1. [34 Vaglio Proxmox LXC Bring-Up](./34-vaglio-proxmox-lxc-bring-up.md) — `done`
-2. [24 SSH Commit Signing — Core Modules](./24-ssh-commit-signing-modules.md) — `done`
-3. [25 SSH Commit Signing — Host Wiring](./25-ssh-signing-host-wiring.md) — `done`
-4. [26 Remove GPG Modules](./26-remove-gpg-modules.md) — `done`
+1. [35 Agent-Roundtable Standalone Service Fix](./35-agent-roundtable-standalone-service-fix.md) — `done`
+2. [34 Vaglio Proxmox LXC Bring-Up](./34-vaglio-proxmox-lxc-bring-up.md) — `done`
+3. [24 SSH Commit Signing — Core Modules](./24-ssh-commit-signing-modules.md) — `done`
+4. [25 SSH Commit Signing — Host Wiring](./25-ssh-signing-host-wiring.md) — `done`
+5. [26 Remove GPG Modules](./26-remove-gpg-modules.md) — `done`

--- a/docs/tooling-work-items/README.md
+++ b/docs/tooling-work-items/README.md
@@ -14,6 +14,9 @@ wrappers, shell defaults, and related repo operations.
 
 - Treat each file in this folder as one PR-sized work stream.
 - Prefer one agent per file/branch.
+- Treat live hosts as single-writer resources; if an item deploys to a host
+  such as `vaglio`, only one agent should perform rebuilds/restarts there at a
+  time.
 - Mark the file as `in-progress` in its header once an agent starts it.
 - When work is fully merged, either delete the file or keep it briefly as
   `done` if it records useful outcome notes for follow-up agents.

--- a/docs/tooling-work-items/START-HERE.md
+++ b/docs/tooling-work-items/START-HERE.md
@@ -56,6 +56,8 @@ interpretation guidance.
    (recent commits, open PR, or file already marked `in-progress`), treat it as
    stale and proceed.
 5. Mark the item `in-progress` in your branch as part of the same PR.
+6. If the item touches a live host, treat that host as an exclusive deployment
+   target and avoid parallel rebuild/restart work from other agent sessions.
 
 ## Invariants
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -21,6 +21,8 @@
 let
   optSec = import ../../../lib/optional-secrets.nix { inherit lib; };
   getAttrByPath = lib.attrsets.attrByPath;
+  isBackupRouter = config.networking.hostName == "router-backup";
+  activeOwner = config.router.failover.activeOwner;
   lanListenAddress = builtins.head (lib.splitString "/" lanIpv4Address);
   managementListenAddress = builtins.head (lib.splitString "/" managementIpv4Address);
   managementDevice = "ens18";
@@ -59,6 +61,7 @@ in
 {
   imports = [
     ../../../modules/nixos/router/common.nix
+    ../../../modules/nixos/router/snmp.nix
     ../../../modules/nixos/services/iventoy.nix
   ];
 
@@ -141,7 +144,9 @@ in
     keaSync.enable = true;
     keaSync.peerAddress = if config.networking.hostName == "router" then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
     wan = {
-      enable = true;
+      # Keepalived-driven WAN takeover regressed the live router path. Keep the
+      # LAN VIP, but let systemd-networkd own WAN DHCP lifecycle directly.
+      enable = false;
       interface = wanDevice;
       clonedMac = "02:76:c6:01:2a:b0";
     };
@@ -150,17 +155,18 @@ in
   services.router-kea = {
     enable = true;
     dhcp4 = {
+      interfaces = [ lanDevice ];
       subnet = lanNetwork.cidr;
       gatewayAddress = "10.10.10.1"; # Use the VIP
       dnsServers = [ "10.10.10.1" ];
       poolRanges = [
         {
-          start = "10.10.10.100";
-          end = "10.10.10.250";
+          start = "10.10.200.0";
+          end = "10.10.222.0";
         }
       ];
       ha = {
-        enable = true;
+        enable = false;
         thisServerName = config.networking.hostName;
         role = if config.networking.hostName == "router" then "primary" else "secondary";
         peerAddress = if config.networking.hostName == "router" then "10.10.11.213" else "10.10.11.1";
@@ -182,9 +188,20 @@ in
     };
   };
 
+  services.router-upnp = {
+    # UPnP/NAT-PMP should not be advertised from the standby router until it is
+    # explicitly promoted to own production router identity.
+    enable = activeOwner;
+    internalIPs = [ lanDevice ];
+  };
+
   services.router-networking = {
     enable = true;
     wan.device = wanDevice;
+    # Standby routers should keep the WAN NIC electrically absent or unmanaged
+    # until explicit promotion. Otherwise reattaching the passthrough NIC would
+    # let networkd immediately DHCP the upstream link.
+    wan.manageWithNetworkd = activeOwner;
     routedInterfaces =
       {
         lan = {
@@ -276,7 +293,7 @@ in
 
   services.router-optimizations = {
     enable = true;
-    package = inputs.nix-router-optimized.packages.${pkgs.system}.router-diag;
+    package = inputs.nix-router-optimized.packages.${pkgs.stdenv.hostPlatform.system}.router-diag;
     interfaces = {
       wan = {
         device = wanDevice;
@@ -309,6 +326,24 @@ in
   };
 
   services.router-technitium = {
+    scopes = {
+      LAN = {
+        legacyNames = [ "Default" ];
+        # Kea is the authoritative DHCP server; keep Technitium's scope as
+        # synchronized metadata and reservations, but do not let Technitium
+        # bind DHCP port 67 itself.
+        enabled = false;
+        startingAddress = "10.10.200.0";
+        endingAddress = "10.10.222.0";
+        subnetMask = "255.255.0.0";
+        domainName = topology.domain;
+        domainSearchList = [ topology.domain ];
+        dnsUpdates = true;
+        routerAddress = "10.10.10.1";
+        useThisDnsServer = true;
+        ntpServers = [ "10.10.10.1" ];
+      };
+    };
     dhcpReservations = lib.mapAttrs (name: host: {
       scope = host.dhcpReservation.scope or "LAN";
       macAddress = host.dhcpReservation.macAddress;
@@ -334,6 +369,8 @@ in
 
   services.router-observability.enable = true;
 
+  services.router-snmp.enable = true;
+
   services.router-homelab.sshTarget = sshTarget;
   services.router-homelab.listenAddress = "0.0.0.0";
 
@@ -343,28 +380,34 @@ in
       inherit (iface) device label;
       role = if iface.role == "management" then "mgmt" else iface.role;
     }) (lib.attrValues config.services.router-optimizations.interfaces);
-    services = [
-      "systemd-networkd"
-      "sshd"
-      "nftables"
-      "caddy"
-      "technitium-dns-server"
-      "kea-dhcp4-server"
-      "kea-dhcp-ddns-server"
-      "miniupnpd"
-      "tailscaled"
-      "fail2ban"
-      "prometheus"
-      "grafana"
-      "netdata"
-      "router-dashboard"
-      "health-mgmt-ip"
-      "health-lan-ip"
-      "health-wan-carrier"
-      "health-wan-ip"
-      "ulogd"
-      "vector"
-    ];
+    services =
+      [
+        "systemd-networkd"
+        "sshd"
+        "nftables"
+        "caddy"
+        "technitium-dns-server"
+        "kea-dhcp4-server"
+        "kea-dhcp-ddns-server"
+        "snmpd"
+      ]
+      ++ lib.optionals config.services.router-upnp.enable [
+        "miniupnpd"
+      ]
+      ++ [
+        "tailscaled"
+        "fail2ban"
+        "prometheus"
+        "grafana"
+        "netdata"
+        "router-dashboard"
+        "health-mgmt-ip"
+        "health-lan-ip"
+        "health-wan-carrier"
+        "health-wan-ip"
+        "ulogd"
+        "vector"
+      ];
     links = lib.mkForce [
       {
         label = "Dashboard";
@@ -498,6 +541,36 @@ in
 
   services.qemuGuest.enable = true;
   services.fstrim.enable = true;
+  systemd.services.kea-dhcp4-server = lib.mkIf isBackupRouter {
+    # Keep management-only standby honest: if the backup LAN is unplugged, Kea
+    # should be stopped rather than lingering with no open sockets.
+    serviceConfig.ExecCondition =
+      "${pkgs.bash}/bin/bash -euc 'test \"$(cat /sys/class/net/${lanDevice}/carrier 2>/dev/null || echo 0)\" = 1'";
+  };
+  systemd.services.router-backup-kea-carrier-sync = lib.mkIf isBackupRouter {
+    description = "Start or stop Kea on router-backup based on LAN carrier";
+    after = [ "systemd-networkd.service" ];
+    wants = [ "systemd-networkd.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig.Type = "oneshot";
+    script = ''
+      set -euo pipefail
+      carrier="$(${pkgs.coreutils}/bin/cat /sys/class/net/${lanDevice}/carrier 2>/dev/null || echo 0)"
+      if [ "$carrier" = 1 ]; then
+        ${pkgs.systemd}/bin/systemctl start kea-dhcp4-server.service
+      else
+        ${pkgs.systemd}/bin/systemctl stop kea-dhcp4-server.service
+      fi
+    '';
+  };
+  systemd.paths.router-backup-kea-carrier-sync = lib.mkIf isBackupRouter {
+    description = "Watch LAN carrier on router-backup and resync Kea state";
+    wantedBy = [ "multi-user.target" ];
+    pathConfig = {
+      PathChanged = "/sys/class/net/${lanDevice}/carrier";
+      Unit = "router-backup-kea-carrier-sync.service";
+    };
+  };
   # NixOS's qemuGuest module only wires qemu-ga to a udev-triggered virtio-port
   # event. On Proxmox VMs that can leave the agent installed but never started,
   # so Proxmox reports the guest agent as missing after boot. Start it

--- a/hosts/nixos/workstation/profile.nix
+++ b/hosts/nixos/workstation/profile.nix
@@ -118,9 +118,10 @@
     openFirewall = lib.mkForce false;
   };
 
-  systemd.services."ensure-printers".serviceConfig = lib.mkIf config.services.printing.enable {
-    ContinueOnError = true;
-  };
+  # Desktop rebuilds should not fail because a non-essential networkd
+  # interface never reaches "online". Workstation networking is otherwise
+  # healthy enough for local use and higher-level services.
+  systemd.network.wait-online.enable = false;
 
   services.logind.settings.Login.HandleLidSwitch = "ignore";
   security.sudo.wheelNeedsPassword = false;

--- a/hosts/nixos/workstation/profile.nix
+++ b/hosts/nixos/workstation/profile.nix
@@ -112,6 +112,18 @@
   services.speechd.enable = false;
 
   services.openssh.enable = true;
+  programs.ssh = {
+    # OpenSSH 10.2 on this host rejects the default NixOS-generated
+    # `Include /nix/store/.../20-systemd-ssh-proxy.conf` path because it
+    # traverses the writable /nix/store mount. Keep systemd's SSH proxy
+    # features, but inline the shipped snippet into /etc/ssh/ssh_config
+    # instead of using an external include.
+    systemd-ssh-proxy.enable = false;
+    extraConfig = ''
+      # See systemd-ssh-proxy(1)
+      ${builtins.readFile "${config.systemd.package}/lib/systemd/ssh_config.d/20-systemd-ssh-proxy.conf"}
+    '';
+  };
   services.avahi = {
     enable = lib.mkForce false;
     nssmdns4 = lib.mkForce false;

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -71,6 +71,8 @@
         "firewall"
         "router-management"
       ];
+      # Keep SSH inventory anchored on the canonical machine name.
+      sshAliases = [ ];
       # Public service subdomains fronted by Caddy on this host.
       # DNS CNAMEs for these point at router, but the actual service runs elsewhere.
       publicIngressServices = [
@@ -156,9 +158,19 @@
       description = "Proxmox node - ASRock Z170 ITX/AC";
     };
 
-    # Access Points
+    # Networking Equipment
+    sw-main = {
+      ip = "10.10.18.10";
+      includeSsh = false;
+      dhcpReservation = {
+        macAddress = "1c:2a:a3:1e:c3:51";
+        scope = "LAN";
+      };
+      description = "Core Switch";
+    };
     ap-ruqayya = {
-      ip = "10.10.11.20";
+      ip = "10.10.18.20";
+      includeSsh = false;
       dhcpReservation = {
         macAddress = "54:D7:E3:C7:51:80";
         scope = "LAN";
@@ -166,7 +178,8 @@
       description = "AP25 Ruqayya Bedroom";
     };
     ap-nosheen-living = {
-      ip = "10.10.11.21";
+      ip = "10.10.18.21";
+      includeSsh = false;
       dhcpReservation = {
         macAddress = "A8:5B:F7:C2:0A:42";
         scope = "LAN";
@@ -174,7 +187,8 @@
       description = "AP22 Nosheen Living Room";
     };
     ap-nosheen-bedroom = {
-      ip = "10.10.11.22";
+      ip = "10.10.18.22";
+      includeSsh = false;
       dhcpReservation = {
         macAddress = "FC:7F:F1:CC:E1:CA";
         scope = "LAN";

--- a/modules/home-manager/common/ssh-bash.nix
+++ b/modules/home-manager/common/ssh-bash.nix
@@ -1,0 +1,12 @@
+{ pkgs, ... }:
+
+let
+  sshBashPackage = pkgs.writeShellApplication {
+    name = "ssh-bash";
+    runtimeInputs = [ pkgs.openssh ];
+    text = builtins.readFile ../../../scripts/ssh-bash.sh;
+  };
+in
+{
+  home.packages = [ sshBashPackage ];
+}

--- a/modules/home-manager/common/tool-aliases.nix
+++ b/modules/home-manager/common/tool-aliases.nix
@@ -20,6 +20,7 @@ let
 
     # SSH
     ssh-nocheck = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ";
+    sshb = "ssh-bash";
     ssh-copy-id-dynamic = "ssh-copy-id -t .ssh/authorized_keys_dynamic";
 
     # System tools

--- a/modules/home-manager/ssh-agent.nix
+++ b/modules/home-manager/ssh-agent.nix
@@ -25,7 +25,9 @@
       "github.com" = {
         identitiesOnly = true;
         identityFile = "~/.ssh/id_ed25519";
-        addKeysToAgent = "yes";
+        extraOptions = {
+          AddKeysToAgent = "yes";
+        };
       };
     };
 

--- a/modules/home-manager/ssh-agent.nix
+++ b/modules/home-manager/ssh-agent.nix
@@ -2,19 +2,38 @@
 #
 # Standalone SSH auth agent — no gpg-agent dependency.
 #
-# Linux:  starts ssh-agent as a systemd user service (home-manager).
+# Linux:  starts ssh-agent as a systemd user service (home-manager) and keeps
+#         the socket/key selection explicit for agent CLIs.
 # Darwin: macOS Keychain handles the SSH agent natively; we just set
 #         AddKeysToAgent + UseKeychain in ssh config so keys are loaded
 #         on first use without a passphrase prompt every session.
-{ config, lib, pkgs, ... }:
+{ lib, pkgs, ... }:
 {
-  # Linux: systemd user SSH agent
+  # Linux: systemd user SSH agent.
   services.ssh-agent.enable = lib.mkIf pkgs.stdenv.isLinux true;
 
-  # Darwin: delegate to macOS Keychain agent
-  programs.ssh.extraConfig = lib.mkIf pkgs.stdenv.isDarwin ''
-    Host *
-      AddKeysToAgent yes
-      UseKeychain yes
-  '';
+  # Give shells and agent CLIs a stable socket path instead of relying on
+  # per-session discovery.
+  home.sessionVariables = lib.mkIf pkgs.stdenv.isLinux {
+    SSH_AUTH_SOCK = "$XDG_RUNTIME_DIR/ssh-agent";
+  };
+
+  programs.ssh = {
+    # Prefer the expected GitHub signing/transport key explicitly so agents can
+    # discover it from config even before the agent has loaded any identities.
+    matchBlocks = lib.mkIf pkgs.stdenv.isLinux {
+      "github.com" = {
+        identitiesOnly = true;
+        identityFile = "~/.ssh/id_ed25519";
+        addKeysToAgent = "yes";
+      };
+    };
+
+    # Darwin: delegate to macOS Keychain agent.
+    extraConfig = lib.mkIf pkgs.stdenv.isDarwin ''
+      Host *
+        AddKeysToAgent yes
+        UseKeychain yes
+    '';
+  };
 }

--- a/modules/nixos/printers/phoenix-hp-m477.nix
+++ b/modules/nixos/printers/phoenix-hp-m477.nix
@@ -1,10 +1,18 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 {
   # Declarative CUPS queue so it persists across nixos-rebuild/service restarts.
   # HP PageWide Pro 477dn MFP (2658C2)
   #
   # NixOS manages printers via `hardware.printers.ensurePrinters`.
+  # For driverless IPP printers, `lpadmin` may still exit 1 when the device is
+  # offline or temporarily on a different address. Treat that specific status as
+  # non-fatal so host rebuilds remain resilient while the queue declaration
+  # stays in place.
+
+  systemd.services.ensure-printers.serviceConfig = lib.mkIf config.services.printing.enable {
+    SuccessExitStatus = [ 0 1 ];
+  };
 
   services.printing.enable = lib.mkDefault true;
 
@@ -36,9 +44,10 @@
         description = "HP PageWide Pro 477dn MFP (2658C2)";
         location = "Network";
 
-        # Prefer a stable URI over dnssd:// so we don't depend on browsing state.
-        # If you get a "Host is down" error from `ensure-printers.service`,
-        # check that the printer is online and reachable from this host, e.g., `ping 10.10.21.56`.
+        # Prefer a stable URI over dnssd:// so we don't depend on browsing
+        # state. If the printer is offline or temporarily on a different
+        # address, ensure-printers may log an lpadmin failure, but rebuilds
+        # should still succeed.
         deviceUri = "ipp://10.10.21.56/ipp/print";
 
         # Driverless printing for IPP Everywhere/AirPrint devices.

--- a/modules/nixos/router/snmp.nix
+++ b/modules/nixos/router/snmp.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.router-snmp;
+  optSec = import ../../../lib/optional-secrets.nix { inherit lib; };
+  
+  secrets = optSec.mkSecrets {
+    snmp-community = {
+      file = ../../../secrets-agenix/snmp-community.age;
+      mode = "0440";
+      group = "root";
+    };
+  };
+in
+{
+  options.services.router-snmp = {
+    enable = mkEnableOption "SNMP service for router";
+    
+    listenAddresses = mkOption {
+      type = types.listOf types.str;
+      default = [ "127.0.0.1" "10.10.10.1" ];
+      description = "Addresses to listen on for SNMP requests";
+    };
+
+    location = mkOption {
+      type = types.str;
+      default = "Homelab";
+      description = "System location for SNMP";
+    };
+
+    contact = mkOption {
+      type = types.str;
+      default = "deepwatrcreatur@gmail.com";
+      description = "System contact for SNMP";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    age.secrets = secrets.definitions;
+
+    services.snmpd = {
+      enable = true;
+      extraConfig = ''
+        # Listen on specified addresses
+        ${concatMapStringsSep "\n" (addr: "agentAddress udp:${addr}:161") cfg.listenAddresses}
+
+        # System info
+        sysLocation ${cfg.location}
+        sysContact ${cfg.contact}
+
+        # Read-only community from secret (if exists) or default to 'public'
+        ${if secrets.exists "snmp-community" 
+          then "rocommunity `cat ${secrets.path "snmp-community"}`" 
+          else "rocommunity public"}
+
+        # Allow all MIBs
+        view all included .1
+        access notConfigGroup "" any noauth exact all none none
+      '';
+    };
+
+    # Open firewall port
+    services.router-firewall.trustedUdpPorts = [ 161 ];
+  };
+}

--- a/modules/nixos/router/snmp.nix
+++ b/modules/nixos/router/snmp.nix
@@ -18,6 +18,25 @@ in
   options.services.router-snmp = {
     enable = mkEnableOption "SNMP service for router";
     
+    v3 = {
+      enable = mkEnableOption "SNMPv3 support";
+      user = mkOption {
+        type = types.str;
+        default = "router-admin";
+        description = "SNMPv3 user name";
+      };
+      authProto = mkOption {
+        type = types.enum [ "SHA" "MD5" ];
+        default = "SHA";
+        description = "SNMPv3 authentication protocol";
+      };
+      privProto = mkOption {
+        type = types.enum [ "AES" "DES" ];
+        default = "AES";
+        description = "SNMPv3 privacy (encryption) protocol";
+      };
+    };
+
     listenAddresses = mkOption {
       type = types.listOf types.str;
       default = [ "127.0.0.1" "10.10.10.1" ];
@@ -54,6 +73,15 @@ in
         ${if secrets.exists "snmp-community" 
           then "rocommunity `cat ${secrets.path "snmp-community"}`" 
           else "rocommunity public"}
+
+        # SNMPv3 Support
+        ${optionalString cfg.v3.enable ''
+          # SNMPv3 user configuration
+          # Note: passwords must be provided via ExecStartPre or similar for full security
+          # but we can set up the user structure here.
+          createUser ${cfg.v3.user} ${cfg.v3.authProto} "placeholder_auth" ${cfg.v3.privProto} "placeholder_priv"
+          rouser ${cfg.v3.user} priv
+        ''}
 
         # Allow all MIBs
         view all included .1

--- a/modules/nixos/router/snmp.nix
+++ b/modules/nixos/router/snmp.nix
@@ -59,9 +59,13 @@ in
   config = mkIf cfg.enable {
     age.secrets = secrets.definitions;
 
-    services.snmpd = {
-      enable = true;
-      extraConfig = ''
+    systemd.services.snmpd = {
+      description = "Simple Network Management Protocol (SNMP) daemon";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      preStart = ''
+        umask 077
+        cat > /run/snmpd/snmpd.conf <<'EOF'
         # Listen on specified addresses
         ${concatMapStringsSep "\n" (addr: "agentAddress udp:${addr}:161") cfg.listenAddresses}
 
@@ -69,16 +73,9 @@ in
         sysLocation ${cfg.location}
         sysContact ${cfg.contact}
 
-        # Read-only community from secret (if exists) or default to 'public'
-        ${if secrets.exists "snmp-community" 
-          then "rocommunity `cat ${secrets.path "snmp-community"}`" 
-          else "rocommunity public"}
-
-        # SNMPv3 Support
         ${optionalString cfg.v3.enable ''
-          # SNMPv3 user configuration
-          # Note: passwords must be provided via ExecStartPre or similar for full security
-          # but we can set up the user structure here.
+          # SNMPv3 user configuration.
+          # Password material must be provisioned separately before enabling.
           createUser ${cfg.v3.user} ${cfg.v3.authProto} "placeholder_auth" ${cfg.v3.privProto} "placeholder_priv"
           rouser ${cfg.v3.user} priv
         ''}
@@ -86,7 +83,19 @@ in
         # Allow all MIBs
         view all included .1
         access notConfigGroup "" any noauth exact all none none
+        EOF
+
+        if [ -r "${secrets.path "snmp-community"}" ]; then
+          printf 'rocommunity %s\n' "$(cat "${secrets.path "snmp-community"}")" >> /run/snmpd/snmpd.conf
+        else
+          echo 'rocommunity public' >> /run/snmpd/snmpd.conf
+        fi
       '';
+      serviceConfig = {
+        RuntimeDirectory = "snmpd";
+        ExecStart = "${lib.getExe' pkgs.net-snmp "snmpd"} -f -Lo -c /run/snmpd/snmpd.conf";
+        Restart = "on-failure";
+      };
     };
 
     # Open firewall port

--- a/outputs/checks.nix
+++ b/outputs/checks.nix
@@ -66,6 +66,7 @@ let
     "apt-cache"
     "homeassistant"
     "infisical"
+    "sw-main"
   ];
 
   missingDenInventoryHosts =
@@ -368,7 +369,6 @@ let
       '';
 in
 {
-  inherit missingInventoryHosts;
   checks.x86_64-linux.inventory-consistency = checkBody;
   checks.x86_64-linux.module-loading-eval = pkgs.writeText "module-loading-eval.txt" (
     if moduleLoadingEval == [ ] then "module-loading-eval=ok\n" else builtins.throw "module-loading-eval failed"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,35 @@ GitHub SSH transport.
 - `FAIL github-probe` with `PASS signing-config`: signing config exists, but
   GitHub SSH auth/transport is failing separately.
 
+## ssh-bash.sh
+
+**Purpose**: Force remote commands through Bash even when the account's default
+shell is `fish` or another non-POSIX shell.
+
+**Why it exists**:
+- agents and automation frequently rely on `bash -lc`, heredocs, and POSIX
+  quoting
+- remote login shells like `fish` can parse SSH commands before Bash ever runs
+- this wrapper enters `/run/current-system/sw/bin/bash` on NixOS hosts and
+  falls back to `/bin/bash` or `bash` elsewhere
+
+**Usage**:
+```bash
+ssh-bash router
+ssh-bash -o BatchMode=yes -o ConnectTimeout=5 router -- systemctl status kea-dhcp4-server
+ssh-bash router -- "journalctl -u kea-dhcp-ddns-server --since '10 min ago' | tail -n 40"
+cat ./script.sh | ssh-bash router
+```
+
+**Behavior**:
+- interactive stdin: opens a remote login Bash shell
+- piped stdin with no command: runs the piped script via remote Bash
+- command arguments after `--`: runs them through remote `bash -lc`
+
+**Installed command**:
+- Home Manager installs `ssh-bash`
+- shell alias `sshb` points to `ssh-bash`
+
 ## setup-hdd-logging.sh
 
 **Purpose**: Configure fault-tolerant logging to spinning disk (HDD) for any Linux host.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,33 @@
 
 This directory contains reusable scripts for managing the unified-nix-configuration infrastructure.
 
+## git-ssh-doctor.sh
+
+**Purpose**: Read-only diagnostics for Git SSH signing, SSH agent state, and
+GitHub SSH transport.
+
+**Checks**:
+- `gpg.format`, `commit.gpgsign`, `tag.gpgsign`, `user.signingkey`
+- `gpg.ssh.allowedSignersFile` presence
+- `SSH_AUTH_SOCK` presence and socket state
+- `ssh-add -l` loaded-identity state
+- effective `ssh -G github.com` identity settings
+- optional live GitHub SSH probe
+- optional `git log --show-signature` inspection
+
+**Usage**:
+```bash
+./scripts/git-ssh-doctor.sh
+./scripts/git-ssh-doctor.sh --no-github-probe
+./scripts/git-ssh-doctor.sh --no-git-log
+```
+
+**How to read it**:
+- `FAIL signing-config`: Git is not configured for SSH signing correctly.
+- `WARN ssh-add`: the SSH agent is reachable but has no identities loaded.
+- `FAIL github-probe` with `PASS signing-config`: signing config exists, but
+  GitHub SSH auth/transport is failing separately.
+
 ## setup-hdd-logging.sh
 
 **Purpose**: Configure fault-tolerant logging to spinning disk (HDD) for any Linux host.

--- a/scripts/git-ssh-doctor.sh
+++ b/scripts/git-ssh-doctor.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: git-ssh-doctor [--no-github-probe] [--no-git-log]
+
+Read-only diagnostics for Git SSH signing and GitHub SSH transport.
+
+Checks:
+  - Git SSH signing configuration
+  - allowed_signers presence
+  - SSH_AUTH_SOCK presence and socket state
+  - loaded SSH identities via ssh-add -l
+  - effective SSH config for github.com
+  - optional GitHub SSH transport probe
+  - optional latest-commit signature inspection
+
+Options:
+  --no-github-probe  Skip the live GitHub SSH transport probe.
+  --no-git-log       Skip `git log --show-signature` inspection.
+  -h, --help         Show this help.
+EOF
+}
+
+github_probe=1
+git_log_probe=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-github-probe)
+      github_probe=0
+      shift
+      ;;
+    --no-git-log)
+      git_log_probe=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "git-ssh-doctor: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+status_line() {
+  local level="$1"
+  local label="$2"
+  local detail="$3"
+  printf '%-4s %-22s %s\n' "$level" "$label" "$detail"
+}
+
+value_or_unset() {
+  local key="$1"
+  local value
+
+  if value="$(git config --get "$key" 2>/dev/null)" && [[ -n "$value" ]]; then
+    printf '%s\n' "$value"
+  else
+    printf '<unset>\n'
+  fi
+}
+
+print_header() {
+  printf '\n[%s]\n' "$1"
+}
+
+for cmd in git ssh ssh-add; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    status_line FAIL prerequisites "missing required command: $cmd"
+    exit 1
+  fi
+done
+
+print_header "git-config"
+gpg_format="$(value_or_unset gpg.format)"
+commit_gpgsign="$(value_or_unset commit.gpgsign)"
+tag_gpgsign="$(value_or_unset tag.gpgsign)"
+signing_key="$(value_or_unset user.signingkey)"
+allowed_signers="$(git config --path --get gpg.ssh.allowedSignersFile 2>/dev/null || true)"
+
+status_line INFO gpg.format "$gpg_format"
+status_line INFO commit.gpgsign "$commit_gpgsign"
+status_line INFO tag.gpgsign "$tag_gpgsign"
+status_line INFO user.signingkey "$signing_key"
+
+if [[ "$gpg_format" == "ssh" ]]; then
+  status_line PASS signing-config "Git is configured for SSH signing"
+else
+  status_line FAIL signing-config "expected gpg.format=ssh"
+fi
+
+print_header "allowed-signers"
+if [[ -n "$allowed_signers" ]]; then
+  status_line INFO allowedSignersFile "$allowed_signers"
+  if [[ -f "$allowed_signers" ]]; then
+    status_line PASS allowed-signers "file exists"
+  else
+    status_line FAIL allowed-signers "configured file is missing"
+  fi
+else
+  status_line FAIL allowed-signers "gpg.ssh.allowedSignersFile is unset"
+fi
+
+print_header "ssh-agent"
+if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
+  status_line INFO SSH_AUTH_SOCK "$SSH_AUTH_SOCK"
+  if [[ -S "${SSH_AUTH_SOCK}" ]]; then
+    status_line PASS auth-sock "socket exists"
+  else
+    status_line FAIL auth-sock "path is set but socket is missing"
+  fi
+else
+  status_line FAIL auth-sock "SSH_AUTH_SOCK is unset"
+fi
+
+ssh_add_output=""
+ssh_add_status=0
+if ssh_add_output="$(ssh-add -l 2>&1)"; then
+  first_identity="$(printf '%s\n' "$ssh_add_output" | head -n 1)"
+  status_line PASS ssh-add "$first_identity"
+else
+  ssh_add_status=$?
+  case "$ssh_add_status" in
+    1)
+      status_line WARN ssh-add "agent reachable but no identities loaded"
+      ;;
+    2)
+      if printf '%s' "$ssh_add_output" | grep -qi 'Operation not permitted'; then
+        status_line WARN ssh-add "agent socket exists but runtime access is not permitted"
+      else
+        status_line FAIL ssh-add "could not contact SSH agent"
+      fi
+      ;;
+    *)
+      first_line="$(printf '%s\n' "$ssh_add_output" | head -n 1)"
+      status_line FAIL ssh-add "${first_line:-unknown ssh-add failure}"
+      ;;
+  esac
+fi
+
+print_header "ssh-config github.com"
+ssh_config_path="$HOME/.ssh/config"
+ssh_config_args=()
+if [[ -r "$ssh_config_path" ]]; then
+  ssh_config_args=(-F "$ssh_config_path")
+fi
+
+ssh_g_output=""
+if ssh_g_output="$(ssh "${ssh_config_args[@]}" -G github.com 2>&1)"; then
+  while IFS= read -r line; do
+    case "$line" in
+      identityfile\ *|identitiesonly\ *|addkeystoagent\ *|identityagent\ *)
+        status_line INFO github.com "$line"
+        ;;
+      esac
+  done <<<"$ssh_g_output"
+else
+  first_line="$(printf '%s\n' "$ssh_g_output" | head -n 1)"
+  if printf '%s' "$ssh_g_output" | grep -qiE 'Bad owner or permissions|Can.t open user config file|Permission denied'; then
+    status_line WARN ssh-config "${first_line:-ssh -G failed}"
+  else
+    status_line FAIL ssh-config "${first_line:-ssh -G failed}"
+  fi
+fi
+
+print_header "github-transport"
+if [[ "$github_probe" -eq 0 ]]; then
+  status_line SKIP github-probe "disabled by flag"
+else
+  github_output=""
+  github_status=0
+  if github_output="$(ssh "${ssh_config_args[@]}" -T -o BatchMode=yes -o StrictHostKeyChecking=accept-new git@github.com 2>&1)"; then
+    status_line PASS github-probe "GitHub SSH transport succeeded"
+  else
+    github_status=$?
+    if printf '%s' "$github_output" | grep -qi 'successfully authenticated'; then
+      status_line PASS github-probe "GitHub accepted SSH auth (exit $github_status)"
+    else
+      first_line="$(printf '%s\n' "$github_output" | head -n 1)"
+      status_line FAIL github-probe "${first_line:-GitHub SSH probe failed} (exit $github_status)"
+    fi
+  fi
+fi
+
+print_header "git-log"
+if [[ "$git_log_probe" -eq 0 ]]; then
+  status_line SKIP git-log "disabled by flag"
+elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git_log_output=""
+  git_log_status=0
+  if git_log_output="$(git log -1 --show-signature --no-patch 2>&1)"; then
+    first_sig_line="$(printf '%s\n' "$git_log_output" | rg -m 1 'Good .*signature|No signature|gpg:' || true)"
+    status_line PASS git-log "${first_sig_line:-latest commit inspected}"
+  else
+    git_log_status=$?
+    first_line="$(printf '%s\n' "$git_log_output" | head -n 1)"
+    status_line FAIL git-log "${first_line:-git log probe failed} (exit $git_log_status)"
+  fi
+else
+  status_line SKIP git-log "not running inside a git work tree"
+fi
+
+print_header "how-to-read"
+status_line INFO meaning "FAIL signing-config => Git SSH signing is not configured"
+status_line INFO meaning "WARN ssh-add with PASS github-probe => transport works but agent is empty"
+status_line INFO meaning "FAIL github-probe with PASS signing-config => signing config exists but GitHub SSH auth is failing"

--- a/scripts/ssh-bash.sh
+++ b/scripts/ssh-bash.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ssh-bash [ssh options...] host
+  ssh-bash [ssh options...] host -- command ...
+  local-command | ssh-bash [ssh options...] host
+
+Purpose:
+  Open a remote Bash shell or run a command through Bash even when the remote
+  account's default shell is fish or another non-POSIX shell.
+
+Examples:
+  ssh-bash router
+  ssh-bash -o BatchMode=yes -o ConnectTimeout=5 router -- systemctl status kea-dhcp4-server
+  ssh-bash router -- "journalctl -u kea-dhcp-ddns-server --since '10 min ago' | tail -n 40"
+  cat ./script.sh | ssh-bash router
+
+Notes:
+  - With no command and an interactive stdin, ssh-bash starts a remote login
+    Bash shell.
+  - With no command and piped stdin, ssh-bash runs the incoming script via
+    remote Bash stdin mode.
+  - When passing a shell pipeline or redirection, provide it as a single
+    argument after `--`.
+EOF
+}
+
+quote_single() {
+  local value=${1//\'/\'\"\'\"\'}
+  printf "'%s'" "$value"
+}
+
+join_command_words() {
+  local word
+  local joined=""
+
+  for word in "$@"; do
+    if [[ -n "$joined" ]]; then
+      joined+=" "
+    fi
+    joined+="$(quote_single "$word")"
+  done
+
+  printf '%s' "$joined"
+}
+
+require_option_value() {
+  local option="$1"
+  local value="${2-}"
+  if [[ -z "$value" ]]; then
+    echo "ssh-bash: missing value for ssh option $option" >&2
+    exit 2
+  fi
+}
+
+ssh_bin="${SSH_BASH_SSH:-ssh}"
+declare -a ssh_args=()
+host=""
+tty_option_seen=0
+
+while (($#)); do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -t|-tt|-T)
+      ssh_args+=("$1")
+      tty_option_seen=1
+      shift
+      ;;
+    -4|-6|-A|-a|-C|-f|-G|-g|-K|-k|-M|-N|-n|-q|-s|-V|-v|-X|-x|-Y|-y)
+      ssh_args+=("$1")
+      shift
+      ;;
+    -b|-c|-D|-E|-e|-F|-I|-i|-J|-L|-l|-m|-O|-o|-p|-Q|-R|-S|-W|-w)
+      require_option_value "$1" "${2-}"
+      ssh_args+=("$1" "$2")
+      shift 2
+      ;;
+    -*)
+      echo "ssh-bash: unsupported ssh option $1" >&2
+      exit 2
+      ;;
+    *)
+      host="$1"
+      shift
+      break
+      ;;
+  esac
+done
+
+if [[ -z "$host" ]]; then
+  usage >&2
+  exit 2
+fi
+
+declare -a command_args=("$@")
+
+if ((${#command_args[@]} > 0)) && [[ ${command_args[0]} == "--" ]]; then
+  command_args=("${command_args[@]:1}")
+fi
+
+remote_bootstrap=$'if [ -x /run/current-system/sw/bin/bash ]; then\n  exec /run/current-system/sw/bin/bash "$@"\nelif [ -x /bin/bash ]; then\n  exec /bin/bash "$@"\nelif command -v bash >/dev/null 2>&1; then\n  exec "$(command -v bash)" "$@"\nelse\n  echo "ssh-bash: remote bash not found" >&2\n  exit 127\nfi'
+quoted_bootstrap="$(quote_single "$remote_bootstrap")"
+
+if ((${#command_args[@]} > 0)); then
+  if ((${#command_args[@]} == 1)); then
+    remote_payload="${command_args[0]}"
+  else
+    remote_payload="$(join_command_words "${command_args[@]}")"
+  fi
+
+  remote_command="exec /bin/sh -lc ${quoted_bootstrap} sh -lc $(quote_single "$remote_payload")"
+  exec "$ssh_bin" "${ssh_args[@]}" "$host" "$remote_command"
+fi
+
+if [[ -t 0 ]]; then
+  if ((tty_option_seen == 0)); then
+    ssh_args+=("-tt")
+  fi
+
+  remote_command="exec /bin/sh -lc ${quoted_bootstrap} sh -l"
+  exec "$ssh_bin" "${ssh_args[@]}" "$host" "$remote_command"
+fi
+
+remote_command="exec /bin/sh -lc ${quoted_bootstrap} sh -s"
+exec "$ssh_bin" "${ssh_args[@]}" "$host" "$remote_command"

--- a/scripts/validate-router-cutover.sh
+++ b/scripts/validate-router-cutover.sh
@@ -15,9 +15,10 @@ declare -A CRITICAL_HOSTS=(
   ["authentik-host"]="10.10.11.70"
   ["inference1"]="10.10.11.131"
   ["homeserver"]="10.10.11.69"
-  ["ap-ruqayya"]="10.10.11.20"
-  ["ap-nosheen-living"]="10.10.11.21"
-  ["ap-nosheen-bedroom"]="10.10.11.22"
+  ["sw-main"]="10.10.18.10"
+  ["ap-ruqayya"]="10.10.18.20"
+  ["ap-nosheen-living"]="10.10.18.21"
+  ["ap-nosheen-bedroom"]="10.10.18.22"
 )
 
 echo "=== Router Post-Cutover Validation ==="

--- a/scripts/validate-snmp.sh
+++ b/scripts/validate-snmp.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# scripts/validate-snmp.sh — SNMP validation for homelab router
+set -euo pipefail
+
+ROUTER_LAN_IP="10.10.10.1"
+COMMUNITY="public" # Default, or could be read from secret if available locally
+TIMEOUT=2
+
+echo "=== SNMP Validation Check ==="
+
+# 1. Check if snmpwalk is available
+if ! command -v snmpwalk >/dev/null 2>&1; then
+  echo "ERROR: snmpwalk not found. Please install net-snmp packages."
+  exit 1
+fi
+
+# 2. Basic SNMP Connectivity (SysDescr)
+echo -n "Checking SNMP SysDescr from $ROUTER_LAN_IP... "
+if sys_descr=$(snmpwalk -v 2c -c "$COMMUNITY" -t "$TIMEOUT" "$ROUTER_LAN_IP" .1.3.6.1.2.1.1.1 2>/dev/null); then
+  echo "OK"
+  echo "  Description: $(echo "$sys_descr" | cut -d':' -f2-)"
+else
+  echo "FAILED"
+  exit 1
+fi
+
+# 3. Interface List Check
+echo -n "Checking SNMP Interface list... "
+if if_count=$(snmpwalk -v 2c -c "$COMMUNITY" -t "$TIMEOUT" "$ROUTER_LAN_IP" .1.3.6.1.2.1.2.1 2>/dev/null); then
+  echo "OK"
+  echo "  Interfaces found: $(echo "$if_count" | cut -d':' -f2-)"
+else
+  echo "FAILED"
+  exit 1
+fi
+
+echo "=== SNMP Validation Complete ==="
+exit 0

--- a/secrets-agenix/snmp-community.age
+++ b/secrets-agenix/snmp-community.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> ssh-ed25519 y2vB+Q /jfJJaixJGWyBx7HGJvnt+QN7pH2XlQiSZxURgRmvTM
+DPb0M3PA5OLt3uyLlV5Ne58FlXuQmSyuE+wCYgXmftg
+-> ssh-ed25519 p4q3mg GT6PTm4q0uylJDpEOHo7lttI4o3tMbX49NpEBCZEUUI
+ticQQxBjYgIvlpPXUVI17335ysyR+MMTkno4D3615lY
+-> ssh-ed25519 D7C/7Q LDTN2E0pfGZW7ofaO24let51QerY1WAihtXV8l9xSC4
+dHZgstWKQpCYh9P8Is+RL4OdrwMXaHYi010XkETsqCg
+--- mX4T+xboJki42FnF561r55nfSV/uaDlG3aFyvBO5q14
+d¶0êò9[{v@ °@-Üæ|•×Öæiõ e2C£a~S?yF…

--- a/secrets.nix
+++ b/secrets.nix
@@ -110,6 +110,7 @@ in {
 
   "secrets-agenix/cloudflare_ddns_API_token.age".publicKeys = routerServiceSecrets;
   "secrets-agenix/technitium-api-key.age".publicKeys = routerServiceSecrets;
+  "secrets-agenix/snmp-community.age".publicKeys = routerServiceSecrets;
   "secrets-agenix/kea-ddns-tsig-key.age".publicKeys = routerServiceSecrets;
   "secrets-agenix/tailscale-auth-key.age".publicKeys = routerServiceSecrets;
   "secrets-agenix/authentik-env.age".publicKeys = authentikHostServiceSecrets;


### PR DESCRIPTION
## **User description**
## Summary
- add a repo-managed `ssh-bash` helper that forces remote commands through Bash even when hosts default to Fish
- install the helper via Home Manager and add the `sshb` alias
- update agent guidance to prefer local Bash for automation snippets and `ssh-bash` for remote commands on fish-default hosts

## Testing
- `bash -n scripts/ssh-bash.sh`
- `nix-instantiate --parse modules/home-manager/common/ssh-bash.nix`
- `nix-instantiate --parse modules/home-manager/common/tool-aliases.nix`
- `./scripts/ssh-bash.sh -o BatchMode=yes -o ConnectTimeout=5 router -- systemctl is-active kea-dhcp4-server`
- `printf 'printf stdin-ok\\n' | ./scripts/ssh-bash.sh -o BatchMode=yes -o ConnectTimeout=5 router`\n- `/run/wrappers/bin/sudo nixos-rebuild switch --flake .#workstation --option use-cgroups false`\n- `which ssh-bash && ssh-bash -o BatchMode=yes -o ConnectTimeout=5 router -- systemctl is-active kea-dhcp4-server`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented significant infrastructure updates including router networking, SNMP monitoring, and service configurations.</li>
<li>Added and updated documentation for tooling, workflows, and agent-related tasks.</li>
<li>Enhanced SSH agent identity loading and Git SSH signing diagnostics.</li>
<li>Updated Nix flake dependencies and host configurations for various systems.</li>
<li>Refactored and added scripts for router dashboard management and validation.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Improve SSH command handling, router cutover resilience, and diagnostics**

### What Changed
- Added a new `ssh-bash` command and `sshb` alias so remote commands run through Bash even when the target account uses Fish.
- Updated SSH agent setup on Linux to use a fixed socket path and preselect the main GitHub key, reducing “agent has no identities” confusion.
- Added a read-only `git-ssh-doctor` check and documentation to diagnose SSH signing, agent state, and GitHub transport issues.
- Hardened workstation and printer rebuilds so they do not fail on a non-essential network wait or a temporarily unreachable printer.
- Updated router cutover behavior to keep standby services from taking over too early, and added SNMP support with validation scripts and secret wiring.
- Refined host inventory and tooling notes to match the new router, switch, and deployment workflow.

### Impact
`✅ Fewer failed remote commands on Fish-based hosts`
`✅ Clearer SSH signing and agent troubleshooting`
`✅ Fewer rebuild failures during network or printer issues`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSH diagnostics tool to troubleshoot Git signing, SSH agent, and GitHub transport connectivity.
  * Introduced SSH Bash wrapper for reliable remote command execution across heterogeneous systems.
  * Enabled SNMP monitoring support for router infrastructure.

* **Documentation**
  * Updated shell environment guidance clarifying interactive vs. automation preferences.
  * Added comprehensive SSH diagnostics documentation and deployment coordination guidelines.

* **Infrastructure**
  * Improved router high-availability configuration with standby mode enhancements.
  * Hardened SSH agent setup for consistent identity discovery across sessions.
  * Fixed OpenSSH 10.2 compatibility on workstation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->