### PR TITLE
chore(router): refresh evebox packaging fix pin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782470439,
-        "narHash": "sha256-Be82Dp5xnc4AkZGvn0wXCmAtzanLEAr/XusdGwVqpzM=",
+        "lastModified": 1782543686,
+        "narHash": "sha256-7q8THSvqQ+tiJ3KFVr7rLWfsUobYumuoWxKbY7HFbps=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "9e6a4c41c6ba0ded2a68c27b90b2f0f7b655e652",
+        "rev": "ca7e1c385e6ebfe7bbea30c016559cea85ad50ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- refresh nix-router-optimized to the merged EveBox packaging fix
- keep unified-nix-configuration aligned with the upstream flake default

## Testing
- nix flake lock --update-input nix-router-optimized


<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated the 'nix-router-optimized' dependency to a newer revision (ca7e1c385e6ebfe7bbea30c016559cea85ad50ff).</li>
</ul></div>