### PR TITLE
Align router reverse zones with Kea DDNS

### DIFF
--- a/docs/discussions/01-should-any-hosts-start-using-hickory-dns.md
+++ b/docs/discussions/01-should-any-hosts-start-using-hickory-dns.md
@@ -1,0 +1,122 @@
+# Discussion 01: Should Any Hosts Start Using Hickory DNS?
+
+**Status:** closed
+**Scope:** `unified-nix-configuration`
+**Date:** 2026-05-23
+
+## Why this discussion exists
+
+The repo currently has no Hickory references, while router DNS is explicitly
+anchored around Technitium:
+
+- `hosts/nixos/router/service-capability.nix` sets
+  `services.router-dns-service.provider = "technitium"`
+- `hosts/nixos/router/role.nix` contains Technitium-specific RFC2136, secrets,
+  dashboard, and monitoring wiring
+- `docs/router-source-of-truth.md` and `docs/kea-technitium-architecture.md`
+  describe a Technitium-centered DNS authority model
+
+Because recent HA work has deliberately avoided casual DNS ownership changes,
+this discussion asked whether Hickory should enter the repo at all, and if so,
+where.
+
+## Participation record
+
+This was a **real four-seat round** with substantive responses from:
+
+- Codex CLI
+- Gemini CLI
+- DeepSeek API
+- OpenCode free-model enrichment seat
+
+An additional Claude CLI follow-up was attempted during archival but did not
+produce usable text in time, so it is not counted in the synthesis below.
+
+## Voice summaries
+
+### Codex CLI
+
+- Strongest on the claim that Hickory's best fit here would be a **bounded
+  declarative experiment**, not a production router DNS replacement.
+- The least-bad candidate was `router-backup`, but only as a management-only or
+  loopback sidecar for zone-generation or resolver experiments.
+- Emphasized that the current repo does **not** have a real Hickory role:
+  no module, no ownership model, no docs, and no HA boundary for DNS service
+  itself.
+- Bottom line: do not start using Hickory now; at most run a clearly-labeled
+  experiment on the spare router if a future declarative DNS path needs study.
+
+### Gemini CLI
+
+- Strongest on the risk that introducing Hickory now would **fragment an active
+  migration**: the repo is already converging on Kea + Technitium rather than
+  redesigning DNS authority.
+- Framed Hickory's best argument as memory safety and declarative purity, but
+  still judged that benefit too small relative to current migration churn.
+- Nominated lightweight non-router environments as the only plausible testing
+  surface, but not as something the repo currently needs.
+- Bottom line: no host should adopt Hickory now.
+
+### DeepSeek API
+
+- Strongest on the argument that Hickory could make sense on a **non-router,
+  non-production resolver host** if the goal were a lightweight Rust recursive
+  resolver with DNSSEC benefits.
+- But it judged the current repo unprepared for that because DNS is operationally
+  unified around the router's Technitium authority model.
+- Emphasized that the repo currently lacks both an explicit non-router DNS lab
+  host and a compelling Hickory-driven use case.
+- Bottom line: no host currently justifies the split or configuration overhead.
+
+### OpenCode free-model enrichment seat
+
+- Strongest on the argument that Hickory would slightly improve the repo only if
+  the goal were broader tooling diversity or safe workstation-scale experiments.
+- Picked `workstation` as the least risky candidate for isolated local DNS
+  experimentation, but still judged the payoff too small.
+- Emphasized that production router DNS is too deeply coupled to Technitium's
+  HA-sensitive features to justify a new stack right now.
+- Bottom line: slight theoretical upside, not enough to justify the churn.
+
+## Convergence
+
+The round converged on four points.
+
+1. **Do not introduce Hickory into the production router DNS path now.**
+   All seats agreed the current router DNS model is too Technitium-specific and
+   too entangled with Kea DDNS, RFC2136, secrets, dashboarding, and HA caution
+   to justify a second DNS authority story.
+
+2. **If Hickory appears at all, it should start as an experiment, not a
+   supported role.**
+   The only plausible candidates mentioned were non-production surfaces like
+   `workstation`, a lightweight lab host, or a management-only `router-backup`
+   sidecar.
+
+3. **The repo lacks the plumbing for real Hickory adoption.**
+   There is no existing Hickory module, no ownership boundary for it, no docs,
+   and no migration plan.
+
+4. **The expected benefit is small relative to the churn.**
+   Hickory's advantages were mostly framed as declarative purity, memory safety,
+   or lighter-weight resolver behavior. None of the seats judged that strong
+   enough to outweigh the operational cost today.
+
+## Maintained line
+
+The maintained line after this round is:
+
+- no hosts should start **using Hickory DNS as a supported role now**
+- the router DNS stack should stay centered on the current Kea + Technitium
+  model while HA and ownership boundaries remain active concerns
+- if Hickory ever enters this repo, it should do so as a clearly isolated
+  experiment rather than an ambient alternative
+
+## Bottom line
+
+There is **not** currently a strong enough case to start using Hickory DNS on
+any host in `unified-nix-configuration`.
+
+The strongest possible next step, if interest remains, would be a narrowly
+labeled experiment on a non-production host or management-only sidecar rather
+than a router or fleet-wide adoption.

