### PR TITLE
fix(router): disable WAN HA on primary

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -82,11 +82,11 @@ den/inventory/hosts.nix          ← entry point
 | NAT policy | `hosts/nixos/router/service-capability.nix` | `networking.nat.enable = false`; nftables handles NAT in role.nix |
 | Disk layout (router) | `hosts/nixos/router/disko.nix` | Hardware-adjacent; keep separate |
 | Disk layout (backup) | `hosts/nixos/router-backup/disko.nix` | Imported by `configuration.nix`; hardware-adjacent, keep separate |
-| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly. Public ingress is currently primary-only because `router-backup` has no attached WAN NIC, even though DDNS execution follows HA-owned `inadyn` units rather than a static `activeOwner` toggle |
+| Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly. Public ingress is currently pinned to the primary because WAN HA is disabled on both nodes until `router-backup` regains a real WAN NIC and that path is revalidated |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
 | Runtime single-owner LAN services | `hosts/nixos/router/role.nix` via `services.router-ha.singleActiveUnits` and `/run/router-ha/role` | The promoted node owns DDNS, DHCP, UPnP, and IPv6 RA runtime units; Chrony remains shared |
-| WAN failover participation | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` via `enableWanHa` | `router` keeps WAN HA enabled; `router-backup` currently disables it because there is no real standby WAN interface attached |
+| WAN failover participation | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` via `enableWanHa` | Both nodes currently disable WAN HA. This keeps WAN locally managed on the primary and avoids HA-triggered WAN/networkd churn until the backup has a real standby WAN interface again |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -121,8 +121,9 @@ The currently validated consumer failover split is:
   - DHCP, UPnP, and IPv6 RA runtime ownership through the same
     `singleActiveUnits` boundary
 - **Primary-only today**
-  - public WAN ownership and public ingress, because `router-backup` does not
-    currently have a real WAN NIC and therefore sets `enableWanHa = false`
+  - public WAN ownership and public ingress, because WAN HA is disabled on both
+    nodes until `router-backup` has a real WAN NIC and that failover path is
+    revalidated
 - **Shared on both nodes**
   - `services.router-ntp.enable = true` so Chrony stays available on the backup
   - Suricata and EveBox, which remain useful on standby without claiming

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -18,8 +18,9 @@ in a shared VRRP-based router identity.
 - VRRP/Keepalived decides which node currently owns the LAN VIP
 - both nodes can stay cabled to the production LAN when the HA pair is healthy;
   the safety rule is that only one node should own the active role at a time
-- public WAN/public-ingress failover is currently primary-only because
-  `router-backup` does not have a real WAN NIC attached
+- public WAN/public-ingress failover is currently disabled in HA config. WAN
+  stays locally managed on `router` until `router-backup` has a real WAN NIC
+  and the failover path is validated separately
 
 ## Promotion
 
@@ -32,8 +33,8 @@ To recover with `router-backup` after a failure or bad rebuild:
    - `systemctl status keepalived`
 4. Verify the production identity is present on the promoted node:
    - the LAN VIP answers
-   - if the backup node has no WAN NIC, expect LAN recovery only rather than
-     public-ingress failover
+   - expect LAN recovery only; WAN/public-ingress failover is intentionally out
+     of scope in the current stage
 5. Verify client-facing services that are supposed to move or remain shared.
 
 ### Current config note
@@ -53,12 +54,13 @@ To recover with `router-backup` after a failure or bad rebuild:
   emits IPv6 RAs without needing a separate static owner flag.
 - `services.router-ntp.enable = true` on both nodes. Chrony is intentionally
   shared rather than single-owner in the current deployment.
-- `router-backup` currently has no attached WAN device, so `enableWanHa = false`
-  there. That keeps LAN-side standby behavior available without letting
-  Keepalived or HA hooks manipulate a nonexistent `ens27`.
+- WAN HA is currently disabled on both nodes. `router-backup` has no attached
+  standby WAN device, and the current router-ha WAN hooks are too disruptive on
+  the primary because they restart `systemd-networkd` during promotion.
 - This means the current failover split is:
   - LAN VIP/DDNS/DHCP/UPnP/IPv6 RA: promotion-aware
-  - public WAN/public ingress: primary-only until the backup regains a real WAN NIC
+  - public WAN/public ingress: primary-owned but not HA-promoted until the
+    backup regains a real WAN NIC
   - Chrony and some observability: shared on both nodes
 
 ## Technitium
