### PR TITLE
fix(router): harden standby and kea startup

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -82,10 +82,11 @@ den/inventory/hosts.nix          ← entry point
 | NAT policy | `hosts/nixos/router/service-capability.nix` | `networking.nat.enable = false`; nftables handles NAT in role.nix |
 | Disk layout (router) | `hosts/nixos/router/disko.nix` | Hardware-adjacent; keep separate |
 | Disk layout (backup) | `hosts/nixos/router-backup/disko.nix` | Imported by `configuration.nix`; hardware-adjacent, keep separate |
-| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly; public ingress works with VRRP/WAN ownership and DDNS execution now follows HA-owned `inadyn` units rather than a static `activeOwner` toggle |
+| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly. Public ingress is currently primary-only because `router-backup` has no attached WAN NIC, even though DDNS execution follows HA-owned `inadyn` units rather than a static `activeOwner` toggle |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
 | Runtime single-owner LAN services | `hosts/nixos/router/role.nix` via `services.router-ha.singleActiveUnits` and `/run/router-ha/role` | The promoted node owns DDNS, DHCP, UPnP, and IPv6 RA runtime units; Chrony remains shared |
+| WAN failover participation | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` via `enableWanHa` | `router` keeps WAN HA enabled; `router-backup` currently disables it because there is no real standby WAN interface attached |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -114,11 +115,14 @@ den/inventory/hosts.nix          ← entry point
 The currently validated consumer failover split is:
 
 - **VRRP / Keepalived owned**
-  - LAN VIP and WAN ownership through `services.router-ha`
+  - LAN VIP ownership through `services.router-ha`
   - DDNS execution through `services.router-ha.singleActiveUnits`, currently
     using `inadyn.service` in this consumer tree
   - DHCP, UPnP, and IPv6 RA runtime ownership through the same
     `singleActiveUnits` boundary
+- **Primary-only today**
+  - public WAN ownership and public ingress, because `router-backup` does not
+    currently have a real WAN NIC and therefore sets `enableWanHa = false`
 - **Shared on both nodes**
   - `services.router-ntp.enable = true` so Chrony stays available on the backup
   - Suricata and EveBox, which remain useful on standby without claiming
@@ -127,7 +131,17 @@ The currently validated consumer failover split is:
 This is the working reference shape today. It is still narrower than
 "every important service follows VRRP automatically" because Chrony and other
 shared observability services remain intentionally outside the single-owner
-boundary.
+boundary, and WAN/public-ingress failover is deferred until the backup regains
+real WAN hardware.
+
+## Current HA Stage
+
+The safest current interpretation of this pair is:
+
+1. `router-backup` is a meaningful LAN-side standby and test target.
+2. `router-backup` is not yet a full public-ingress substitute for `router`.
+3. WAN/public-ingress failover should be re-enabled only after the backup has a
+   real WAN NIC again and that path is validated separately.
 
 ## Current `activeOwner` Consumers
 

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -15,10 +15,11 @@ in a shared VRRP-based router identity.
 - the shared LAN VIP is `10.10.10.1/16`
 - `router` and `router-backup` each also keep their own stable node address on
   the LAN
-- VRRP/Keepalived decides which node currently owns the VIP and WAN-side active
-  role
+- VRRP/Keepalived decides which node currently owns the LAN VIP
 - both nodes can stay cabled to the production LAN when the HA pair is healthy;
   the safety rule is that only one node should own the active role at a time
+- public WAN/public-ingress failover is currently primary-only because
+  `router-backup` does not have a real WAN NIC attached
 
 ## Promotion
 
@@ -26,12 +27,13 @@ To recover with `router-backup` after a failure or bad rebuild:
 
 1. Confirm `router` is out of service or should no longer be the active node.
 2. Verify `router-backup` still has management reachability.
-3. Confirm VRRP/WAN ownership, not just service state:
+3. Confirm VRRP role, not just service state:
    - `/run/router-ha/role`
    - `systemctl status keepalived`
 4. Verify the production identity is present on the promoted node:
    - the LAN VIP answers
-   - WAN ownership and public ingress behave as expected
+   - if the backup node has no WAN NIC, expect LAN recovery only rather than
+     public-ingress failover
 5. Verify client-facing services that are supposed to move or remain shared.
 
 ### Current config note
@@ -51,8 +53,12 @@ To recover with `router-backup` after a failure or bad rebuild:
   emits IPv6 RAs without needing a separate static owner flag.
 - `services.router-ntp.enable = true` on both nodes. Chrony is intentionally
   shared rather than single-owner in the current deployment.
+- `router-backup` currently has no attached WAN device, so `enableWanHa = false`
+  there. That keeps LAN-side standby behavior available without letting
+  Keepalived or HA hooks manipulate a nonexistent `ens27`.
 - This means the current failover split is:
-  - VRRP/WAN/DDNS/DHCP/UPnP/IPv6 RA: promotion-aware
+  - LAN VIP/DDNS/DHCP/UPnP/IPv6 RA: promotion-aware
+  - public WAN/public ingress: primary-only until the backup regains a real WAN NIC
   - Chrony and some observability: shared on both nodes
 
 ## Technitium

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -18,6 +18,7 @@ in
       inherit inputs;
       sshTarget = "ssh router-backup";
       wanDevice = "ens27";
+      enableWanHa = false;
       lanDevice = "ens19";
       # Keep the standby LAN identity local to this host definition. Inventory
       # intentionally does not advertise a production IP for router-backup.
@@ -108,10 +109,9 @@ in
   # Current Proxmox wiring:
   #   ens18 -> management virtio
   #   ens19 -> LAN virtio
-  #   ens27 -> WAN passthrough
   #
-  # Keep the host leaf aligned to the actual slot names instead of carrying
-  # old passthrough-era renames for NICs that no longer exist.
+  # There is currently no standby WAN device on this VM, so public-ingress
+  # failover stays disabled here until a real WAN NIC is attached again.
 
   home-manager.extraSpecialArgs.hostName = lib.mkForce "router-backup";
 

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -21,6 +21,7 @@ in
       inherit inputs;
       sshTarget = "ssh router";
       wanDevice = "enp6s17";
+      enableWanHa = true;
       lanDevice = "enp6s16";
       inherit lanIpv4Address managementIpv4Address;
       grafanaDomain = mkFqdn "grafana";

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -61,9 +61,9 @@ let
 
     iface=${lib.escapeShellArg lanDevice}
     expected_ipv4=${lib.escapeShellArg staticLanIp}
-    deadline=$(( $(date +%s) + 30 ))
+    SECONDS=0
 
-    while [ "$(date +%s)" -lt "$deadline" ]; do
+    while [ "$SECONDS" -lt 30 ]; do
       if ${pkgs.iproute2}/bin/ip -o link show dev "$iface" 2>/dev/null | ${pkgs.gnugrep}/bin/grep -q "LOWER_UP" \
         && ${pkgs.iproute2}/bin/ip -o -4 addr show dev "$iface" 2>/dev/null | ${pkgs.gnugrep}/bin/grep -q " $expected_ipv4/"; then
         exit 0
@@ -116,7 +116,7 @@ let
       "miniupnpd.service"
       "router-ipv6-ra-owner.service"
     ]
-    ++ lib.optional (config.systemd.timers ? inadyn) "inadyn.timer";
+    ++ lib.optional (config.services.router-ddns.enable or false) "inadyn.timer";
   ipv6RaOwnerDropInDir = "/run/systemd/network/08-router-parent-${lanDevice}.network.d";
   ipv6RaOwnerDropIn = "${ipv6RaOwnerDropInDir}/90-router-ha-ra.conf";
   enableIpv6RaOwner = pkgs.writeShellScript "router-ipv6-ra-owner-enable" ''

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -10,6 +10,7 @@
   prometheusBindMountPath,
   enableExtraRoutedNetworks ? false,
   enableLogStorage ? true,
+  enableWanHa ? true,
   inputs,
 }:
 {
@@ -55,6 +56,24 @@ let
       chmod 0640 "$lease_file"
     done
   '';
+  waitForKeaLanReady = pkgs.writeShellScript "router-kea-wait-for-lan-ready" ''
+    set -euo pipefail
+
+    iface=${lib.escapeShellArg lanDevice}
+    expected_ipv4=${lib.escapeShellArg staticLanIp}
+    deadline=$(( $(date +%s) + 30 ))
+
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+      if ${pkgs.iproute2}/bin/ip -o link show dev "$iface" 2>/dev/null | ${pkgs.gnugrep}/bin/grep -q "LOWER_UP" \
+        && ${pkgs.iproute2}/bin/ip -o -4 addr show dev "$iface" 2>/dev/null | ${pkgs.gnugrep}/bin/grep -q " $expected_ipv4/"; then
+        exit 0
+      fi
+      ${pkgs.coreutils}/bin/sleep 1
+    done
+
+    echo "router-kea: LAN interface $iface was not carrier-up with IPv4 $expected_ipv4 within 30 seconds" >&2
+    exit 1
+  '';
 
   secrets = optSec.mkSecrets {
     cloudflare-api-key = {
@@ -96,7 +115,8 @@ let
       "kea-dhcp-ddns-server.service"
       "miniupnpd.service"
       "router-ipv6-ra-owner.service"
-    ];
+    ]
+    ++ lib.optional (config.systemd.timers ? inadyn) "inadyn.timer";
   ipv6RaOwnerDropInDir = "/run/systemd/network/08-router-parent-${lanDevice}.network.d";
   ipv6RaOwnerDropIn = "${ipv6RaOwnerDropInDir}/90-router-ha-ra.conf";
   enableIpv6RaOwner = pkgs.writeShellScript "router-ipv6-ra-owner-enable" ''
@@ -221,7 +241,7 @@ in
     wan = {
       # Public ingress failover requires WAN ownership to follow VRRP
       # promotion, not just the LAN VIP.
-      enable = true;
+      enable = enableWanHa;
       interface = wanDevice;
       clonedMac = "02:76:c6:01:2a:b0";
     };
@@ -302,7 +322,10 @@ in
 
   systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [
     "+${ensureKeaLeaseState}"
+    "+${waitForKeaLanReady}"
   ];
+  systemd.services.kea-dhcp4-server.wantedBy = lib.mkForce [ ];
+  systemd.services.kea-dhcp-ddns-server.wantedBy = lib.mkForce [ ];
   systemd.services.inadyn = {
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];
@@ -311,9 +334,11 @@ in
       masterExecCondition
     ];
   };
+  systemd.timers.inadyn.wantedBy = lib.mkForce [ ];
   systemd.services.miniupnpd = {
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];
+    wantedBy = lib.mkForce [ ];
     serviceConfig.ExecCondition = lib.mkBefore [
       masterExecCondition
     ];


### PR DESCRIPTION
## **User description**
## Summary
- disable WAN HA on `router-backup` while it has no real WAN NIC attached
- add a Kea LAN-readiness preflight so DHCP does not start before the LAN interface is actually usable
- document the current staged HA model: LAN-side standby first, WAN/public failover later

## Why
- `router-backup` currently has only `ens18` and `ens19`; the old `ens27` WAN HA path was unsafe and contributed to failover instability
- `kea-dhcp4-server` could come up `active` but with no UDP 67 listener if the LAN interface was not ready yet at boot

## Validation
- `nix build --no-link /tmp/unified-nix-router-sip-friendly-deploy#nixosConfigurations.router.config.system.build.toplevel`
- `nix build --no-link /tmp/unified-nix-router-sip-friendly-deploy#nixosConfigurations.router-backup.config.system.build.toplevel`

