### PR TITLE
feat(router): move LAN failover to runtime HA role

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -85,7 +85,7 @@ den/inventory/hosts.nix          ← entry point
 | Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public ingress works with VRRP/WAN ownership and DDNS execution now follows HA-owned `inadyn` units rather than a static `activeOwner` toggle |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
-| Active single-owner identity | `modules/nixos/router/common.nix` via `router.failover.activeOwner` | Defaults to `true` on `router`, `false` on `router-backup`; still gates `kea-dhcp4-server` / `kea-dhcp-ddns-server` startup and `services.router-upnp.enable`, but no longer owns DDNS timer/service execution or router NTP policy |
+| Runtime single-owner LAN services | `hosts/nixos/router/role.nix` via `services.router-ha.singleActiveUnits` and `/run/router-ha/role` | The promoted node owns DDNS, DHCP, UPnP, and IPv6 RA runtime units; Chrony remains shared |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -97,8 +97,8 @@ den/inventory/hosts.nix          ← entry point
 
 - **DNS / NTP shared capability**: `hosts/nixos/router/service-capability.nix`.
 - **Primary hostname / domain defaults**: `hosts/nixos/router/networking.nix`.
-- **Active single-owner identity / DHCP ownership**: `modules/nixos/router/common.nix` via
-  `router.failover.activeOwner`.
+- **Runtime single-owner LAN services**: `hosts/nixos/router/role.nix` via
+  `services.router-ha.singleActiveUnits` and `/run/router-ha/role`.
 - **Firewall / NAT / observability / VPN**: tune options provided by
   `nix-router-optimized` modules; the entry point is `den/aspects/router-router.nix`.
 - **Caddy virtualHosts, ACME, DDNS**: `hosts/nixos/router/caddy.nix`.
@@ -118,31 +118,26 @@ The currently validated consumer failover split is:
   - DDNS execution through `services.router-ha.singleActiveUnits`, always
     including `inadyn.service` and including any matching inadyn timer unit
     only if the evaluated system actually exposes it under that name
+  - DHCP, UPnP, and IPv6 RA runtime ownership through the same
+    `singleActiveUnits` boundary
 - **Shared on both nodes**
   - `services.router-ntp.enable = true` so Chrony stays available on the backup
   - Suricata and EveBox, which remain useful on standby without claiming
     single-owner semantics
-- **Still single-active / consumer-gated**
-  - `kea-dhcp4-server`
-  - `kea-dhcp-ddns-server`
-  - `services.router-upnp.enable`
 
-This is the working reference shape today. It is intentionally narrower than
-"every important service follows VRRP automatically."
+This is the working reference shape today. It is still narrower than
+"every important service follows VRRP automatically" because Chrony and other
+shared observability services remain intentionally outside the single-owner
+boundary.
 
 ## Current `activeOwner` Consumers
 
-`router.failover.activeOwner` currently has a narrow, explicit consumer-side
-meaning:
+`router.failover.activeOwner` is now a legacy static hint, not the live
+ownership switch for DDNS, DHCP, UPnP, or IPv6 RA. Those services follow the
+runtime HA role file and `services.router-ha.singleActiveUnits` instead.
 
-- in `hosts/nixos/router/role.nix`, it gates `kea-dhcp4-server.service` startup
-- in `hosts/nixos/router/role.nix`, it gates `kea-dhcp-ddns-server.service`
-  startup
-- in `hosts/nixos/router/role.nix`, it gates `services.router-upnp.enable`
-
-That is the current supported single-owner boundary in this tree. Other
-router-facing services may still be present on both nodes, but they should not
-be described as `activeOwner`-governed unless they are wired explicitly.
+If future consumer code still uses `activeOwner`, that should be treated as an
+explicit compatibility choice rather than the default HA mechanism.
 
 The next consumer-side HA follow-up is tracked as
 `nix-router-optimized/docs/work-items/75-consumer-active-owner-service-boundary-and-expansion.md`.

--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -115,9 +115,8 @@ The currently validated consumer failover split is:
 
 - **VRRP / Keepalived owned**
   - LAN VIP and WAN ownership through `services.router-ha`
-  - DDNS execution through `services.router-ha.singleActiveUnits`, always
-    including `inadyn.service` and including any matching inadyn timer unit
-    only if the evaluated system actually exposes it under that name
+  - DDNS execution through `services.router-ha.singleActiveUnits`, currently
+    using `inadyn.service` in this consumer tree
   - DHCP, UPnP, and IPv6 RA runtime ownership through the same
     `singleActiveUnits` boundary
 - **Shared on both nodes**

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -36,26 +36,25 @@ To recover with `router-backup` after a failure or bad rebuild:
 
 ### Current config note
 
