### PR TITLE
docs(router): update consumer failover guidance

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -82,10 +82,10 @@ den/inventory/hosts.nix          ← entry point
 | NAT policy | `hosts/nixos/router/service-capability.nix` | `networking.nat.enable = false`; nftables handles NAT in role.nix |
 | Disk layout (router) | `hosts/nixos/router/disko.nix` | Hardware-adjacent; keep separate |
 | Disk layout (backup) | `hosts/nixos/router-backup/disko.nix` | Imported by `configuration.nix`; hardware-adjacent, keep separate |
-| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public DDNS ownership is gated by `router.failover.activeOwner` |
+| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public ingress works with VRRP/WAN ownership and DDNS execution now follows HA-owned `inadyn` units rather than a static `activeOwner` toggle |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
-| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; currently gates public DDNS ownership, `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup, `services.router-upnp.enable`, and `services.router-ntp.enable` in the consumer tree |
+| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; still gates `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup and `services.router-upnp.enable`, but no longer owns DDNS timer/service execution or router NTP policy |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -109,17 +109,34 @@ den/inventory/hosts.nix          ← entry point
   it in both `router` and `router-backup` `aspectsList` entries in
   `den/inventory/hosts.nix`.
 
+## Current Consumer Failover Shape
+
+The currently validated consumer failover split is:
+
+- **VRRP / Keepalived owned**
+  - LAN VIP and WAN ownership through `services.router-ha`
+  - DDNS execution through `services.router-ha.singleActiveUnits = [ "inadyn.service" "inadyn.timer" ]`
+- **Shared on both nodes**
+  - `services.router-ntp.enable = true` so Chrony stays available on the backup
+  - Suricata and EveBox, which remain useful on standby without claiming
+    single-owner semantics
+- **Still single-active / consumer-gated**
+  - `kea-dhcp4-server`
+  - `kea-dhcp-ddns-server`
+  - `services.router-upnp.enable`
+
+This is the working reference shape today. It is intentionally narrower than
+"every important service follows VRRP automatically."
+
 ## Current `activeOwner` Consumers
 
 `router.failover.activeOwner` currently has a narrow, explicit consumer-side
 meaning:
 
-- in `hosts/nixos/router/caddy.nix`, it gates public Cloudflare DDNS ownership
 - in `hosts/nixos/router/role.nix`, it gates `kea-dhcp4-server.service` startup
 - in `hosts/nixos/router/role.nix`, it gates `kea-dhcp-ddns-server.service`
   startup
 - in `hosts/nixos/router/role.nix`, it gates `services.router-upnp.enable`
-- in `hosts/nixos/router/role.nix`, it gates `services.router-ntp.enable`
 
 That is the current supported single-owner boundary in this tree. Other
 router-facing services may still be present on both nodes, but they should not

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -1,7 +1,7 @@
 # Router Spare Cutover
 
-`router` and `router-backup` are separate management nodes, but they share the
-same production router identity.
+`router` and `router-backup` are separate management nodes that now participate
+in a shared VRRP-based router identity.
 
 ## Management
 
@@ -12,22 +12,27 @@ same production router identity.
 
 ## Production Identity
 
-- both router hosts are configured with the same production LAN address:
-  `10.10.10.1/16`
-- this is safe only because only one machine should be physically connected to
-  the production WAN/LAN ports at a time
-- do not leave both machines cabled to the production LAN while both claim
-  `10.10.10.1`
+- the shared LAN VIP is `10.10.10.1/16`
+- `router` and `router-backup` each also keep their own stable node address on
+  the LAN
+- VRRP/Keepalived decides which node currently owns the VIP and WAN-side active
+  role
+- both nodes can stay cabled to the production LAN when the HA pair is healthy;
+  the safety rule is that only one node should own the active role at a time
 
 ## Promotion
 
-To promote `router-backup` after a failure or bad rebuild:
+To recover with `router-backup` after a failure or bad rebuild:
 
