### PR TITLE
docs(router): soften failover unit-name assumptions

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -115,7 +115,9 @@ The currently validated consumer failover split is:
 
 - **VRRP / Keepalived owned**
   - LAN VIP and WAN ownership through `services.router-ha`
-  - DDNS execution through `services.router-ha.singleActiveUnits = [ "inadyn.service" "inadyn.timer" ]`
+  - DDNS execution through `services.router-ha.singleActiveUnits`, always
+    including `inadyn.service` and including any matching inadyn timer unit
+    only if the evaluated system actually exposes it under that name
 - **Shared on both nodes**
   - `services.router-ntp.enable = true` so Chrony stays available on the backup
   - Suricata and EveBox, which remain useful on standby without claiming

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -46,8 +46,10 @@ To recover with `router-backup` after a failure or bad rebuild:
   so only the configured active owner answers LAN DHCP or advertises
   UPnP/NAT-PMP mappings.
 - DDNS execution no longer hangs off `activeOwner` directly. The current
-  consumer tree hands `inadyn.service` and `inadyn.timer` to
-  `services.router-ha.singleActiveUnits`, so DDNS follows VRRP promotion.
+  consumer tree hands `inadyn.service` to
+  `services.router-ha.singleActiveUnits`, and adds any corresponding inadyn
+  timer unit only when the evaluated system exposes that unit name, so DDNS
+  follows VRRP promotion without assuming a timer name that may not exist.
 - `services.router-ntp.enable = true` on both nodes. Chrony is intentionally
   shared rather than single-owner in the current deployment.
 - This means the current failover split is:


### PR DESCRIPTION
## **User description**
## Summary
- align consumer failover docs with the upstream router-ha ownership boundary
- document inadyn.service as the guaranteed HA-owned DDNS unit
- note that timer units should only be added to singleActiveUnits if the evaluated system exposes them under that name

## Testing
- not run (docs only)


___

## **CodeAnt-AI Description**
Clarify which DDNS units are covered during router failover

### What Changed
- The failover docs now say `inadyn.service` is always handled during VRRP promotion
- The docs no longer assume a fixed `inadyn.timer` name; the timer is only included when that unit exists on the evaluated system
- The validated failover split section was updated to match this narrower unit-name rule

### Impact
`✅ Fewer incorrect failover setup assumptions`
`✅ Clearer router HA documentation`
`✅ Less confusion when DDNS timer names differ`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
