### PR TITLE
feat(router): move LAN single-owner services behind HA role

### DIFF
--- a/docs/network-source-of-truth.md
+++ b/docs/network-source-of-truth.md
@@ -62,7 +62,7 @@ If `router` and `router-backup` are both kept online on the management network,
 Technitium clustering can be used to keep DNS/admin configuration aligned
 between them. In the current consumer boundary, that also means LAN-facing DNS
 service is intentionally treated as a shared capability on both routers rather
-than another `router.failover.activeOwner` surface.
+than another `router-ha` single-active service surface.
 
 This does not currently extend to DHCP scopes or lease state, so the standby
 router still needs its DHCP scope checked separately in the web UI.

--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -120,12 +120,14 @@ Today the promoted node owns these services through
 - public DDNS updates via `inadyn.service`
 - LAN DHCP via `kea-dhcp4-server.service`
 - DHCP-DDNS updates via `kea-dhcp-ddns-server.service`
-- LAN NTP via `chronyd.service`
 - LAN UPnP/NAT-PMP via `miniupnpd.service`
 - IPv6 router advertisements via `router-ipv6-ra-owner.service`
 
 `router.failover.activeOwner` remains only as a compatibility shim in
 `modules/nixos/router/common.nix`; it is no longer the live service gate.
+
+`chronyd.service` stays running on both nodes so the standby router keeps time
+for TLS, DNSSEC, and clean promotion.
 - **Hardware**: regenerate `hardware-configuration.nix` on the target machine with
   `nixos-generate-config`; never edit the generated file.
 

--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -82,10 +82,10 @@ den/inventory/hosts.nix          ← entry point
 | NAT policy | `hosts/nixos/router/service-capability.nix` | `networking.nat.enable = false`; nftables handles NAT in role.nix |
 | Disk layout (router) | `hosts/nixos/router/disko.nix` | Hardware-adjacent; keep separate |
 | Disk layout (backup) | `hosts/nixos/router-backup/disko.nix` | Imported by `configuration.nix`; hardware-adjacent, keep separate |
-| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public DDNS ownership is gated by `router.failover.activeOwner` |
+| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public DDNS ownership follows the HA runtime role via `inadyn.service` single-active gating |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
-| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; currently gates public DDNS ownership, `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup, `services.router-upnp.enable`, and `services.router-ntp.enable` in the consumer tree |
+| Active single-owner identity | `services.router-ha.singleActiveUnits` plus `/run/router-ha/role` | Keepalived notify hooks now start/stop DDNS, DHCP, NTP, UPnP, and IPv6 RA ownership on the promoted router |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -97,8 +97,8 @@ den/inventory/hosts.nix          ← entry point
 
 - **DNS / NTP shared capability**: `hosts/nixos/router/service-capability.nix`.
 - **Primary hostname / domain defaults**: `hosts/nixos/router/networking.nix`.
-- **Active single-owner identity / DHCP ownership**: `modules/nixos/router/common.nix` via
-  `router.failover.activeOwner`.
+- **Active single-owner identity / DHCP ownership**: `hosts/nixos/router/role.nix`
+  via `services.router-ha.singleActiveUnits` and the HA runtime role file.
 - **Firewall / NAT / observability / VPN**: tune options provided by
   `nix-router-optimized` modules; the entry point is `den/aspects/router-router.nix`.
 - **Caddy virtualHosts, ACME, DDNS**: `hosts/nixos/router/caddy.nix`.
@@ -109,24 +109,23 @@ den/inventory/hosts.nix          ← entry point
   it in both `router` and `router-backup` `aspectsList` entries in
   `den/inventory/hosts.nix`.
 
-## Current `activeOwner` Consumers
+## Current Single-Owner Boundary
 
-`router.failover.activeOwner` currently has a narrow, explicit consumer-side
-meaning:
+Consumer-side single-owner service control now follows `router-ha` runtime
+state rather than the legacy static `router.failover.activeOwner` hint.
 
-- in `hosts/nixos/router/caddy.nix`, it gates public Cloudflare DDNS ownership
-- in `hosts/nixos/router/role.nix`, it gates `kea-dhcp4-server.service` startup
-- in `hosts/nixos/router/role.nix`, it gates `kea-dhcp-ddns-server.service`
-  startup
-- in `hosts/nixos/router/role.nix`, it gates `services.router-upnp.enable`
-- in `hosts/nixos/router/role.nix`, it gates `services.router-ntp.enable`
+Today the promoted node owns these services through
+`services.router-ha.singleActiveUnits`:
 
-That is the current supported single-owner boundary in this tree. Other
-router-facing services may still be present on both nodes, but they should not
-be described as `activeOwner`-governed unless they are wired explicitly.
+- public DDNS updates via `inadyn.service`
+- LAN DHCP via `kea-dhcp4-server.service`
+- DHCP-DDNS updates via `kea-dhcp-ddns-server.service`
+- LAN NTP via `chronyd.service`
+- LAN UPnP/NAT-PMP via `miniupnpd.service`
+- IPv6 router advertisements via `router-ipv6-ra-owner.service`
 
-The next consumer-side HA follow-up is tracked as
-`nix-router-optimized/docs/work-items/75-consumer-active-owner-service-boundary-and-expansion.md`.
+`router.failover.activeOwner` remains only as a compatibility shim in
+`modules/nixos/router/common.nix`; it is no longer the live service gate.
 - **Hardware**: regenerate `hardware-configuration.nix` on the target machine with
   `nixos-generate-config`; never edit the generated file.
 

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -31,21 +31,19 @@ To promote `router-backup` after a failure or bad rebuild:
 
 ### Current config note
 
-- `router.failover.activeOwner` is the consumer-tree switch for single-owner
-  public identity. It currently defaults to `true` on `router` and `false` on
-  `router-backup`.
-- Today that switch gates:
-  - Caddy's public DDNS ownership
+- Single-owner services now follow the HA runtime role written to
+  `/run/router-ha/role`, not the old static `router.failover.activeOwner`
+  default.
+- Today the promoted router owns:
+  - public DDNS updates via `inadyn.service`
   - `kea-dhcp4-server.service`
   - `kea-dhcp-ddns-server.service`
-  - `services.router-upnp.enable`
-  - `services.router-ntp.enable`
-  so both nodes can keep shared capability while only the active owner answers
-  LAN DHCP, advertises UPnP/NAT-PMP mappings, serves the advertised LAN NTP
-  identity, or updates public DNS identity.
-- More failover-sensitive ownership should move behind this same boundary as
-  the HA refactor continues. That next step is now tracked explicitly in
-  work item `75-consumer-active-owner-service-boundary-and-expansion`.
+  - `chronyd.service`
+  - `miniupnpd.service`
+  - IPv6 router advertisements via `router-ipv6-ra-owner.service`
+- That means both nodes can keep shared capability in the closure while only
+  the promoted router answers LAN DHCP, advertises UPnP/NAT-PMP mappings,
+  serves the shared LAN NTP identity, emits IPv6 RAs, or updates public DNS.
 
 ## Technitium
 

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -38,12 +38,13 @@ To promote `router-backup` after a failure or bad rebuild:
   - public DDNS updates via `inadyn.service`
   - `kea-dhcp4-server.service`
   - `kea-dhcp-ddns-server.service`
-  - `chronyd.service`
   - `miniupnpd.service`
   - IPv6 router advertisements via `router-ipv6-ra-owner.service`
 - That means both nodes can keep shared capability in the closure while only
   the promoted router answers LAN DHCP, advertises UPnP/NAT-PMP mappings,
-  serves the shared LAN NTP identity, emits IPv6 RAs, or updates public DNS.
+  emits IPv6 RAs, or updates public DNS.
+- `chronyd.service` stays running on both nodes so the standby keeps time even
+  before promotion.
 
 ## Technitium
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -86,7 +86,33 @@ let
   managementNetwork = topology.networks.management;
   mkFqdn = label: "${label}.${topology.domain}";
   isPrimaryRouter = config.networking.hostName == "router";
-  activeOwner = config.router.failover.activeOwner;
+  routerHaRoleFile = "/run/router-ha/role";
+  masterExecCondition =
+    "${pkgs.runtimeShell} -c '[ \"$(cat ${routerHaRoleFile} 2>/dev/null || true)\" = master ]'";
+  singleActiveLanUnits = [
+    "inadyn.service"
+    "kea-dhcp4-server.service"
+    "kea-dhcp-ddns-server.service"
+    "chronyd.service"
+    "miniupnpd.service"
+    "router-ipv6-ra-owner.service"
+  ];
+  ipv6RaOwnerDropInDir = "/run/systemd/network/08-router-parent-${lanDevice}.network.d";
+  ipv6RaOwnerDropIn = "${ipv6RaOwnerDropInDir}/90-router-ha-ra.conf";
+  enableIpv6RaOwner = pkgs.writeShellScript "router-ipv6-ra-owner-enable" ''
+    set -euo pipefail
+    install -d -m 0755 ${lib.escapeShellArg ipv6RaOwnerDropInDir}
+    cat > ${lib.escapeShellArg ipv6RaOwnerDropIn} <<'EOF'
+    [Network]
+    IPv6SendRA=true
+    EOF
+    ${pkgs.systemd}/bin/systemctl restart systemd-networkd.service
+  '';
+  disableIpv6RaOwner = pkgs.writeShellScript "router-ipv6-ra-owner-disable" ''
+    set -euo pipefail
+    rm -f ${lib.escapeShellArg ipv6RaOwnerDropIn}
+    ${pkgs.systemd}/bin/systemctl restart systemd-networkd.service
+  '';
   # Static LAN IP assigned to this router node, distinct from the shared VIP.
   staticLanIp = builtins.head (lib.splitString "/" lanIpv4Address);
   reservableHosts = lib.filterAttrs (
@@ -187,7 +213,7 @@ in
     role = if isPrimaryRouter then "master" else "backup";
     virtualIp = "10.10.10.1/16";
     vrrpInterface = lanDevice;
-    singleActiveUnits = [ "inadyn.service" ];
+    singleActiveUnits = singleActiveLanUnits;
     keaSync.enable = isPrimaryRouter;
     keaSync.peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
     wan = {
@@ -262,14 +288,14 @@ in
     # Bind miniupnpd to explicit interface names so the generated config does
     # not fall back to invalid address-based guesses. Only the active owner
     # should advertise LAN-side UPnP/NAT-PMP mappings.
-    enable = activeOwner;
+    enable = true;
     externalInterface = wanDevice;
     internalIPs = [ lanDevice ];
   };
 
   # The shared router profile advertises one LAN-facing NTP identity via DHCP
   # option 42, so only the active owner should actually serve that identity.
-  services.router-ntp.enable = activeOwner;
+  services.router-ntp.enable = true;
 
   systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [
     "+${ensureKeaLeaseState}"
@@ -278,15 +304,46 @@ in
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];
     serviceConfig.ExecCondition = lib.mkBefore [
-      "${pkgs.runtimeShell} -c '[ \"$(cat /run/router-ha/role 2>/dev/null || true)\" = master ]'"
+      masterExecCondition
     ];
   };
+  systemd.services.chronyd = {
+    after = [ "router-ha-initial-role-state.service" ];
+    requires = [ "router-ha-initial-role-state.service" ];
+    serviceConfig.ExecCondition = lib.mkBefore [
+      masterExecCondition
+    ];
+  };
+  systemd.services.miniupnpd = {
+    after = [ "router-ha-initial-role-state.service" ];
+    requires = [ "router-ha-initial-role-state.service" ];
+    serviceConfig.ExecCondition = lib.mkBefore [
+      masterExecCondition
+    ];
+  };
+  systemd.services.router-ipv6-ra-owner = {
+    description = "Apply IPv6 RA ownership to the active router";
+    after = [ "router-ha-initial-role-state.service" ];
+    requires = [ "router-ha-initial-role-state.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecCondition = [ masterExecCondition ];
+      ExecStart = [ "+${enableIpv6RaOwner}" ];
+      ExecStop = [ "+${disableIpv6RaOwner}" ];
+    };
+  };
   systemd.services.kea-dhcp4-server.serviceConfig.ExecCondition = lib.mkBefore [
-    "${pkgs.runtimeShell} -c '${if activeOwner then "exit 0" else "exit 1"}'"
+    masterExecCondition
   ];
   systemd.services.kea-dhcp-ddns-server.serviceConfig.ExecCondition = lib.mkBefore [
-    "${pkgs.runtimeShell} -c '${if activeOwner then "exit 0" else "exit 1"}'"
+    masterExecCondition
   ];
+  systemd.services.kea-dhcp4-server.after = [ "router-ha-initial-role-state.service" ];
+  systemd.services.kea-dhcp4-server.requires = [ "router-ha-initial-role-state.service" ];
+  systemd.services.kea-dhcp-ddns-server.after = [ "router-ha-initial-role-state.service" ];
+  systemd.services.kea-dhcp-ddns-server.requires = [ "router-ha-initial-role-state.service" ];
 
   services.router-networking = {
     enable = true;
@@ -861,15 +918,15 @@ in
       DNS = [ "127.0.0.1" ];
       Domains = [ topology.domain ];
       IPv6PrivacyExtensions = "no";
-      IPv6SendRA = activeOwner;
+      IPv6SendRA = false;
     };
     linkConfig.RequiredForOnline = lib.mkForce "routable";
-    ipv6SendRAConfig = lib.mkIf activeOwner {
+    ipv6SendRAConfig = {
       EmitDNS = true;
       Managed = false;
       OtherInformation = false;
     };
-    ipv6Prefixes = lib.mkIf activeOwner [
+    ipv6Prefixes = [
       {
         Prefix = "::/64";
         PreferredLifetimeSec = 1800;

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -93,7 +93,6 @@ let
     "inadyn.service"
     "kea-dhcp4-server.service"
     "kea-dhcp-ddns-server.service"
-    "chronyd.service"
     "miniupnpd.service"
     "router-ipv6-ra-owner.service"
   ];
@@ -106,12 +105,14 @@ let
     [Network]
     IPv6SendRA=true
     EOF
-    ${pkgs.systemd}/bin/systemctl restart systemd-networkd.service
+    ${pkgs.systemd}/bin/networkctl reload
+    ${pkgs.systemd}/bin/networkctl reconfigure ${lib.escapeShellArg lanDevice}
   '';
   disableIpv6RaOwner = pkgs.writeShellScript "router-ipv6-ra-owner-disable" ''
     set -euo pipefail
     rm -f ${lib.escapeShellArg ipv6RaOwnerDropIn}
-    ${pkgs.systemd}/bin/systemctl restart systemd-networkd.service
+    ${pkgs.systemd}/bin/networkctl reload
+    ${pkgs.systemd}/bin/networkctl reconfigure ${lib.escapeShellArg lanDevice}
   '';
   # Static LAN IP assigned to this router node, distinct from the shared VIP.
   staticLanIp = builtins.head (lib.splitString "/" lanIpv4Address);
@@ -293,21 +294,15 @@ in
     internalIPs = [ lanDevice ];
   };
 
-  # The shared router profile advertises one LAN-facing NTP identity via DHCP
-  # option 42, so only the active owner should actually serve that identity.
+  # Keep chronyd running on both nodes so the standby stays time-synchronised
+  # for TLS, DNSSEC, and clean promotion. DHCP option 42 still advertises the
+  # shared router identity to LAN clients.
   services.router-ntp.enable = true;
 
   systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [
     "+${ensureKeaLeaseState}"
   ];
   systemd.services.inadyn = {
-    after = [ "router-ha-initial-role-state.service" ];
-    requires = [ "router-ha-initial-role-state.service" ];
-    serviceConfig.ExecCondition = lib.mkBefore [
-      masterExecCondition
-    ];
-  };
-  systemd.services.chronyd = {
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];
     serviceConfig.ExecCondition = lib.mkBefore [

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -33,7 +33,7 @@ in
 
   services.router-ntp = {
     # Shared capability belongs here, but the consumer-side role owns the final
-    # single-owner gate via router.failover.activeOwner.
+    # single-owner gate via router-ha runtime ownership.
     enable = lib.mkDefault true;
     lanSubnets = [ topology.networks.lan.cidr ];
   };
@@ -41,7 +41,7 @@ in
   # UPnP/NAT-PMP should remain available on whichever router currently owns
   # the LAN path so failover does not silently drop port mapping support.
   # Shared capability belongs here, but the consumer-side role owns the final
-  # single-owner gate via router.failover.activeOwner.
+  # single-owner gate via router-ha runtime ownership.
   services.router-upnp.enable = lib.mkDefault true;
 
   # NAT is handled by nftables (see role.nix).

--- a/modules/nixos/router/common.nix
+++ b/modules/nixos/router/common.nix
@@ -14,9 +14,10 @@ in
   options.router.failover.activeOwner = lib.mkOption {
     type = lib.types.bool;
     description = ''
-      Whether this node should currently own the production router identity.
-      Shared service capability can exist on both routers, but only the active
-      owner should advertise or update single-owner identity such as public DDNS.
+      Legacy static hint for which node is expected to own production identity.
+      Runtime single-owner service control now follows `/run/router-ha/role`
+      via Keepalived notify hooks; keep this option only as a compatibility shim
+      until remaining consumer docs and callers are retired.
     '';
   };
 


### PR DESCRIPTION
## **User description**
## Summary
- move LAN single-owner services to router-ha runtime ownership
- gate DHCP, DHCP-DDNS, NTP, UPnP, and DDNS with runtime master ExecConditions
- add an HA-owned IPv6 RA unit that toggles a networkd drop-in on promotion/demotion
- update router failover docs to describe the runtime ownership model

## Validation
- nix build --no-link /tmp/unified-nix-router-lan-service-failover#nixosConfigurations.router.config.system.build.toplevel
- nix build --no-link /tmp/unified-nix-router-lan-service-failover#nixosConfigurations.router-backup.config.system.build.toplevel

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Migrated single-owner service gating from a static `router.failover.activeOwner` configuration option to a dynamic runtime state based on `/run/router-ha/role`.</li>
<li>Updated systemd services (DHCP, DDNS, NTP, UPnP, IPv6 RA) to use `ExecCondition` for runtime role verification, ensuring only the active HA node runs these services.</li>
<li>Added a new `router-ipv6-ra-owner` systemd service to dynamically manage IPv6 Router Advertisement ownership via networkd drop-in files.</li>
<li>Retained `router.failover.activeOwner` as a legacy compatibility shim in `modules/nixos/router/common.nix`.</li>
<li>Updated documentation to reflect the shift from static configuration to HA runtime state for service ownership.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Move router single-owner services to HA runtime role**

### What Changed
- The promoted router now controls LAN DHCP, DHCP-DNS updates, NTP, UPnP/NAT-PMP, public DDNS, and IPv6 router advertisements at runtime.
- Standby routers still keep the shared services available, but they no longer answer as the active owner unless the HA role says so.
- IPv6 router advertisements now switch on promotion and off on demotion without relying on the old static ownership setting.
- The old `router.failover.activeOwner` setting is now a compatibility fallback and is no longer the live service gate.

### Impact
`✅ Fewer split-brain LAN services`
`✅ Cleaner router failover`
`✅ Fewer duplicate DHCP, NTP, and UPnP responses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
