### PR TITLE
feat(router): expose evebox for suricata

### DIFF
--- a/den/aspects/router-router.nix
+++ b/den/aspects/router-router.nix
@@ -12,6 +12,7 @@
     inputs.nix-router-optimized.nixosModules.router-optimizations
     inputs.nix-router-optimized.nixosModules.router-tailscale
     inputs.nix-router-optimized.nixosModules.router-observability
+    inputs.nix-router-optimized.nixosModules.router-network-security
     inputs.nix-router-optimized.nixosModules.router-vpn
     inputs.nix-router-optimized.nixosModules.router-ntp
     inputs.nix-router-optimized.nixosModules.router-nat64

--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781335082,
-        "narHash": "sha256-V+Q4VtO3GRJfZLl3AODLprnb5MQx8pgWiJNL1QyAMLk=",
+        "lastModified": 1782380579,
+        "narHash": "sha256-hdWvSKJpPcFoItBYUq/s46E7Vrg2n83DihGqaF4ZLoo=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "5ca136c05c5a99656271088074ba98a06f4bee55",
+        "rev": "66748f444d70dbd71a09a820f734b3249880993f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782380579,
-        "narHash": "sha256-hdWvSKJpPcFoItBYUq/s46E7Vrg2n83DihGqaF4ZLoo=",
+        "lastModified": 1782469761,
+        "narHash": "sha256-bbjb5TuTzHzzEpxs3zp6pbp1LCIa/JBXdAW4twHuSJ4=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "66748f444d70dbd71a09a820f734b3249880993f",
+        "rev": "5d2ab9ed99e1fefa29a6516eb52fe6f639577f44",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782469761,
-        "narHash": "sha256-bbjb5TuTzHzzEpxs3zp6pbp1LCIa/JBXdAW4twHuSJ4=",
+        "lastModified": 1782470439,
+        "narHash": "sha256-Be82Dp5xnc4AkZGvn0wXCmAtzanLEAr/XusdGwVqpzM=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "5d2ab9ed99e1fefa29a6516eb52fe6f639577f44",
+        "rev": "9e6a4c41c6ba0ded2a68c27b90b2f0f7b655e652",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -82,7 +82,7 @@ in
 
       "${mkFqdn "homelab"}" = {
         extraConfig = ''
-          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10
+          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10 fd7a:115c:a1e0::/48
           handle @trusted {
             reverse_proxy 127.0.0.1:8888
           }
@@ -140,7 +140,7 @@ in
       # Internal-only admin services
       "${mkFqdn "technitium"}" = {
         extraConfig = ''
-          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10
+          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10 fd7a:115c:a1e0::/48
           handle @trusted {
             reverse_proxy 127.0.0.1:5380
           }
@@ -150,7 +150,7 @@ in
 
       "${mkFqdn "netdata"}" = {
         extraConfig = ''
-          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10
+          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10 fd7a:115c:a1e0::/48
           handle @trusted {
             reverse_proxy 127.0.0.1:19999
           }
@@ -160,7 +160,7 @@ in
 
       "${mkFqdn "prometheus"}" = {
         extraConfig = ''
-          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10
+          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10 fd7a:115c:a1e0::/48
           handle @trusted {
             reverse_proxy 127.0.0.1:9090
           }
@@ -170,7 +170,7 @@ in
 
       "${mkFqdn "evebox"}" = {
         extraConfig = ''
-          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10
+          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10 fd7a:115c:a1e0::/48
           handle @trusted {
             reverse_proxy 127.0.0.1:5636
           }

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -168,6 +168,16 @@ in
         '';
       };
 
+      "${mkFqdn "evebox"}" = {
+        extraConfig = ''
+          @trusted remote_ip ${lanNetwork.cidr} 100.64.0.0/10
+          handle @trusted {
+            reverse_proxy 127.0.0.1:5636
+          }
+          respond "Access restricted to home LAN and Tailnet" 403
+        '';
+      };
+
       "http://${routerHost.ip}" = {
         extraConfig = ''
           root * /srv/pxe

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -430,7 +430,10 @@ in
 
   services.router-network-security = {
     enable = true;
-    suricata.enable = true;
+    suricata = {
+      enable = true;
+      evebox.enable = true;
+    };
   };
 
   services.router-snmp = {
@@ -473,6 +476,7 @@ in
       "ulogd"
       "vector"
       "suricata"
+      "router-evebox"
     ];
     links = lib.mkForce [
       {
@@ -484,6 +488,11 @@ in
         label = "Grafana";
         url = "https://${mkFqdn "grafana"}";
         icon = "📈";
+      }
+      {
+        label = "EveBox";
+        url = "https://${mkFqdn "evebox"}";
+        icon = "🔎";
       }
       {
         label = "DNS Admin Mgmt";

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -428,6 +428,11 @@ in
 
   services.router-observability.enable = true;
 
+  services.router-network-security = {
+    enable = true;
+    suricata.enable = true;
+  };
+
   services.router-snmp = {
     enable = true;
     listenAddresses = [
@@ -467,6 +472,7 @@ in
       "health-wan-ip"
       "ulogd"
       "vector"
+      "suricata"
     ];
     links = lib.mkForce [
       {

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -92,6 +92,7 @@
         technitium = 5380;
         netdata = 19999;
         prometheus = 9090;
+        evebox = 5636;
       };
       ddnsServices = [
         "@"


### PR DESCRIPTION
## **User description**
## Summary
- enable Suricata EveBox for router and router-backup
- expose EveBox through trusted Caddy routing at evebox.deepwatercreature.com
- add EveBox to router dashboard links and service monitoring
- update nix-router-optimized lock to the EveBox branch tip

## Validation
- nix build --no-link .#nixosConfigurations.router.config.system.build.toplevel
- nix build --no-link .#nixosConfigurations.router-backup.config.system.build.toplevel

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enabled network security services including Suricata and EveBox on the router.</li>
<li>Configured Caddy reverse proxy for EveBox with restricted access for LAN and Tailnet.</li>
<li>Updated nix-router-optimized flake input to a newer revision.</li>
<li>Added EveBox to the router's service list and dashboard links.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Enable Suricata and EveBox on the router pair**

### What Changed
- The router now runs network security monitoring with Suricata enabled on both routers
- EveBox is now available for viewing Suricata alerts through the router
- EveBox is only reachable from the home LAN and Tailnet, and is blocked from other access
- The router dashboard now includes a direct EveBox link

### Impact
`✅ Fewer missed Suricata alerts`
`✅ Quicker security log review from home or Tailnet`
`✅ Clearer access to router security tools`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
