### PR TITLE
fix(router): align active-owner service boundaries

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -85,7 +85,7 @@ den/inventory/hosts.nix          ← entry point
 | Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public DDNS ownership is gated by `router.failover.activeOwner` |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
-| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; currently gates public DDNS ownership and `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup, while LAN DNS remains a shared Technitium capability |
+| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; currently gates public DDNS ownership, `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup, `services.router-upnp.enable`, and `services.router-ntp.enable` in the consumer tree |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -97,10 +97,8 @@ den/inventory/hosts.nix          ← entry point
 
 - **DNS / NTP shared capability**: `hosts/nixos/router/service-capability.nix`.
 - **Primary hostname / domain defaults**: `hosts/nixos/router/networking.nix`.
-- **Active single-owner identity**: `modules/nixos/router/common.nix` via
+- **Active single-owner identity / DHCP ownership**: `modules/nixos/router/common.nix` via
   `router.failover.activeOwner`.
-- **Shared LAN DNS / Technitium clustering boundary**:
-  `hosts/nixos/router/service-capability.nix`.
 - **Firewall / NAT / observability / VPN**: tune options provided by
   `nix-router-optimized` modules; the entry point is `den/aspects/router-router.nix`.
 - **Caddy virtualHosts, ACME, DDNS**: `hosts/nixos/router/caddy.nix`.
@@ -110,10 +108,6 @@ den/inventory/hosts.nix          ← entry point
 - **New shared router behaviour**: add a den aspect under `den/aspects/` and reference
   it in both `router` and `router-backup` `aspectsList` entries in
   `den/inventory/hosts.nix`.
-- **Hardware**: regenerate `hardware-configuration.nix` on the target machine with
-  `nixos-generate-config`; never edit the generated file.
-
----
 
 ## Current `activeOwner` Consumers
 
@@ -124,15 +118,17 @@ meaning:
 - in `hosts/nixos/router/role.nix`, it gates `kea-dhcp4-server.service` startup
 - in `hosts/nixos/router/role.nix`, it gates `kea-dhcp-ddns-server.service`
   startup
-- it does not currently gate LAN-facing Technitium DNS service
-- future consumer-side ownership narrowing for NTP or UPnP should be treated as
-  separate follow-up work, not assumed from shared capability declarations
+- in `hosts/nixos/router/role.nix`, it gates `services.router-upnp.enable`
+- in `hosts/nixos/router/role.nix`, it gates `services.router-ntp.enable`
 
-`services.router-dns-service` is intentionally **not** an `activeOwner`
-consumer today. The consumer tree treats LAN-facing DNS service as a shared
-Technitium capability on both routers, with clustering used to keep DNS/admin
-state aligned, while DHCP failover and public DDNS ownership remain separate
-boundaries.
+That is the current supported single-owner boundary in this tree. Other
+router-facing services may still be present on both nodes, but they should not
+be described as `activeOwner`-governed unless they are wired explicitly.
+
+The next consumer-side HA follow-up is tracked as
+`nix-router-optimized/docs/work-items/75-consumer-active-owner-service-boundary-and-expansion.md`.
+- **Hardware**: regenerate `hardware-configuration.nix` on the target machine with
+  `nixos-generate-config`; never edit the generated file.
 
 ---
 

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -38,9 +38,14 @@ To promote `router-backup` after a failure or bad rebuild:
   - Caddy's public DDNS ownership
   - `kea-dhcp4-server.service`
   - `kea-dhcp-ddns-server.service`
-- `services.router-dns-service` is intentionally **not** behind this gate.
-  LAN-facing DNS remains a shared Technitium capability on both routers, while
-  DHCP failover and public DDNS ownership stay separate.
+  - `services.router-upnp.enable`
+  - `services.router-ntp.enable`
+  so both nodes can keep shared capability while only the active owner answers
+  LAN DHCP, advertises UPnP/NAT-PMP mappings, serves the advertised LAN NTP
+  identity, or updates public DNS identity.
+- More failover-sensitive ownership should move behind this same boundary as
+  the HA refactor continues. That next step is now tracked explicitly in
+  work item `75-consumer-active-owner-service-boundary-and-expansion`.
 
 ## Technitium
 
@@ -58,23 +63,18 @@ Use Technitium clustering only for DNS/admin-state sync between `router` and
 - make `router` the primary Technitium node
 - join `router-backup` as a secondary node
 - keep both nodes reachable over the management network