-- `router.failover.activeOwner` is the consumer-tree switch for single-owner
-  public identity. It currently defaults to `true` on `router` and `false` on
-  `router-backup`.
-- Today that switch gates:
-  - `kea-dhcp4-server.service`
-  - `kea-dhcp-ddns-server.service`
-  - `services.router-upnp.enable`
-  so only the configured active owner answers LAN DHCP or advertises
-  UPnP/NAT-PMP mappings.
+- `router.failover.activeOwner` is now only a legacy static hint for the
+  preferred node, not the live service-promotion switch.
 - DDNS execution no longer hangs off `activeOwner` directly. The current
   consumer tree hands `inadyn.service` to
   `services.router-ha.singleActiveUnits`, and adds any corresponding inadyn
   timer unit only when the evaluated system exposes that unit name, so DDNS
   follows VRRP promotion without assuming a timer name that may not exist.
+- The same runtime HA boundary now owns:
+  - `kea-dhcp4-server.service`
+  - `kea-dhcp-ddns-server.service`
+  - `miniupnpd.service`
+  - `router-ipv6-ra-owner.service`
+  so the promoted node answers LAN DHCP, advertises UPnP/NAT-PMP mappings, and
+  emits IPv6 RAs without needing a separate static owner flag.
 - `services.router-ntp.enable = true` on both nodes. Chrony is intentionally
   shared rather than single-owner in the current deployment.
 - This means the current failover split is:
-  - VRRP/WAN/DDNS: promotion-aware
+  - VRRP/WAN/DDNS/DHCP/UPnP/IPv6 RA: promotion-aware
   - Chrony and some observability: shared on both nodes
-  - DHCP and UPnP: still explicit single-owner policy in the consumer config
 
 ## Technitium
 

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -40,9 +40,8 @@ To recover with `router-backup` after a failure or bad rebuild:
   preferred node, not the live service-promotion switch.
 - DDNS execution no longer hangs off `activeOwner` directly. The current
   consumer tree hands `inadyn.service` to
-  `services.router-ha.singleActiveUnits`, and adds any corresponding inadyn
-  timer unit only when the evaluated system exposes that unit name, so DDNS
-  follows VRRP promotion without assuming a timer name that may not exist.
+  `services.router-ha.singleActiveUnits`, so DDNS follows VRRP promotion via
+  the active node without depending on a separate systemd timer unit.
 - The same runtime HA boundary now owns:
   - `kea-dhcp4-server.service`
   - `kea-dhcp-ddns-server.service`

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -86,7 +86,36 @@ let
   managementNetwork = topology.networks.management;
   mkFqdn = label: "${label}.${topology.domain}";
   isPrimaryRouter = config.networking.hostName == "router";