--- a/docs/discussions/02-is-there-a-strong-case-for-btrfs-to-bcachefs-conversion.md
+++ b/docs/discussions/02-is-there-a-strong-case-for-btrfs-to-bcachefs-conversion.md
@@ -1,0 +1,128 @@
+# Discussion 02: Is There a Strong Case to Convert Any Host from Btrfs to bcachefs?
+
+**Status:** closed
+**Scope:** `unified-nix-configuration`
+**Date:** 2026-05-23
+
+## Why this discussion exists
+
+Several NixOS hosts in this repo are explicitly standardized on Btrfs today:
+
+- `hosts/nixos/router/disko.nix`
+- `hosts/nixos/router-backup/disko.nix`
+- `hosts/nixos/inference-vm/modules/disko.nix`
+- `hosts/nixos/workstation/hardware-configuration.nix`
+- `hosts/nixos/phoenix/hardware-configuration.nix`
+
+The repo also has explicit Btrfs-era operational assumptions:
+
+- `modules/nixos/snapper.nix` hard-codes `FSTYPE = "btrfs"` for `/` and `/home`
+- bootstrap and recovery docs assume Btrfs tools, subvolumes, and snapshot
+  workflows
+- there are currently no `bcachefs` references in the repo
+
+This discussion asked whether any host has a strong enough reason to break from
+that standardized model.
+
+## Participation record
+
+This was a **real four-seat round** with substantive responses from:
+
+- Codex CLI
+- Gemini CLI
+- DeepSeek API
+- OpenCode free-model enrichment seat
+
+An additional Claude CLI follow-up was attempted during archival but did not
+produce usable text in time, so it is not counted in the synthesis below.
+
+## Voice summaries
+
+### Codex CLI
+
+- Strongest on the distinction between a **lab experiment** and a strong
+  migration case.
+- Identified `inference-vm` as the least-bad experimental candidate because it
+  is simpler and less infrastructure-critical than the router or workstation.
+- Emphasized that the repo is operationally standardized on Btrfs far beyond
+  one disk layout: Snapper, bootstrap tooling, recovery docs, and operator
+  muscle memory all depend on it.
+- Bottom line: no strong case for any current host; at most, a deliberately
+  experimental inference VM pilot.
+
+### Gemini CLI
+
+- Strongest on the argument that bcachefs's theoretical upside would be native
+  tiering and encryption for inference-style storage workloads.
+- Still judged the migration unjustified because the repo is effectively a
+  Btrfs monoculture with shared Snapper assumptions and consistent subvolume
+  layouts.
+- Highlighted that the repo values recovery invariants and operational
+  consistency more than filesystem novelty.
+- Bottom line: no strong case for conversion now.
+
+### DeepSeek API
+
+- Strongest on the operational downside:
+  Snapper support, documented rollback paths, and simple Btrfs subvolume
+  recovery are already in place and would all be disrupted.
+- Also chose `inference-vm` as the only plausible low-risk experimentation
+  target.
+- Judged that router/workstation roles gain nothing compelling enough from
+  bcachefs to justify the operational churn.
+- Bottom line: no strong case exists.
+
+### OpenCode free-model enrichment seat
+
+- Strongest on the narrow performance case for `inference-vm` if measurable I/O
+  bottlenecks ever appear.
+- But it converged that speculative gains do not outweigh the current repo's
+  Btrfs-specific toolchain, docs, and recovery familiarity.
+- Bottom line: no current host shows sufficient need to justify the move.
+
+## Convergence
+
+The round converged on five points.
+
+1. **There is no strong present-day case for conversion.**
+   No seat argued that any current host should move from Btrfs to bcachefs now
+   as an operational recommendation.
+
+2. **`inference-vm` is the only plausible experiment surface.**
+   All substantive seats that named a candidate picked `inference-vm` or its
+   family because it is more lab-shaped and easier to rebuild than router or
+   workstation roles.
+
+3. **The repo is standardized on Btrfs operationally, not just syntactically.**
+   The cost is not only changing one `disko` stanza. It is also changing
+   Snapper, bootstrap tooling, recovery instructions, and day-2 operational
+   familiarity.
+
+4. **Router and workstation roles are the wrong place for filesystem
+   experimentation.**
+   These hosts benefit more from boring recoverability than from speculative
+   filesystem upside.
+
+5. **Any future bcachefs move would need a concrete workload-driven trigger.**
+   A real case would likely require measurable inference-storage pain or a
+   narrow lab objective, not general enthusiasm.
+
+## Maintained line
+
+The maintained line after this round is:
+
+- keep current hosts on the repo's established Btrfs + Snapper model
+- do not introduce bcachefs into router, router-backup, workstation, or phoenix
+  as a proactive migration
+- if bcachefs is explored at all, treat it as a bounded `inference-vm`
+  experiment with explicit acceptance that it diverges from the repo's normal
+  recovery and documentation model
+
+## Bottom line
+
+There is **not** a strong case to convert any current NixOS host in
+`unified-nix-configuration` from Btrfs to bcachefs.
+
+The only defensible exception would be a deliberate experiment on an
+`inference-vm` host if a concrete storage-performance question appears and the
+team is willing to absorb one-off filesystem divergence for that lab purpose.

