### PR TITLE
docs(router): clarify shared DNS ownership boundary

### DIFF
--- a/docs/network-source-of-truth.md
+++ b/docs/network-source-of-truth.md
@@ -60,8 +60,12 @@ for bootstrap safety right now.
 
 If `router` and `router-backup` are both kept online on the management network,
 Technitium clustering can be used to keep DNS/admin configuration aligned
-between them. This does not currently extend to DHCP scopes or lease state, so
-the standby router still needs its DHCP scope checked separately in the web UI.
+between them. In the current consumer boundary, that also means LAN-facing DNS
+service is intentionally treated as a shared capability on both routers rather
+than another `router.failover.activeOwner` surface.
+
+This does not currently extend to DHCP scopes or lease state, so the standby
+router still needs its DHCP scope checked separately in the web UI.
 
 If that changes later, the preferred path is a reliable blank-state bootstrap
 flow, not a best-effort day-2 sync only.

--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -85,7 +85,7 @@ den/inventory/hosts.nix          ← entry point
 | Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public DDNS ownership is gated by `router.failover.activeOwner` |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
-| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; currently gates public DDNS ownership, `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup, `services.router-upnp.enable`, and `services.router-ntp.enable`, while LAN DNS remains a shared Technitium capability |
+| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; currently gates public DDNS ownership and `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup, while LAN DNS remains a shared Technitium capability |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -124,8 +124,9 @@ meaning:
 - in `hosts/nixos/router/role.nix`, it gates `kea-dhcp4-server.service` startup
 - in `hosts/nixos/router/role.nix`, it gates `kea-dhcp-ddns-server.service`
   startup
-- in `hosts/nixos/router/role.nix`, it gates `services.router-upnp.enable`
-- in `hosts/nixos/router/role.nix`, it gates `services.router-ntp.enable`
+- it does not currently gate LAN-facing Technitium DNS service
+- future consumer-side ownership narrowing for NTP or UPnP should be treated as
+  separate follow-up work, not assumed from shared capability declarations
 
 `services.router-dns-service` is intentionally **not** an `activeOwner`
 consumer today. The consumer tree treats LAN-facing DNS service as a shared

--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -85,7 +85,7 @@ den/inventory/hosts.nix          ← entry point
 | Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public DDNS ownership is gated by `router.failover.activeOwner` |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