-- keep LAN DNS service available on both nodes as a clustered shared
-  capability
 - do not treat clustering as DHCP failover
 
 ### What Clustering Helps With
 
 - DNS zones and records managed in Technitium
 - admin/application configuration inside Technitium
-- keeping the LAN-facing DNS service surface aligned across both routers
 - reducing drift between the primary and spare router
 
 ### What It Does Not Solve
 
 - DHCP scope replication
 - DHCP lease-state failover
-- automatic promotion of DNS, DHCP, and public identity as one inseparable HA
-  unit
 - default-gateway failover
 - WAN ownership
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -27,13 +27,33 @@ let
   operatorStableSshKey = lib.strings.trim (
     builtins.readFile ../../../ssh-keys/deepwatrcreatur-stable-identity.pub
   );
+  keaDhcp4LeaseHeader =
+    "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id";
   ensureKeaLeaseState = pkgs.writeShellScript "router-kea-ensure-state" ''
     set -euo pipefail
 
     install -d -m 0750 -o kea -g kea /var/lib/private/kea
-    touch /var/lib/private/kea/dhcp4.leases /var/lib/private/kea/dhcp4.leases.2
-    chown kea:kea /var/lib/private/kea/dhcp4.leases /var/lib/private/kea/dhcp4.leases.2
-    chmod 0640 /var/lib/private/kea/dhcp4.leases /var/lib/private/kea/dhcp4.leases.2
+
+    expected_header='${keaDhcp4LeaseHeader}'
+
+    for lease_file in /var/lib/private/kea/dhcp4.leases /var/lib/private/kea/dhcp4.leases.2; do
+      if [ ! -e "$lease_file" ]; then
+        : > "$lease_file"
+      fi
+
+      if [ -s "$lease_file" ]; then
+        header="$(head -n 1 "$lease_file" || true)"
+        if [ "$header" != "$expected_header" ]; then
+          backup="$lease_file.incompatible.$(date +%s)"
+          cp -a "$lease_file" "$backup"
+          : > "$lease_file"
+          echo "router-kea-ensure-state: reset incompatible lease file header in $lease_file (backup: $backup)" >&2
+        fi
+      fi
+
+      chown kea:kea "$lease_file"
+      chmod 0640 "$lease_file"
+    done
   '';
 
   secrets = optSec.mkSecrets {
@@ -62,6 +82,7 @@ let
   managementNetwork = topology.networks.management;
   mkFqdn = label: "${label}.${topology.domain}";
   isPrimaryRouter = config.networking.hostName == "router";
+  activeOwner = config.router.failover.activeOwner;
   # Static LAN IP assigned to this router node, distinct from the shared VIP.
   staticLanIp = builtins.head (lib.splitString "/" lanIpv4Address);
   reservableHosts = lib.filterAttrs (
@@ -175,6 +196,8 @@ in
   };
 
   services.router-kea = {
+    # Keep Kea defined on both nodes so the unit, user/group, and secret wiring
+    # remain coherent, but gate actual DHCP ownership at service start.
     enable = true;
     dhcp4 = {
       interfaces = [ lanDevice ];
@@ -224,14 +247,25 @@ in
 
   services.router-upnp = {
     # Bind miniupnpd to explicit interface names so the generated config does
-    # not fall back to invalid address-based guesses.
-    enable = true;
+    # not fall back to invalid address-based guesses. Only the active owner
+    # should advertise LAN-side UPnP/NAT-PMP mappings.
+    enable = activeOwner;
     externalInterface = wanDevice;
     internalIPs = [ lanDevice ];
   };
 
+  # The shared router profile advertises one LAN-facing NTP identity via DHCP
+  # option 42, so only the active owner should actually serve that identity.
+  services.router-ntp.enable = activeOwner;
+
   systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [
     "+${ensureKeaLeaseState}"
+  ];
+  systemd.services.kea-dhcp4-server.serviceConfig.ExecCondition = lib.mkBefore [
+    "${pkgs.runtimeShell} -c '${if activeOwner then "exit 0" else "exit 1"}'"
+  ];
+  systemd.services.kea-dhcp-ddns-server.serviceConfig.ExecCondition = lib.mkBefore [
+    "${pkgs.runtimeShell} -c '${if activeOwner then "exit 0" else "exit 1"}'"
   ];
 
   services.router-networking = {
@@ -329,34 +363,37 @@ in
   services.router-optimizations = {
     enable = true;
     package = inputs.nix-router-optimized.packages.${pkgs.system}.router-diag;
-    interfaces = {
-      wan = {
-        device = wanDevice;
-        role = "wan";
-        label = "WAN";
-        bandwidth = "1Gbit";
+    interfaces =
+      {
+        wan = {
+          device = wanDevice;
+          role = "wan";
+          label = "WAN";
+          bandwidth = "1Gbit";
+        };
+        lan = {
+          device = lanDevice;
+          role = "lan";
+          label = "LAN";
+        };
+        management = {
+          device = managementDevice;
+          role = "management";
+          label = "Management";
+        };
+      }
+      // lib.optionalAttrs enableExtraRoutedNetworks {
+        iot = {
+          device = "${lanDevice}.20";
+          role = "lan";
+          label = "IoT VLAN";
+        };
+        guest = {
+          device = "${lanDevice}.30";
+          role = "lan";
+          label = "Guest VLAN";
+        };
       };
-      lan = {
-        device = lanDevice;
-        role = "lan";
-        label = "LAN";
-      };
-      iot = {
-        device = "${lanDevice}.20";
-        role = "lan";
-        label = "IoT VLAN";
-      };
-      guest = {
-        device = "${lanDevice}.30";
-        role = "lan";
-        label = "Guest VLAN";
-      };
-      management = {
-        device = managementDevice;
-        role = "management";
-        label = "Management";
-      };
-    };
     conntrack-max = 262144;
   };
 
@@ -736,9 +773,8 @@ in
             -H "Content-Type: application/x-www-form-urlencoded" \
             --data-urlencode "token=$TOKEN" \
             --data-urlencode "zone=${fwdZone}" \
-            --data-urlencode "update=UseSpecifiedNetworkACL" \
+            --data-urlencode "update=AllowOnlySpecifiedNetworkAddresses" \
             --data-urlencode "updateNetworkACL=127.0.0.1" \
-            --data-urlencode "updateSecurityPolicies=kea-ddns|*|A,AAAA,DHCID" \
             "http://127.0.0.1:5380/api/zones/options/set" \
             >/dev/null
 
@@ -747,9 +783,8 @@ in
             -H "Content-Type: application/x-www-form-urlencoded" \
             --data-urlencode "token=$TOKEN" \
             --data-urlencode "zone=${revZone}" \
-            --data-urlencode "update=UseSpecifiedNetworkACL" \
+            --data-urlencode "update=AllowOnlySpecifiedNetworkAddresses" \
             --data-urlencode "updateNetworkACL=127.0.0.1" \
-            --data-urlencode "updateSecurityPolicies=kea-ddns|*|PTR,DHCID" \
             "http://127.0.0.1:5380/api/zones/options/set" \
             >/dev/null
 

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -17,10 +17,6 @@ in
       haVirtualIpAddress
     ];
     searchDomains = [ topology.domain ];
-    # LAN-facing DNS remains a shared clustered capability on both routers.
-    # Do not casually move this behind router.failover.activeOwner: public DDNS
-    # and DHCP ownership are narrower single-owner surfaces than the
-    # Technitium-backed LAN resolver/admin state.
     # Advertise the router's chrony instance to LAN clients via DHCP option 42.
     # This remains the shared production identity; only the active owner should
     # actually present that identity on the production LAN.
@@ -36,15 +32,17 @@ in
   };
 
   services.router-ntp = {
-    # Shared capability belongs here even if consumer-side ownership becomes
-    # narrower later.
-    enable = true;
+    # Shared capability belongs here, but the consumer-side role owns the final
+    # single-owner gate via router.failover.activeOwner.
+    enable = lib.mkDefault true;
     lanSubnets = [ topology.networks.lan.cidr ];
   };
 
-  # UPnP/NAT-PMP stays declared here as shared capability wiring even if a
-  # narrower failover ownership adapter is introduced later.
-  services.router-upnp.enable = true;
+  # UPnP/NAT-PMP should remain available on whichever router currently owns
+  # the LAN path so failover does not silently drop port mapping support.
+  # Shared capability belongs here, but the consumer-side role owns the final
+  # single-owner gate via router.failover.activeOwner.
+  services.router-upnp.enable = lib.mkDefault true;
 
   # NAT is handled by nftables (see role.nix).
   networking.nat.enable = false;

--- a/modules/nixos/router-dashboard-runtime-repair.nix
+++ b/modules/nixos/router-dashboard-runtime-repair.nix
@@ -117,20 +117,40 @@ in
       };
       script = ''
         set -euo pipefail
-        src=""
-        for candidate in /var/lib/private/kea/dhcp4.leases /var/lib/kea/dhcp4.leases; do
-          if [ -f "$candidate" ]; then
-            src="$candidate"
-            break
+        tmp="$(mktemp /run/router-dashboard/kea-dhcp4.leases.XXXXXX)"
+        trap 'rm -f "$tmp"' EXIT
+
+        header=""
+        found_source=0
+
+        for candidate in \
+          /var/lib/private/kea/dhcp4.leases.2 \
+          /var/lib/private/kea/dhcp4.leases \
+          /var/lib/kea/dhcp4.leases.2 \
+          /var/lib/kea/dhcp4.leases
+        do
+          if [ ! -f "$candidate" ]; then
+            continue
           fi
+
+          found_source=1
+
+          if [ -z "$header" ]; then
+            header="$(head -n 1 "$candidate" || true)"
+            if [ -n "$header" ]; then
+              printf '%s\n' "$header" > "$tmp"
+            fi
+          fi
+
+          tail -n +2 "$candidate" | sed '/^$/d;/^#/d' >> "$tmp"
         done
 
-        if [ -z "$src" ]; then
+        if [ "$found_source" -eq 0 ] || [ -z "$header" ]; then
           echo "No Kea lease file found" >&2
           exit 1
         fi
 
-        install -m 0640 -o root -g router-dashboard "$src" "${keaLeaseSnapshotFile}"
+        install -m 0640 -o root -g router-dashboard "$tmp" "${keaLeaseSnapshotFile}"
       '';
       wantedBy = [ "multi-user.target" ];
     };

