### PR TITLE
fix(router): make DDNS timer fully HA-owned

### DIFF
--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -187,7 +187,10 @@ in
     role = if isPrimaryRouter then "master" else "backup";
     virtualIp = "10.10.10.1/16";
     vrrpInterface = lanDevice;
-    singleActiveUnits = [ "inadyn.service" ];
+    singleActiveUnits = [
+      "inadyn.service"
+      "inadyn.timer"
+    ];
     keaSync.enable = isPrimaryRouter;
     keaSync.peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
     wan = {
@@ -277,10 +280,12 @@ in
   systemd.services.inadyn = {
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];
+    wantedBy = lib.mkForce [ ];
     serviceConfig.ExecCondition = lib.mkBefore [
       "${pkgs.runtimeShell} -c '[ \"$(cat /run/router-ha/role 2>/dev/null || true)\" = master ]'"
     ];
   };
+  systemd.timers.inadyn.wantedBy = lib.mkForce [ ];
   systemd.services.kea-dhcp4-server.serviceConfig.ExecCondition = lib.mkBefore [
     "${pkgs.runtimeShell} -c '${if activeOwner then "exit 0" else "exit 1"}'"
   ];


### PR DESCRIPTION
## **User description**
## Summary
- make both inadyn.service and inadyn.timer fully HA-owned instead of boot-enabled on both routers
- stop standby backup routers from waking inadyn every 5 minutes just to hit ExecCondition
- keep the service-level ExecCondition as a defense-in-depth guard

## Validation
- nix build --no-link .#nixosConfigurations.router-backup.config.system.build.toplevel
- nix build --no-link .#nixosConfigurations.router.config.system.build.toplevel
- nixos-rebuild test --flake .#router-backup --target-host root@192.168.100.99 --option use-cgroups false
- verified on router-backup that inadyn.timer and inadyn.service are both inactive on standby and journalctl -u inadyn.service --since "2026-07-02 09:36:00" returns no entries

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added inadyn.timer to the list of singleActiveUnits to ensure the timer is managed alongside the service in high-availability mode.</li>
<li>Disabled automatic activation of the inadyn service and timer by setting wantedBy to an empty list using lib.mkForce.</li>
<li>Maintained the existing ExecCondition for the inadyn service to ensure it only runs on the master router.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Keep DDNS updates under active router control**

### What Changed
- The DDNS timer now stays tied to the active router instead of starting on both nodes
- Backup routers no longer wake the DDNS service every few minutes just to be blocked
- The DDNS service still checks that only the master router is allowed to run it

### Impact
`✅ Fewer background wakeups on standby routers`
`✅ Less wasted DDNS polling on backup nodes`
`✅ Cleaner failover behavior for router DNS updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router high-availability failover behavior so dynamic DNS updates only run on the active master node.
  * Prevented the update timer from being started unintentionally during role changes, reducing duplicate or conflicting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->