-1. Confirm `router` is out of service.
-2. Power down or isolate `router` from the production WAN/LAN NICs.
-3. Move the WAN cable to `router-backup`.
-4. Move the LAN cable to `router-backup`.
-5. Verify clients can reach `10.10.10.1`, resolve DNS, and reach the internet.
+1. Confirm `router` is out of service or should no longer be the active node.
+2. Verify `router-backup` still has management reachability.
+3. Confirm VRRP/WAN ownership, not just service state:
+   - `/run/router-ha/role`
+   - `systemctl status keepalived`
+4. Verify the production identity is present on the promoted node:
+   - the LAN VIP answers
+   - WAN ownership and public ingress behave as expected
+5. Verify client-facing services that are supposed to move or remain shared.
 
 ### Current config note
 
@@ -35,17 +40,20 @@ To promote `router-backup` after a failure or bad rebuild:
   public identity. It currently defaults to `true` on `router` and `false` on
   `router-backup`.
 - Today that switch gates:
-  - Caddy's public DDNS ownership
   - `kea-dhcp4-server.service`
   - `kea-dhcp-ddns-server.service`
   - `services.router-upnp.enable`
-  - `services.router-ntp.enable`
-  so both nodes can keep shared capability while only the active owner answers
-  LAN DHCP, advertises UPnP/NAT-PMP mappings, serves the advertised LAN NTP
-  identity, or updates public DNS identity.
-- More failover-sensitive ownership should move behind this same boundary as
-  the HA refactor continues. That next step is now tracked explicitly in
-  work item `75-consumer-active-owner-service-boundary-and-expansion`.
+  so only the configured active owner answers LAN DHCP or advertises
+  UPnP/NAT-PMP mappings.
+- DDNS execution no longer hangs off `activeOwner` directly. The current
+  consumer tree hands `inadyn.service` and `inadyn.timer` to
+  `services.router-ha.singleActiveUnits`, so DDNS follows VRRP promotion.
+- `services.router-ntp.enable = true` on both nodes. Chrony is intentionally
+  shared rather than single-owner in the current deployment.
+- This means the current failover split is:
+  - VRRP/WAN/DDNS: promotion-aware
+  - Chrony and some observability: shared on both nodes
+  - DHCP and UPnP: still explicit single-owner policy in the consumer config
 
 ## Technitium
 
@@ -75,8 +83,8 @@ Use Technitium clustering only for DNS/admin-state sync between `router` and
 
 - DHCP scope replication
 - DHCP lease-state failover
-- default-gateway failover
-- WAN ownership
+- automatic DHCP ownership transfer
+- WAN ownership beyond what VRRP/Keepalived is already configured to do
 
 ### Standby Checklist
 
@@ -92,5 +100,6 @@ After enabling clustering, still verify the standby router manually:
 When a router is used as a spare or dev box:
 
 - the management IP on the virtio interface stays reachable even with WAN/LAN unplugged
-- the production LAN IP (`10.10.10.1/16`) remains configured without carrier so dashboard and monitoring can start in a degraded state
+- the shared production identity is the VRRP VIP plus per-node LAN addresses,
+  not two identical static host addresses
 - LAN/WAN-dependent checks are expected to show degraded or failed until cables are reattached


### PR DESCRIPTION
## **User description**
## Summary
- update the consumer source-of-truth doc to reflect the current VRRP/DDNS/shared-Chrony split
- remove stale claims that DDNS and router-ntp are still gated by activeOwner
- rewrite the spare-cutover note so it matches the current VRRP/VIP topology instead of the old cable-swap/static-IP model

## Validation
- docs-only change
- guidance matches the currently validated router-backup failover behavior


___

## **CodeAnt-AI Description**
**Update router failover guidance to match the current VRRP-based setup**

### What Changed
- Rewrites the spare cutover steps around VRRP and the shared LAN VIP instead of the old cable-swap/static-IP approach
- Clarifies that both router nodes can stay connected, while only one should own the active role at a time
- Updates the source-of-truth notes to show the current split: DDNS follows VRRP promotion, Chrony stays shared on both nodes, and DHCP/UPnP remain single-owner
- Removes stale guidance that treated DDNS and router NTP as part of the `activeOwner` boundary

### Impact
`✅ Clearer router failover steps`
`✅ Fewer mistakes during spare promotion`
`✅ More accurate backup-router runbook`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