--- a/scripts/router-dashboard-api-wrapper.py
+++ b/scripts/router-dashboard-api-wrapper.py
@@ -148,11 +148,14 @@ def read_kea_leases_from_snapshot(path):
 
             address = row[0].strip()
             hardware_address = row[1].strip()
-            lease_expires = format_kea_expiry(row[4])
+            raw_expiry = row[4].strip()
             hostname = row[8].strip()
             state = row[9].strip()
 
-            if not address:
+            if not address or address == "address" or state == "state":
+                continue
+
+            if state != "0":
                 continue
 
             entry = {
@@ -161,13 +164,13 @@ def read_kea_leases_from_snapshot(path):
                 "address": address,
                 "hostname": hostname,
                 "hardwareAddress": hardware_address,
-                "leaseExpires": lease_expires,
-                "type": "active" if state == "0" else state,
+                "leaseExpires": format_kea_expiry(raw_expiry),
+                "type": "active",
                 "_state": state,
             }
 
             current = leases_by_ip.get(address)
-            if current is None or (current.get("_state") != "0" and state == "0"):
+            if current is None:
                 leases_by_ip[address] = entry
 
     leases = sorted(leases_by_ip.values(), key=lambda entry: ip_sort_key(entry["address"]))


### PR DESCRIPTION
## **User description**
## Summary
- align router active-owner service boundaries on a fresh branch rooted at `origin/main`
- carry only the coherent router-role, service-capability, dashboard runtime repair, and related router docs slice
- avoid mixing this publishable change with the unrelated leftover docs/search-domain edits from the preserved branch

