### PR TITLE
feat(router): add public ingress failover plumbing

### DIFF
--- a/den/aspects/router-router.nix
+++ b/den/aspects/router-router.nix
@@ -6,6 +6,7 @@
     inputs.nix-router-optimized.nixosModules.router-networking
     inputs.nix-router-optimized.nixosModules.router-firewall
     inputs.nix-router-optimized.nixosModules.router-dns-service
+    inputs.nix-router-optimized.nixosModules.router-ddns
     inputs.nix-router-optimized.nixosModules.router-homelab
     inputs.nix-router-optimized.nixosModules.router-kea
     inputs.nix-router-optimized.nixosModules.router-log-storage

--- a/den/hosts/router/default.nix
+++ b/den/hosts/router/default.nix
@@ -18,7 +18,7 @@ den.mkInventoryHostModule {
     # for inlining once router/configuration.nix is fully migrated.
     ../../../hosts/nixos/router/networking.nix
 
-    # caddy.nix — full Caddy configuration with virtualHosts, DDNS, ACME.
+    # caddy.nix — full Caddy configuration with virtualHosts and ACME.
     # Large and host-specific; should remain a separate file.
     ../../../hosts/nixos/router/caddy.nix
 

--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782543686,
-        "narHash": "sha256-7q8THSvqQ+tiJ3KFVr7rLWfsUobYumuoWxKbY7HFbps=",
+        "lastModified": 1782629304,
+        "narHash": "sha256-SQ9uv31vNt0ACtcxwiACmbsP/Dz114qHa3rTN0JTYf0=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "ca7e1c385e6ebfe7bbea30c016559cea85ad50ff",
+        "rev": "cfee93156f8c7edc691c8b8f5fd782a351451ac0",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -8,8 +8,6 @@ let
   authentikHost = topology.hosts.authentik-host;
   podmanHost = topology.hosts.podman;
   roundtableHost = topology.hosts.vaglio;
-  ddnsLabels = routerHost.ddnsServices or [ ];
-  ddnsDomainsLine = lib.concatStringsSep " " ([ topology.domain ] ++ ddnsLabels);
   mkFqdn = label: "${label}.${topology.domain}";
 
   # Optional secrets library for graceful degradation
@@ -19,21 +17,6 @@ let
   cfSecret = optSec.mkSecret "cloudflare-api-key" {
     file = ../../../secrets-agenix/cloudflare_ddns_API_token.age;
   };
-  activeOwner = config.router.failover.activeOwner;
-  dynamicDnsConfig = lib.optionalString activeOwner ''
-    dynamic_dns {
-      provider cloudflare {$CLOUDFLARE_API_TOKEN}
-      domains {
-        # `home-assistant` is intentionally excluded here. We publish it as a
-        # Cloudflare CNAME to another DDNS-managed hostname so Caddy's DDNS
-        # updater does not fight Cloudflare over the same record name.
-        ${ddnsDomainsLine}
-      }
-      check_interval 5m
-      versions ipv4 ipv6
-      ttl 1h
-    }
-  '';
 in
 {
   services.caddy = {
@@ -42,9 +25,8 @@ in
     package = pkgs.caddy.withPlugins {
       plugins = [
         "github.com/caddy-dns/cloudflare@v0.2.3"
-        "github.com/mholt/caddy-dynamicdns@v0.0.0-20251231002810-1af4f8876598"
       ];
-      hash = "sha256-iHlgpFqJjAld419OH4CRbwXlAmRafjBJYoJM+vm64vs=";
+      hash = "sha256-LEpsjwy0CYx04cg42CfG6/sFv86kHmhezUG6yGedYcA=";
     };
     environmentFile = "/run/caddy/caddy.env";
 
@@ -52,7 +34,7 @@ in
     globalConfig = ''
       # ACME/Let's Encrypt configuration
       email deepwatrcreatur@gmail.com
-      ${dynamicDnsConfig}
+      acme_dns cloudflare {$CLOUDFLARE_API_TOKEN}
 
       # Use staging for testing, comment out for production
       # acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
@@ -198,16 +180,16 @@ in
     wants = [ "network-online.target" ];
     preStart = ''
       install -d -m 0750 -o caddy -g caddy /run/caddy
-      ${lib.optionalString (activeOwner && cfSecret.exists) ''
+      ${lib.optionalString cfSecret.exists ''
         token="$(tr -d '\n' < ${config.age.secrets.cloudflare-api-key.path})"
         test -n "$token"
         printf 'CLOUDFLARE_API_TOKEN=%s\n' "$token" > /run/caddy/caddy.env
         chown caddy:caddy /run/caddy/caddy.env
         chmod 0400 /run/caddy/caddy.env
       ''}
-      ${lib.optionalString (!activeOwner || !cfSecret.exists) ''
-        # In standby mode or without the Cloudflare secret, keep an empty env
-        # file so Caddy can still start without public DDNS ownership.
+      ${lib.optionalString (!cfSecret.exists) ''
+        # Without the Cloudflare secret, keep an empty env file so Caddy can
+        # still start on local-only or lab setups.
         : > /run/caddy/caddy.env
         chown caddy:caddy /run/caddy/caddy.env
         chmod 0400 /run/caddy/caddy.env

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -181,21 +181,30 @@ in
   };
 
   services.router-ha = {
-    # Keep the family-facing router as the sole HA participant while the
-    # backup node is used as a development and recovery target.
-    enable = isPrimaryRouter;
+    # Both router nodes participate in VRRP so LAN VIP and WAN ownership can
+    # move together during failover.
+    enable = true;
     role = if isPrimaryRouter then "master" else "backup";
     virtualIp = "10.10.10.1/16";
     vrrpInterface = lanDevice;
+    singleActiveUnits = [ "inadyn.service" ];
     keaSync.enable = isPrimaryRouter;
     keaSync.peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
     wan = {
-      # Keepalived-driven WAN link/MAC manipulation regressed the router's own
-      # internet recovery on newer generations. Keep the LAN VIP logic, but let
-      # systemd-networkd own WAN DHCP lifecycle directly on the primary router.
-      enable = false;
+      # Public ingress failover requires WAN ownership to follow VRRP
+      # promotion, not just the LAN VIP.
+      enable = true;
       interface = wanDevice;
       clonedMac = "02:76:c6:01:2a:b0";
+    };
+  };
+
+  services.router-ddns = {
+    enable = true;
+    cloudflare = {
+      zoneName = topology.domain;
+      labels = topology.routerHost.ddnsServices;
+      apiTokenFile = config.age.secrets.cloudflare-api-key.path;
     };
   };
 
@@ -265,6 +274,13 @@ in
   systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [
     "+${ensureKeaLeaseState}"
   ];
+  systemd.services.inadyn = {
+    after = [ "router-ha-initial-role-state.service" ];
+    requires = [ "router-ha-initial-role-state.service" ];
+    serviceConfig.ExecCondition = lib.mkBefore [
+      "${pkgs.runtimeShell} -c '[ \"$(cat /run/router-ha/role 2>/dev/null || true)\" = master ]'"
+    ];
+  };
   systemd.services.kea-dhcp4-server.serviceConfig.ExecCondition = lib.mkBefore [
     "${pkgs.runtimeShell} -c '${if activeOwner then "exit 0" else "exit 1"}'"
   ];

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -44,7 +44,7 @@
   #             router/Caddy, not the router machine itself). Kept separate
   #             from aliases so inventory checks can detect collisions between
   #             service names and machine hostnames.
-  #   ddnsServices: public DNS labels that Caddy's dynamic_dns plugin should
+  #   ddnsServices: public DNS labels that the router DDNS owner should
   #                 publish for this host at Cloudflare. This is only for
   #                 internet-facing ingress names, not general internal host
   #                 registration, which comes from Technitium/DHCP.


### PR DESCRIPTION
## **User description**
## Summary
- import router-ddns and move public DNS ownership to inadyn
- switch Caddy to Cloudflare DNS-01 so both routers can hold valid certs
- enable HA participation on both router nodes and wire WAN ownership for public ingress failover
- gate inadyn on the router HA runtime role file

## Validation
- nix build --no-link .#nixosConfigurations.router.config.system.build.toplevel
- nix build --no-link .#nixosConfigurations.router-backup.config.system.build.toplevel

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Migrated DDNS management from Caddy's dynamic_dns plugin to a dedicated router-ddns service.</li>
<li>Enabled WAN ownership failover in router-ha, allowing both router nodes to participate in VRRP for public ingress.</li>
<li>Configured inadyn as the DDNS provider, gated by the router's HA master role.</li>
<li>Updated Caddy configuration to use Cloudflare for ACME DNS challenges instead of dynamic DNS updates.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Enable public ingress failover for the router**

### What Changed
- Both router nodes now take part in failover, so public access can move with the active router instead of staying tied to one machine
- The router now publishes its public DNS names through a dedicated DDNS service, instead of relying on Caddy for DNS updates
- Caddy now uses Cloudflare only for certificate validation, and it can still start when the Cloudflare secret is missing for local or lab setups
- DDNS updates only run on the active router role, preventing standby routing nodes from changing public DNS records

### Impact
`✅ Public access keeps working during router failover`
`✅ Fewer stale DNS records after a router switch`
`✅ Clearer certificate setup for public router services`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
