### PR TITLE
fix(router): harden primary boot readiness

### DIFF
--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -38,7 +38,9 @@ in
   host.networking.enableTailscale = lib.mkForce false;
   services.router-tailscale.enable = lib.mkForce false;
 
-  systemd.network.wait-online.enable = lib.mkForce false;
+  # Keep wait-online enabled on the standby so the shared router role's
+  # RequiredForOnline settings actually gate management-plane readiness.
+  systemd.network.wait-online.enable = lib.mkForce true;
 
   systemd.services = {
     health-wan-carrier.enable = lib.mkForce false;

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -22,7 +22,7 @@ let
   waitForPrimaryDnsWarmup = pkgs.writeShellScript "router-caddy-wait-for-primary-dns-warmup" ''
     set -euo pipefail
 
-    for _ in $(seq 1 45); do
+    for _ in {1..45}; do
       if ${pkgs.curl}/bin/curl -fsS http://127.0.0.1:5380/api/dns/status >/dev/null 2>&1 \
         && ${pkgs.glibc.bin}/bin/getent ahostsv4 api.cloudflare.com >/dev/null 2>&1; then
         exit 0

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -23,8 +23,9 @@ let
     set -euo pipefail
 
     for _ in {1..45}; do
-      if ${pkgs.curl}/bin/curl -fsS http://127.0.0.1:5380/api/dns/status >/dev/null 2>&1 \
-        && ${pkgs.glibc.bin}/bin/getent ahostsv4 api.cloudflare.com >/dev/null 2>&1; then
+      if ${pkgs.curl}/bin/curl --max-time 2 -fsS http://127.0.0.1:5380/api/dns/status >/dev/null 2>&1 \
+        && ${pkgs.coreutils}/bin/timeout 2s \
+          ${pkgs.glibc.bin}/bin/getent ahostsv4 api.cloudflare.com >/dev/null 2>&1; then
         exit 0
       fi
       ${pkgs.coreutils}/bin/sleep 1

--- a/hosts/nixos/router/caddy.nix
+++ b/hosts/nixos/router/caddy.nix
@@ -4,6 +4,7 @@ let
   topology = config.router.topology;
   routerHost = topology.routerHost;
   lanNetwork = topology.networks.lan;
+  isPrimaryRouter = config.networking.hostName == "router";
   homeAssistantHost = topology.hosts.homeassistant;
   authentikHost = topology.hosts.authentik-host;
   podmanHost = topology.hosts.podman;
@@ -17,6 +18,20 @@ let
   cfSecret = optSec.mkSecret "cloudflare-api-key" {
     file = ../../../secrets-agenix/cloudflare_ddns_API_token.age;
   };
+
+  waitForPrimaryDnsWarmup = pkgs.writeShellScript "router-caddy-wait-for-primary-dns-warmup" ''
+    set -euo pipefail
+
+    for _ in $(seq 1 45); do
+      if ${pkgs.curl}/bin/curl -fsS http://127.0.0.1:5380/api/dns/status >/dev/null 2>&1 \
+        && ${pkgs.glibc.bin}/bin/getent ahostsv4 api.cloudflare.com >/dev/null 2>&1; then
+        exit 0
+      fi
+      ${pkgs.coreutils}/bin/sleep 1
+    done
+
+    echo "router-caddy: upstream DNS was not ready after 45 seconds; continuing startup" >&2
+  '';
 in
 {
   services.caddy = {
@@ -176,8 +191,14 @@ in
 
   # Ensure Caddy can access the services and prepare its dynamic DNS token
   systemd.services.caddy = {
-    after = [ "network-online.target" ];
-    wants = [ "network-online.target" ];
+    after = [
+      "network-online.target"
+      "technitium-dns-server.service"
+    ];
+    wants = [
+      "network-online.target"
+      "technitium-dns-server.service"
+    ];
     preStart = ''
       install -d -m 0750 -o caddy -g caddy /run/caddy
       ${lib.optionalString cfSecret.exists ''
@@ -193,6 +214,9 @@ in
         : > /run/caddy/caddy.env
         chown caddy:caddy /run/caddy/caddy.env
         chmod 0400 /run/caddy/caddy.env
+      ''}
+      ${lib.optionalString isPrimaryRouter ''
+        ${waitForPrimaryDnsWarmup}
       ''}
     '';
     serviceConfig = {

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -108,6 +108,7 @@ let
   routerHaRoleFile = "/run/router-ha/role";
   masterExecCondition =
     "${pkgs.runtimeShell} -c '[ \"$(cat ${routerHaRoleFile} 2>/dev/null || true)\" = master ]'";
+  wanRequiredForOnline = if enableWanHa then "routable" else "no";
   singleActiveLanUnits =
     [
       "inadyn.service"
@@ -368,7 +369,10 @@ in
 
   services.router-networking = {
     enable = true;
-    wan.device = wanDevice;
+    wan = {
+      device = wanDevice;
+      requiredForOnline = wanRequiredForOnline;
+    };
     routedInterfaces =
       {
         lan = {
@@ -376,7 +380,7 @@ in
           ipv4Address = if config.networking.hostName == "router" then "10.10.10.2/16" else "10.10.10.3/16";
           dns = [ "127.0.0.1" ];
           domains = [ topology.domain ];
-          requiredForOnline = "routable";
+          requiredForOnline = "no";
           extraRoutes = [
             {
               destination = lanNetwork.cidr;
@@ -387,6 +391,7 @@ in
         management = {
           device = managementDevice;
           ipv4Address = managementIpv4Address;
+          requiredForOnline = "carrier";
           prefixDelegationMode = "managed";
         };
       }
@@ -693,18 +698,12 @@ in
   # intentionally unplugged on a standby/dev router. That allows dashboard and
   # router-role services to come up in a degraded-but-testable state.
   systemd.network.networks."20-router-lan".networkConfig.ConfigureWithoutCarrier = true;
+  systemd.network.networks."20-router-lan".linkConfig.RequiredForOnline = lib.mkForce "no";
 
-  # Do not block network-online.target on the data-plane LAN NIC.
-  #
-  # caddy and router-dashboard wait on network-online.target. With the default
-  # anyInterface = false, systemd-networkd-wait-online waits for ALL required
-  # interfaces — including LAN (RequiredForOnline = routable). Without carrier,
-  # LAN cannot reach "routable", so caddy/dashboard appear stuck in activating
-  # even though the management plane is fully usable.
-  #
-  # anyInterface = true: exit as soon as any one managed interface (management
-  # always has carrier) reaches its required state.
-  systemd.network.wait-online.anyInterface = true;
+  # Make network-online.target wait for the interfaces that matter on each
+  # node. The primary should wait for WAN before WAN-dependent services start,
+  # while the WAN-less backup should only wait for the management plane.
+  systemd.network.wait-online.anyInterface = lib.mkForce false;
 
   boot.loader.grub.enable = false;
   boot.loader.limine.enable = true;
@@ -946,7 +945,7 @@ in
       IPv6PrivacyExtensions = "no";
       IPv6SendRA = false;
     };
-    linkConfig.RequiredForOnline = lib.mkForce "routable";
+    linkConfig.RequiredForOnline = lib.mkForce "no";
     ipv6SendRAConfig = {
       EmitDNS = true;
       Managed = false;


### PR DESCRIPTION
## **User description**
## Summary
- make router network-online wait for management plus the interfaces that matter on each node
- stop LAN parent/router LAN files from gating online state on the router pair
- make primary caddy wait briefly for local Technitium and working upstream DNS before Cloudflare/ACME work

## Validation
- nix build --no-link /tmp/unified-nix-router-primary-boot-readiness#nixosConfigurations.router.config.system.build.toplevel
- nix build --no-link /tmp/unified-nix-router-primary-boot-readiness#nixosConfigurations.router-backup.config.system.build.toplevel
- nixos-rebuild test --flake /tmp/unified-nix-router-primary-boot-readiness#router-backup --target-host root@192.168.100.99 --option use-cgroups false
- nixos-rebuild switch --flake /tmp/unified-nix-router-primary-boot-readiness#router-backup --target-host root@192.168.100.99 --option use-cgroups false

## Context
This addresses the boot-time outage path where generation 93 could leave Kea running without binding LAN DHCP, while Caddy started WAN-dependent DNS/TLS work before upstream DNS was actually usable on the primary.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a pre-start script to Caddy to wait for Technitium DNS server readiness on the primary router.</li>
<li>Updated Caddy systemd service to depend on technitium-dns-server.service.</li>
<li>Configured WAN interface to conditionally require 'routable' status for online state based on HA settings.</li>
<li>Adjusted LAN interface 'requiredForOnline' setting to 'no' and added 'carrier' requirement for the management interface.</li>
</ul></div>


___

## **CodeAnt-AI Description**
**Make router startup wait on the right network and DNS readiness**

### What Changed
- The primary router now waits for local DNS to be ready and for upstream Cloudflare DNS to respond before Caddy starts, reducing failed startup attempts for DNS/TLS features.
- Network readiness now follows the active router role: the primary waits for WAN-dependent services, while the backup only waits for the management network.
- LAN and standby router paths no longer block `network-online.target`, so router services can come up when the management side is available even if the data-plane link is unplugged.

### Impact
`✅ Fewer router boot failures`
`✅ Faster recovery after reboot`
`✅ Clearer service startup on primary and backup routers`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved router startup behavior by waiting for DNS readiness on the primary router before continuing.
  * Refined network online detection so primary and backup routers use more appropriate readiness checks.

* **Bug Fixes**
  * Reduced false “offline” states for LAN and management connectivity during failover or standby scenarios.
  * Made router services more resilient when WAN connectivity is unavailable on non-primary nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->