## Operational note
- This intentionally keeps `router-backup` as a meaningful LAN-side standby/test target without claiming full WAN/public-ingress failover until a real backup WAN NIC is reattached and validated.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Introduced an `enableWanHa` configuration flag to allow disabling WAN failover on nodes without a dedicated WAN NIC.</li>
<li>Disabled WAN failover for `router-backup` in its configuration, while keeping it enabled for `router`.</li>
<li>Added a `waitForKeaLanReady` script to ensure the LAN interface is ready before starting the Kea DHCP server.</li>
<li>Updated Kea DHCP server service to include the new readiness check and adjusted its `wantedBy` configuration.</li>
<li>Updated documentation to clarify that public-ingress failover is currently primary-only until the backup node regains a real WAN NIC.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to control WAN HA behavior for the router role, and explicitly disabled WAN HA for the backup router.
  * Kept LAN-side HA behavior consistent with a shared LAN VIP model.
* **Bug Fixes**
  * Prevented premature DHCP availability by waiting for LAN link readiness and expected IP before starting DHCP services.
* **Documentation**
  * Updated router failover/cutover guides with the current LAN-only standby behavior, verification steps, and clarified that public WAN/public-ingress failover is primary-only until WAN hardware is restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Keep router-backup as LAN standby while delaying WAN failover until real backup hardware is present**

### What Changed
- `router-backup` no longer tries to take over WAN/public ingress when it has no real WAN NIC attached.
- Kea DHCP now waits for the LAN interface to be up and assigned the expected address before starting, so DHCP does not come up too early at boot.
- LAN-side standby services stay tied to the active router role, while DDNS timers and WAN failover behavior are no longer enabled on the backup node.
- The router documentation now states that LAN failover is active, but public WAN failover remains primary-only until the backup gets real WAN hardware again.

### Impact
`✅ Fewer failed WAN failovers`
`✅ Fewer DHCP startups with no LAN listener`
`✅ Clearer standby router behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
