### PR TITLE
fix(router-dashboard): avoid standby Kea snapshot churn

### DIFF
--- a/modules/nixos/router-dashboard-runtime-repair.nix
+++ b/modules/nixos/router-dashboard-runtime-repair.nix
@@ -91,8 +91,6 @@ in
 
     systemd.services.router-dashboard-kea-lease-snapshot = lib.mkIf config.services.kea.dhcp4.enable {
       description = "Refresh router dashboard Kea lease snapshot";
-      after = [ "kea-dhcp4-server.service" ];
-      wants = [ "kea-dhcp4-server.service" ];
       serviceConfig = {
         Type = "oneshot";
         User = "root";


### PR DESCRIPTION
## **User description**
## Summary
- remove the dashboard Kea snapshot unit's dependency on kea-dhcp4-server
- stop the standby backup router from nudging Kea every 30 seconds via the snapshot timer
- keep lease snapshot refresh working from on-disk lease files without requiring the DHCP service to start

## Validation
- nix build --no-link .#nixosConfigurations.router-backup.config.system.build.toplevel
- nix build --no-link .#nixosConfigurations.router.config.system.build.toplevel
- nixos-rebuild test --flake .#router-backup --target-host root@192.168.100.99 --option use-cgroups false
- verified on router-backup that journalctl -u kea-dhcp4-server --since "2026-07-01 05:59:00" returns no new entries while the snapshot timer continues to run

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Removed 'after' and 'wants' dependencies on 'kea-dhcp4-server.service' from the 'router-dashboard-kea-lease-snapshot' systemd service.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Keep the router dashboard Kea lease snapshot from waking the DHCP service**

### What Changed
- The Kea lease snapshot now runs without waiting for or starting the DHCP service.
- Standby routers can keep refreshing lease data from disk without triggering extra Kea activity.

### Impact
`✅ Fewer unwanted DHCP service starts`
`✅ Lower standby router churn`
`✅ Steadier lease snapshot refreshes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