-  activeOwner = config.router.failover.activeOwner;
+  routerHaRoleFile = "/run/router-ha/role";
+  masterExecCondition =
+    "${pkgs.runtimeShell} -c '[ \"$(cat ${routerHaRoleFile} 2>/dev/null || true)\" = master ]'";
+  singleActiveLanUnits =
+    [
+      "inadyn.service"
+      "kea-dhcp4-server.service"
+      "kea-dhcp-ddns-server.service"
+      "miniupnpd.service"
+      "router-ipv6-ra-owner.service"
+    ]
+    ++ lib.optional (config.systemd.timers ? inadyn) "inadyn.timer";
+  ipv6RaOwnerDropInDir = "/run/systemd/network/08-router-parent-${lanDevice}.network.d";
+  ipv6RaOwnerDropIn = "${ipv6RaOwnerDropInDir}/90-router-ha-ra.conf";
+  enableIpv6RaOwner = pkgs.writeShellScript "router-ipv6-ra-owner-enable" ''
+    set -euo pipefail
+    install -d -m 0755 ${lib.escapeShellArg ipv6RaOwnerDropInDir}
+    cat > ${lib.escapeShellArg ipv6RaOwnerDropIn} <<'EOF'
+    [Network]
+    IPv6SendRA=true
+    EOF
+    ${pkgs.systemd}/bin/networkctl reload
+    ${pkgs.systemd}/bin/networkctl reconfigure ${lib.escapeShellArg lanDevice}
+  '';
+  disableIpv6RaOwner = pkgs.writeShellScript "router-ipv6-ra-owner-disable" ''
+    set -euo pipefail
+    rm -f ${lib.escapeShellArg ipv6RaOwnerDropIn}
+    ${pkgs.systemd}/bin/networkctl reload
+    ${pkgs.systemd}/bin/networkctl reconfigure ${lib.escapeShellArg lanDevice}
+  '';
   # Static LAN IP assigned to this router node, distinct from the shared VIP.
   staticLanIp = builtins.head (lib.splitString "/" lanIpv4Address);
   reservableHosts = lib.filterAttrs (
@@ -187,10 +216,7 @@ in
     role = if isPrimaryRouter then "master" else "backup";
     virtualIp = "10.10.10.1/16";
     vrrpInterface = lanDevice;
-    singleActiveUnits = [
-      "inadyn.service"
-      "inadyn.timer"
-    ];
+    singleActiveUnits = singleActiveLanUnits;
     keaSync.enable = isPrimaryRouter;
     keaSync.peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
     wan = {
@@ -263,9 +289,9 @@ in
 
   services.router-upnp = {
     # Bind miniupnpd to explicit interface names so the generated config does
-    # not fall back to invalid address-based guesses. Only the active owner
-    # should advertise LAN-side UPnP/NAT-PMP mappings.
-    enable = activeOwner;
+    # not fall back to invalid address-based guesses. router-ha owns the
+    # active runtime instance so only the promoted node advertises mappings.
+    enable = true;
     externalInterface = wanDevice;
     internalIPs = [ lanDevice ];
   };
@@ -283,16 +309,39 @@ in
     requires = [ "router-ha-initial-role-state.service" ];
     wantedBy = lib.mkForce [ ];
     serviceConfig.ExecCondition = lib.mkBefore [
-      "${pkgs.runtimeShell} -c '[ \"$(cat /run/router-ha/role 2>/dev/null || true)\" = master ]'"
+      masterExecCondition
     ];
   };
   systemd.timers.inadyn.wantedBy = lib.mkForce [ ];
+  systemd.services.miniupnpd = {
+    after = [ "router-ha-initial-role-state.service" ];
+    requires = [ "router-ha-initial-role-state.service" ];
+    serviceConfig.ExecCondition = lib.mkBefore [
+      masterExecCondition
+    ];
+  };
+  systemd.services.router-ipv6-ra-owner = {
+    description = "Apply IPv6 RA ownership to the active router";
+    after = [ "router-ha-initial-role-state.service" ];
+    requires = [ "router-ha-initial-role-state.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecCondition = [ masterExecCondition ];
+      ExecStart = [ "+${enableIpv6RaOwner}" ];
+      ExecStop = [ "+${disableIpv6RaOwner}" ];
+    };
+  };
   systemd.services.kea-dhcp4-server.serviceConfig.ExecCondition = lib.mkBefore [
-    "${pkgs.runtimeShell} -c '${if activeOwner then "exit 0" else "exit 1"}'"
+    masterExecCondition
   ];
   systemd.services.kea-dhcp-ddns-server.serviceConfig.ExecCondition = lib.mkBefore [
-    "${pkgs.runtimeShell} -c '${if activeOwner then "exit 0" else "exit 1"}'"
+    masterExecCondition
   ];
+  systemd.services.kea-dhcp4-server.after = [ "router-ha-initial-role-state.service" ];
+  systemd.services.kea-dhcp4-server.requires = [ "router-ha-initial-role-state.service" ];
+  systemd.services.kea-dhcp-ddns-server.after = [ "router-ha-initial-role-state.service" ];
+  systemd.services.kea-dhcp-ddns-server.requires = [ "router-ha-initial-role-state.service" ];
 
   services.router-networking = {
     enable = true;
@@ -871,15 +920,15 @@ in
       DNS = [ "127.0.0.1" ];
       Domains = [ topology.domain ];
       IPv6PrivacyExtensions = "no";
-      IPv6SendRA = activeOwner;
+      IPv6SendRA = false;
     };
     linkConfig.RequiredForOnline = lib.mkForce "routable";
-    ipv6SendRAConfig = lib.mkIf activeOwner {
+    ipv6SendRAConfig = {
       EmitDNS = true;
       Managed = false;
       OtherInformation = false;
     };
-    ipv6Prefixes = lib.mkIf activeOwner [
+    ipv6Prefixes = [
       {
         Prefix = "::/64";
         PreferredLifetimeSec = 1800;

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -96,8 +96,7 @@ let
       "kea-dhcp-ddns-server.service"
       "miniupnpd.service"
       "router-ipv6-ra-owner.service"
-    ]
-    ++ lib.optional (config.systemd.timers ? inadyn) "inadyn.timer";
+    ];
   ipv6RaOwnerDropInDir = "/run/systemd/network/08-router-parent-${lanDevice}.network.d";
   ipv6RaOwnerDropIn = "${ipv6RaOwnerDropInDir}/90-router-ha-ra.conf";
   enableIpv6RaOwner = pkgs.writeShellScript "router-ipv6-ra-owner-enable" ''
@@ -312,7 +311,6 @@ in
       masterExecCondition
     ];
   };
-  systemd.timers.inadyn.wantedBy = lib.mkForce [ ];
   systemd.services.miniupnpd = {
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -32,16 +32,17 @@ in
   };
 
   services.router-ntp = {
-    # Shared capability belongs here, but the consumer-side role owns the final
-    # single-owner gate via router.failover.activeOwner.
+    # Shared capability belongs here. The consumer-side role currently keeps
+    # Chrony available on both nodes rather than placing it behind runtime HA
+    # ownership.
     enable = lib.mkDefault true;
     lanSubnets = [ topology.networks.lan.cidr ];
   };
 
   # UPnP/NAT-PMP should remain available on whichever router currently owns
   # the LAN path so failover does not silently drop port mapping support.
-  # Shared capability belongs here, but the consumer-side role owns the final
-  # single-owner gate via router.failover.activeOwner.
+  # Shared capability belongs here; the consumer-side role now hands the live
+  # miniupnpd unit to router-ha runtime ownership.
   services.router-upnp.enable = lib.mkDefault true;
 
   # NAT is handled by nftables (see role.nix).

--- a/modules/nixos/router/common.nix
+++ b/modules/nixos/router/common.nix
@@ -14,9 +14,9 @@ in
   options.router.failover.activeOwner = lib.mkOption {
     type = lib.types.bool;
     description = ''
-      Whether this node should currently own the production router identity.
-      Shared service capability can exist on both routers, but only the active
-      owner should advertise or update single-owner identity such as public DDNS.
+      Legacy static hint for which node is expected to be the preferred router.
+      Runtime failover behavior should follow `services.router-ha` ownership
+      instead of assuming this flag controls live service promotion.
     '';
   };
 


### PR DESCRIPTION
## **User description**
## Summary
- move DHCP, UPnP, and IPv6 RA ownership behind the runtime router-ha role
- keep Chrony shared while treating activeOwner as a legacy static hint
- update consumer failover docs to match the new runtime ownership boundary

## Testing
- nix build --no-link /tmp/unified-nix-runtime-lan-failover-2#nixosConfigurations.router.config.system.build.toplevel
- nix build --no-link /tmp/unified-nix-runtime-lan-failover-2#nixosConfigurations.router-backup.config.system.build.toplevel

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Migrated DHCP, UPnP, and IPv6 RA services from static `activeOwner` gating to dynamic runtime HA ownership via `services.router-ha`.</li>
<li>Deprecated `router.failover.activeOwner` as a live service-promotion switch, reclassifying it as a legacy static preference hint.</li>
<li>Implemented a new `router-ipv6-ra-owner` systemd service to dynamically manage IPv6 RA configuration on the active router node.</li>
<li>Updated systemd service definitions to ensure DHCP and UPnP services depend on the runtime HA role state.</li>
<li>Refactored documentation to reflect the shift from static configuration-based failover to runtime-based service promotion.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit HA-controlled ownership for promoted-node IPv6 RA, activating only when the node is in the master role.
* **Behavior Changes**
  * Updated HA ownership so promoted-node LAN services (DDNS, DHCP, UPnP/related NAT-PMP behavior, and IPv6 RA) follow the runtime HA role boundary rather than the legacy switch.
  * Kept Chrony and select observability services shared on both nodes during failover.
* **Documentation**
  * Reworked router HA docs and cutover guidance to describe runtime ownership, and clarified that the legacy `activeOwner` setting is a static hint, not the live failover switch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Move LAN failover services to runtime router ownership**

### What Changed
- DHCP, UPnP/NAT-PMP, and IPv6 router advertisements now follow the router’s live HA role during failover instead of relying on a static preferred-owner setting
- The backup router keeps shared Chrony service available, while the promoted router takes over LAN-facing services
- DDNS now starts with the active router without depending on a separate timer name
- Router failover docs now describe the new runtime ownership split and mark `router.failover.activeOwner` as a legacy hint

### Impact
`✅ Fewer LAN service drops during router failover`
`✅ Consistent DHCP, UPnP, and IPv6 RA on the promoted router`
`✅ Clearer router failover behavior for operators`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