## Validation
- git diff --check
- python -m py_compile scripts/router-dashboard-api-wrapper.py
- note: `nix flake check --no-build` also fails on clean `main`, so that baseline failure was not introduced by this branch


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refined the 'activeOwner' service boundary to include router-upnp and router-ntp, ensuring only the active router node advertises these services.</li>
<li>Updated Kea DHCP service configuration to use ExecCondition for gating startup based on 'activeOwner', preventing both nodes from attempting to serve DHCP simultaneously.</li>
<li>Enhanced the Kea lease state initialization script to validate and reset lease files with incompatible headers, improving robustness during failover.</li>
<li>Updated documentation to clarify the current supported single-owner service boundary and the role of Technitium clustering.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Keep active router services and lease snapshots consistent during failover**

### What Changed
- Only the active router now starts DHCP, DDNS, UPnP/NAT-PMP, and the advertised LAN NTP service, so the spare node no longer competes for those roles.
- Kea lease snapshots now ignore stale or malformed lease files, reset incompatible lease headers with a backup, and keep the dashboard lease view focused on active leases only.
- Technitium updates now use the current network-access setting for DNS zone changes.
- Router docs now reflect the updated active-owner boundary and the services it controls.

### Impact
`✅ Fewer split-brain DHCP and DNS updates`
`✅ More reliable router failover`
`✅ Cleaner router dashboard lease data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