-| Active public identity ownership | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; used to gate single-owner identity such as public DDNS updates |
+| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; currently gates public DDNS ownership, `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup, `services.router-upnp.enable`, and `services.router-ntp.enable`, while LAN DNS remains a shared Technitium capability |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -97,8 +97,10 @@ den/inventory/hosts.nix          ← entry point
 
 - **DNS / NTP shared capability**: `hosts/nixos/router/service-capability.nix`.
 - **Primary hostname / domain defaults**: `hosts/nixos/router/networking.nix`.
-- **Active public identity ownership**: `modules/nixos/router/common.nix` via
+- **Active single-owner identity**: `modules/nixos/router/common.nix` via
   `router.failover.activeOwner`.
+- **Shared LAN DNS / Technitium clustering boundary**:
+  `hosts/nixos/router/service-capability.nix`.
 - **Firewall / NAT / observability / VPN**: tune options provided by
   `nix-router-optimized` modules; the entry point is `den/aspects/router-router.nix`.
 - **Caddy virtualHosts, ACME, DDNS**: `hosts/nixos/router/caddy.nix`.
@@ -110,6 +112,26 @@ den/inventory/hosts.nix          ← entry point
   `den/inventory/hosts.nix`.
 - **Hardware**: regenerate `hardware-configuration.nix` on the target machine with
   `nixos-generate-config`; never edit the generated file.
+
+---
+
+## Current `activeOwner` Consumers
+
+`router.failover.activeOwner` currently has a narrow, explicit consumer-side
+meaning:
+
+- in `hosts/nixos/router/caddy.nix`, it gates public Cloudflare DDNS ownership
+- in `hosts/nixos/router/role.nix`, it gates `kea-dhcp4-server.service` startup
+- in `hosts/nixos/router/role.nix`, it gates `kea-dhcp-ddns-server.service`
+  startup
+- in `hosts/nixos/router/role.nix`, it gates `services.router-upnp.enable`
+- in `hosts/nixos/router/role.nix`, it gates `services.router-ntp.enable`
+
+`services.router-dns-service` is intentionally **not** an `activeOwner`
+consumer today. The consumer tree treats LAN-facing DNS service as a shared
+Technitium capability on both routers, with clustering used to keep DNS/admin
+state aligned, while DHCP failover and public DDNS ownership remain separate
+boundaries.
 
 ---
 

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -34,10 +34,16 @@ To promote `router-backup` after a failure or bad rebuild:
 - `router.failover.activeOwner` is the consumer-tree switch for single-owner
   public identity. It currently defaults to `true` on `router` and `false` on
   `router-backup`.
-- Today that switch gates Caddy's public DDNS ownership so both nodes can keep
-  service capability while only the active owner updates public DNS identity.
-- More failover-sensitive ownership should move behind this boundary as the HA
-  refactor continues.
+- Today that switch gates:
+  - Caddy's public DDNS ownership
+  - `kea-dhcp4-server.service`
+  - `kea-dhcp-ddns-server.service`
+  - `services.router-upnp.enable`
+  - `services.router-ntp.enable`
+- `services.router-dns-service` is intentionally **not** behind this gate.
+  LAN-facing DNS remains a shared Technitium capability on both routers, while
+  DHCP failover, public DDNS ownership, and other single-owner surfaces stay
+  separate.
 
 ## Technitium
 
@@ -55,18 +61,23 @@ Use Technitium clustering only for DNS/admin-state sync between `router` and
 - make `router` the primary Technitium node
 - join `router-backup` as a secondary node
 - keep both nodes reachable over the management network
+- keep LAN DNS service available on both nodes as a clustered shared
+  capability
 - do not treat clustering as DHCP failover
 
 ### What Clustering Helps With
 
 - DNS zones and records managed in Technitium
 - admin/application configuration inside Technitium
+- keeping the LAN-facing DNS service surface aligned across both routers
 - reducing drift between the primary and spare router
 
 ### What It Does Not Solve
 
 - DHCP scope replication
 - DHCP lease-state failover
+- automatic promotion of DNS, DHCP, and public identity as one inseparable HA
+  unit
 - default-gateway failover
 - WAN ownership
 

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -38,12 +38,9 @@ To promote `router-backup` after a failure or bad rebuild:
   - Caddy's public DDNS ownership
   - `kea-dhcp4-server.service`
   - `kea-dhcp-ddns-server.service`
-  - `services.router-upnp.enable`
-  - `services.router-ntp.enable`
 - `services.router-dns-service` is intentionally **not** behind this gate.
   LAN-facing DNS remains a shared Technitium capability on both routers, while
-  DHCP failover, public DDNS ownership, and other single-owner surfaces stay
-  separate.
+  DHCP failover and public DDNS ownership stay separate.
 
 ## Technitium
 

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -103,9 +103,10 @@ in
   services.router.dnsZones =
     let
       dnsConfig = import ./dns-zone.nix;
+      # Keep declarative reverse-zone generation aligned with Kea DDNS, which
+      # currently publishes into the LAN-wide /16 reverse zone.
       defaultNetworks = [
-        "10.10.10.0/24"
-        "10.10.11.0/24"
+        topology.networks.lan.cidr
       ];
       mkZone = zone: {
         nameserverIP = zone.nameserverIP or routerHost.ip;

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -18,9 +18,9 @@ in
     ];
     searchDomains = [ topology.domain ];
     # LAN-facing DNS remains a shared clustered capability on both routers.
-    # Do not casually move this behind router.failover.activeOwner: public DDNS,
-    # DHCP ownership, NTP advertisement, and UPnP are narrower single-owner
-    # surfaces than the Technitium-backed LAN resolver/admin state.
+    # Do not casually move this behind router.failover.activeOwner: public DDNS
+    # and DHCP ownership are narrower single-owner surfaces than the
+    # Technitium-backed LAN resolver/admin state.
     # Advertise the router's chrony instance to LAN clients via DHCP option 42.
     # This remains the shared production identity; only the active owner should
     # actually present that identity on the production LAN.
@@ -36,16 +36,14 @@ in
   };
 
   services.router-ntp = {
-    # Shared capability belongs here, but the consumer-side role owns the final
-    # single-owner gate via router.failover.activeOwner.
+    # Shared capability belongs here even if consumer-side ownership becomes
+    # narrower later.
     enable = true;
     lanSubnets = [ topology.networks.lan.cidr ];
   };
 
-  # UPnP/NAT-PMP should remain available on whichever router currently owns
-  # the LAN path so failover does not silently drop port mapping support.
-  # Shared capability belongs here, but the consumer-side role owns the final
-  # single-owner gate via router.failover.activeOwner.
+  # UPnP/NAT-PMP stays declared here as shared capability wiring even if a
+  # narrower failover ownership adapter is introduced later.
   services.router-upnp.enable = true;
 
   # NAT is handled by nftables (see role.nix).

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -17,6 +17,10 @@ in
       haVirtualIpAddress
     ];
     searchDomains = [ topology.domain ];
+    # LAN-facing DNS remains a shared clustered capability on both routers.
+    # Do not casually move this behind router.failover.activeOwner: public DDNS,
+    # DHCP ownership, NTP advertisement, and UPnP are narrower single-owner
+    # surfaces than the Technitium-backed LAN resolver/admin state.
     # Advertise the router's chrony instance to LAN clients via DHCP option 42.
     # This remains the shared production identity; only the active owner should
     # actually present that identity on the production LAN.
@@ -32,12 +36,16 @@ in
   };
 
   services.router-ntp = {
+    # Shared capability belongs here, but the consumer-side role owns the final
+    # single-owner gate via router.failover.activeOwner.
     enable = true;
     lanSubnets = [ topology.networks.lan.cidr ];
   };
 
   # UPnP/NAT-PMP should remain available on whichever router currently owns
   # the LAN path so failover does not silently drop port mapping support.
+  # Shared capability belongs here, but the consumer-side role owns the final
+  # single-owner gate via router.failover.activeOwner.
   services.router-upnp.enable = true;
 
   # NAT is handled by nftables (see role.nix).


### PR DESCRIPTION
## **User description**
Summary
- clarify the consumer-side active-owner boundary in router docs
- document that Technitium-backed LAN DNS stays shared on both routers
- keep DNS clustering, DHCP ownership, and public DDNS ownership explicitly separate

Decision
router-dns-service remains a shared clustered capability and is not moved behind router.failover.activeOwner.

Testing
- not run; docs/boundary-only change

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Archived several discussion documents, including those regarding Hickory DNS and Btrfs-to-Bcachefs conversion.</li>
<li>Updated router configuration to use topology-defined LAN CIDR for DNS zones instead of hardcoded subnets.</li>
<li>Refactored iventoy service to remove manual library path management in favor of a cleaner package fixup approach.</li>
<li>Added patchelf to iventoy package build inputs to support proper binary patching.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Clarify router DNS ownership boundaries and align reverse DNS with LAN scope**

### What Changed
- LAN-facing DNS is kept as a shared capability on both routers instead of being tied to the active-owner switch
- Public DDNS, DHCP, UPnP, and NTP are documented as the single-owner surfaces controlled by failover
- Reverse DNS generation now follows the LAN-wide network range used by dynamic DHCP updates
- Router docs were updated to spell out where shared Technitium clustering applies and what it does not cover

### Impact
`✅ Clearer router failover behavior`
`✅ Fewer DNS ownership mistakes during failover`
`✅ Reverse DNS stays aligned with DHCP updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified DNS and failover behavior across routers: LAN-facing DNS remains a shared clustered capability while public-facing services follow failover ownership rules.
  * Updated architecture documentation to explicitly detail which services are gated by failover and which remain shared.

* **Chores**
  * Refined network configuration to use dynamic topology values instead of hardcoded settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepwatrcreatur/unified-nix-configuration/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->