### PR TITLE
feat(router): enable sip-friendly firewall flowtable preset

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1410,11 +1410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782897547,
-        "narHash": "sha256-jyu800T8gDtk7FBHIC689YrSFR+oZ0ewQDt+/+04qk4=",
+        "lastModified": 1783300444,
+        "narHash": "sha256-eL2VSfdJVuUpRLEfkNBerU1JZR2wjVFLCINEu5oZ+Oo=",
         "owner": "deepwatrcreatur",
         "repo": "nix-router-optimized",
-        "rev": "ab4b524b7c05511816669495e088c9f4a329686f",
+        "rev": "e2d9137dad84dab1229aaeff7665e9135c2559a8",
         "type": "github"
       },
       "original": {

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -488,6 +488,7 @@ in
       443
     ];
     hairpinNat.enable = true;
+    flowtable.sipFriendly.enable = true;
     trustedUdpPorts = [ ];
     extraLanLocalRules = ''
       tcp dport 5201 accept comment "iperf3 from LAN"


### PR DESCRIPTION
## **User description**
## Summary
- bump `nix-router-optimized` to the merged SIP-friendly flowtable support
- enable `services.router-firewall.flowtable.sipFriendly.enable = true` in the shared router role
- apply the safer VoIP preset to both `router` and `router-backup`

## Validation
- `nix build --no-link /tmp/unified-nix-router-sip-friendly#nixosConfigurations.router.config.system.build.toplevel`
- `nix build --no-link /tmp/unified-nix-router-sip-friendly#nixosConfigurations.router-backup.config.system.build.toplevel`

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated the nix-router-optimized flake input to a newer revision.</li>
<li>Enabled flowtable SIP-friendly support in the router configuration.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Enable a SIP-friendly firewall flowtable preset on the router**

### What Changed
- The shared router setup now uses a SIP-friendly firewall flowtable preset
- This applies to the router role so VoIP traffic is handled with safer firewall behavior

### Impact
`✅ Fewer VoIP call drops`
`✅ More reliable SIP traffic through the router`
`✅ Safer router firewall defaults for phone services`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