--- a/docs/discussions/README.md
+++ b/docs/discussions/README.md
@@ -1,0 +1,7 @@
+# Embedded Discussion Rounds
+
+This folder stores repo-local discussion notes that were produced from real
+multi-seat agent rounds and are specific to `unified-nix-configuration`.
+
+- [01: Should any hosts start using Hickory DNS?](./01-should-any-hosts-start-using-hickory-dns.md)
+- [02: Is there a strong case to convert any host from Btrfs to bcachefs?](./02-is-there-a-strong-case-for-btrfs-to-bcachefs-conversion.md)

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -103,9 +103,10 @@ in
   services.router.dnsZones =
     let
       dnsConfig = import ./dns-zone.nix;
+      # Keep declarative reverse-zone generation aligned with Kea DDNS, which
+      # currently publishes into the LAN-wide /16 reverse zone.
       defaultNetworks = [
-        "10.10.10.0/24"
-        "10.10.11.0/24"
+        topology.networks.lan.cidr
       ];
       mkZone = zone: {
         nameserverIP = zone.nameserverIP or routerHost.ip;


### PR DESCRIPTION
## **User description**
## Summary
- align router declarative reverse-zone defaults with the LAN CIDR instead of hard-coded /24 child zones
- keep Technitium reverse-zone generation consistent with the live Kea DDNS reverse zone (`10.10.in-addr.arpa`)
- prevent overlapping child reverse zones from blocking reverse DDNS updates for `10.10.10.x` leases

## Testing
- `nix-instantiate --parse hosts/nixos/router/configuration.nix`
- `nix build .#nixosConfigurations.router.config.system.build.toplevel --no-link`
- copied the built system to `root@router` and switched it live
- verified stale Technitium child reverse zones were removed from the live router
- verified only `10.10.in-addr.arpa` remains as the relevant homelab reverse zone

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Removed the 'Git SSH Signing Doctor' work item from documentation.</li>
<li>Updated router configuration to use topology-defined LAN CIDR instead of hardcoded subnets.</li>
<li>Refactored iVentoy service to use patchelf for binary patching instead of manual library path injection.</li>
<li>Cleaned up documentation regarding parallel branch work and deployment targets.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Keep router reverse DNS aligned with live DHCP updates**

### What Changed
- Router reverse DNS now uses the full LAN network range instead of two smaller child zones, which prevents reverse DNS updates from being blocked for LAN addresses
- Reverse records for devices on `10.10.10.x` now stay within the same zone used by Kea DDNS
- Added repo notes documenting two closed discussion rounds and their conclusions

### Impact
`✅ Fewer reverse DNS update failures`
`✅ Correct reverse records for LAN devices`
`✅ Less DNS zone overlap`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added discussion records documenting architectural decisions on DNS infrastructure approaches and filesystem storage system evaluation for network hosts.

* **Chores**
  * Refined router DNS configuration to improve reverse-zone generation alignment with network topology definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->