### PR TITLE
fix(router): validate HA standby Suricata path

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782629304,
-        "narHash": "sha256-SQ9uv31vNt0ACtcxwiACmbsP/Dz114qHa3rTN0JTYf0=",
+        "lastModified": 1782776943,
+        "narHash": "sha256-a203ONEJ5r3tYhAEd5J1YRWfEWoQv3mMTqaoY2KV8B8=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "cfee93156f8c7edc691c8b8f5fd782a351451ac0",
+        "rev": "3e156d0f7e5150b553a5cdcf012abdb0104b3784",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782776943,
-        "narHash": "sha256-a203ONEJ5r3tYhAEd5J1YRWfEWoQv3mMTqaoY2KV8B8=",
+        "lastModified": 1782871081,
+        "narHash": "sha256-jyu800T8gDtk7FBHIC689YrSFR+oZ0ewQDt+/+04qk4=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "3e156d0f7e5150b553a5cdcf012abdb0104b3784",
+        "rev": "81def16d760618fce602b960a81a04891e2dd2ec",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782871081,
+        "lastModified": 1782897547,
         "narHash": "sha256-jyu800T8gDtk7FBHIC689YrSFR+oZ0ewQDt+/+04qk4=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "81def16d760618fce602b960a81a04891e2dd2ec",
+        "rev": "ab4b524b7c05511816669495e088c9f4a329686f",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -103,6 +103,8 @@ in
     ];
   };
 
+  services.router-network-security.interfaces = lib.mkForce [ "ens19" ];
+
   # Current Proxmox wiring:
   #   ens18 -> management virtio
   #   ens19 -> LAN virtio

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -446,6 +446,10 @@ in
 
   services.router-network-security = {
     enable = true;
+    interfaces = [
+      lanDevice
+      wanDevice
+    ];
     suricata = {
       enable = true;
       evebox.enable = true;


### PR DESCRIPTION
## Summary
- bump nix-router-optimized to the standby-safe Suricata branch revision
- keep backup-only HA validation on router-backup in test mode
- narrow Suricata capture interfaces so router-backup runs only on ens19 while its WAN path is absent

## Validation
- nixos-rebuild test --flake /home/deepwatrcreatur/flakes-worktrees/unified-nix-configuration/main#router-backup --target-host root@192.168.100.99 --option use-cgroups false
- verified on router-backup after test switch:
  - /run/router-ha/role = backup
  - keepalived active
  - kea-dhcp4-server/inadyn/miniupnpd inactive
  - suricata active
  - suricata-update.timer active