@@ -90,7 +92,7 @@ Use Technitium clustering only for DNS/admin-state sync between `router` and
 - DHCP scope replication
 - DHCP lease-state failover
 - automatic DHCP ownership transfer
-- WAN ownership beyond what VRRP/Keepalived is already configured to do
+- WAN ownership beyond the current primary-local boundary
 
 ### Standby Checklist
 

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -19,6 +19,7 @@ in
       sshTarget = "ssh router-backup";
       wanDevice = "ens27";
       enableWanHa = false;
+      requireWanOnline = false;
       lanDevice = "ens19";
       # Keep the standby LAN identity local to this host definition. Inventory
       # intentionally does not advertise a production IP for router-backup.

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -25,6 +25,9 @@ in
       # The current router-ha WAN hooks restart systemd-networkd on promotion,
       # which is too disruptive on the live primary.
       enableWanHa = false;
+      # Even with WAN HA disabled, the primary should still wait for the WAN to
+      # be routable before WAN-dependent services start during boot.
+      requireWanOnline = true;
       lanDevice = "enp6s16";
       inherit lanIpv4Address managementIpv4Address;
       grafanaDomain = mkFqdn "grafana";

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -21,7 +21,10 @@ in
       inherit inputs;
       sshTarget = "ssh router";
       wanDevice = "enp6s17";
-      enableWanHa = true;
+      # Keep WAN locally managed until router-backup regains a real WAN NIC.
+      # The current router-ha WAN hooks restart systemd-networkd on promotion,
+      # which is too disruptive on the live primary.
+      enableWanHa = false;
       lanDevice = "enp6s16";
       inherit lanIpv4Address managementIpv4Address;
       grafanaDomain = mkFqdn "grafana";

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -11,6 +11,7 @@
   enableExtraRoutedNetworks ? false,
   enableLogStorage ? true,
   enableWanHa ? true,
+  requireWanOnline ? enableWanHa,
   inputs,
 }:
 {
@@ -108,7 +109,7 @@ let
   routerHaRoleFile = "/run/router-ha/role";
   masterExecCondition =
     "${pkgs.runtimeShell} -c '[ \"$(cat ${routerHaRoleFile} 2>/dev/null || true)\" = master ]'";
-  wanRequiredForOnline = if enableWanHa then "routable" else "no";
+  wanRequiredForOnline = if requireWanOnline then "routable" else "no";
   singleActiveLanUnits =
     [
       "inadyn.service"


### PR DESCRIPTION
## Summary\n- disable WAN HA on the primary router for now\n- keep WAN locally managed until router-backup regains a real WAN NIC\n- update router failover docs to match the current safety boundary\n\n## Why\nThe current router-ha WAN notify hooks restart systemd-networkd during promotion. On the live primary, that caused WAN churn during boot and broke Internet access. This change keeps the boot-readiness and DHCP fixes, but removes the unsafe WAN HA layer from the current homelab topology.\n\n## Validation\n- nix build --no-link /tmp/unified-nix-main-current#nixosConfigurations.router.config.system.build.toplevel\n- nix build --no-link /tmp/unified-nix-main-current#nixosConfigurations.router-backup.config.system.build.toplevel\n- nixos-rebuild dry-activate --flake /tmp/unified-nix-main-current#router --target-host root@192.168.100.100 --option use-cgroups false\n- nixos-rebuild boot --flake /tmp/unified-nix-main-current#router --target-host root@192.168.100.100 --option use-cgroups false\n

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Disabled WAN High Availability (HA) by setting `enableWanHa = false` in `configuration.nix`.</li>
<li>Updated documentation to reflect that WAN failover is now intentionally disabled on both nodes.</li>
<li>Clarified that WAN failover will remain disabled until the backup router regains a physical WAN NIC and the failover path is revalidated.</li>
<li>Noted that current WAN HA hooks are too disruptive due to `systemd-networkd` restarts during promotion.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified and aligned router failover behavior so public WAN/ingress stays on the primary until the backup router has a real WAN interface.
  * Reduced the risk of disruptive WAN/network restarts during promotion by keeping WAN handling locally managed for now.

* **Documentation**
  * Updated router failover docs to reflect the current HA split more accurately, including which services fail over and which remain primary-owned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->