### PR TITLE
fix(router): keep Chrony on the backup router

### DIFF
--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -270,9 +270,10 @@ in
     internalIPs = [ lanDevice ];
   };
 
-  # The shared router profile advertises one LAN-facing NTP identity via DHCP
-  # option 42, so only the active owner should actually serve that identity.
-  services.router-ntp.enable = activeOwner;
+  # Keep Chrony available on both router nodes. Upstream explicitly leaves NTP
+  # ownership as consumer policy, and this deployment wants standby time sync
+  # continuity rather than a single-owner Chrony model.
+  services.router-ntp.enable = true;
 
   systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [
     "+${ensureKeaLeaseState}"


### PR DESCRIPTION
## **User description**
## Summary
- keep services.router-ntp enabled on both router nodes instead of gating it on the legacy activeOwner flag
- align the consumer policy with the upstream HA ownership boundary that leaves NTP as consumer-owned policy
- remove the standby fallback to systemd-timesyncd so router-backup keeps Chrony available

## Validation
- nix build --no-link .#nixosConfigurations.router-backup.config.system.build.toplevel
- nix build --no-link .#nixosConfigurations.router.config.system.build.toplevel
- nixos-rebuild test --flake .#router-backup --target-host root@192.168.100.99 --option use-cgroups false
- verified on router-backup that systemd-timesyncd is removed, chronyd.service is installed, and systemctl start chronyd succeeds with chronyc tracking output

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Enabled NTP service (Chrony) on both router nodes instead of restricting it to the active owner.</li>
<li>Updated configuration to support standby time synchronization continuity.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Keep Chrony running on the backup router**

### What Changed
- The backup router now keeps Chrony enabled instead of turning NTP service off when it is not the active router.
- Time synchronization stays available on standby, so the backup router can maintain current time before it takes over.
- The router no longer falls back to a different time-sync setup when role changes happen.

### Impact
`✅ Fewer time drift issues on standby routers`
`✅ Faster failover with valid time sync already in place`
`✅ More reliable router takeover behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
