### PR TITLE
fix(router): simplify primary routing path

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -85,8 +85,8 @@ den/inventory/hosts.nix          ← entry point
 | Caddy / ingress | `hosts/nixos/router/caddy.nix` | Both hosts share this file directly. Public ingress is currently pinned to the primary because WAN HA is disabled on both nodes until `router-backup` regains a real WAN NIC and that path is revalidated |
 | Router role (networking, firewall, DNS, observability, VPN) | `den/aspects/router-router.nix` + upstream `nix-router-optimized` modules | The den aspect selects which upstream modules to import |
 | Host-specific role args (WAN/LAN devices, IPs, Grafana paths) | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` | Each calls `role.nix` as a function with per-host arguments |
-| Runtime single-owner LAN services | `hosts/nixos/router/role.nix` via `services.router-ha.singleActiveUnits` and `/run/router-ha/role` | The promoted node owns DDNS, DHCP, UPnP, and IPv6 RA runtime units; Chrony remains shared |
-| WAN failover participation | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` via `enableWanHa` | Both nodes currently disable WAN HA. This keeps WAN locally managed on the primary and avoids HA-triggered WAN/networkd churn until the backup has a real standby WAN interface again |
+| Runtime LAN service ownership | `hosts/nixos/router/role.nix` via `enableHa` and `ownLanServices` | The current production shape is non-HA: `router` owns DDNS, DHCP, UPnP, and IPv6 RA directly, while `router-backup` keeps those services disabled |
+| WAN failover participation | `hosts/nixos/router/configuration.nix` and `hosts/nixos/router-backup/configuration.nix` via `enableWanHa` | Both nodes currently disable WAN HA. WAN stays locally managed on `router` until the backup has a real standby WAN interface again |
 | NIC stable names | `hosts/nixos/router/configuration.nix` (MAC-based) and `hosts/nixos/router-backup/configuration.nix` (PCI path-based) | Separate rules because the two machines use different matching strategies |
 | DNS zone data (static hosts, aliases) | `hosts/nixos/router/dns-zone.nix` | Inline-imported by `configuration.nix`; edit here to manage DNS records |
 | ulogd flow logging | `hosts/nixos/router/role.nix` (via nix-router-optimized) | Uses LOGEMU plugin (base `pkgs.ulogd`); JSON plugin requires overlay — not active by default |
@@ -110,45 +110,46 @@ den/inventory/hosts.nix          ← entry point
   it in both `router` and `router-backup` `aspectsList` entries in
   `den/inventory/hosts.nix`.
 
-## Current Consumer Failover Shape
+## Current Consumer Shape
 
-The currently validated consumer failover split is:
+The currently validated consumer shape is intentionally simpler than active HA:
 
-- **VRRP / Keepalived owned**
-  - LAN VIP ownership through `services.router-ha`
-  - DDNS execution through `services.router-ha.singleActiveUnits`, currently
-    using `inadyn.service` in this consumer tree
-  - DHCP, UPnP, and IPv6 RA runtime ownership through the same
-    `singleActiveUnits` boundary
-- **Primary-only today**
+- **Primary-owned today**
+  - LAN gateway identity and client-path services on `router`
+  - DDNS, DHCP, UPnP, and IPv6 RA, all owned directly by `router`
   - public WAN ownership and public ingress, because WAN HA is disabled on both
     nodes until `router-backup` has a real WAN NIC and that failover path is
     revalidated
+- **Cold/manual spare today**
+  - `router-backup` keeps the management plane, observability, and standby
+    tooling available
+  - `router-backup` keeps DDNS, DHCP, UPnP, and IPv6 RA disabled so it does not
+    race the production router during boot or recovery
 - **Shared on both nodes**
   - `services.router-ntp.enable = true` so Chrony stays available on the backup
   - Suricata and EveBox, which remain useful on standby without claiming
     single-owner semantics
 
-This is the working reference shape today. It is still narrower than
-"every important service follows VRRP automatically" because Chrony and other
-shared observability services remain intentionally outside the single-owner
-boundary, and WAN/public-ingress failover is deferred until the backup regains
-real WAN hardware.
+This is the working reference shape today. VRRP/Keepalived is no longer part of
+the live production path, because the current HA hooks are still too disruptive
+for safe primary reboots.
 
-## Current HA Stage
+## Current Recovery Stage
 
 The safest current interpretation of this pair is:
 
-1. `router-backup` is a meaningful LAN-side standby and test target.
-2. `router-backup` is not yet a full public-ingress substitute for `router`.
+1. `router` is the only active production router.
+2. `router-backup` is a cold/manual spare and test target, not an automatic
+   failover peer.
 3. WAN/public-ingress failover should be re-enabled only after the backup has a
-   real WAN NIC again and that path is validated separately.
+   real WAN NIC again and the whole promotion path is revalidated separately.
 
 ## Current `activeOwner` Consumers
 
 `router.failover.activeOwner` is now a legacy static hint, not the live
-ownership switch for DDNS, DHCP, UPnP, or IPv6 RA. Those services follow the
-runtime HA role file and `services.router-ha.singleActiveUnits` instead.
+ownership switch for DDNS, DHCP, UPnP, or IPv6 RA. In the current production
+shape those services are simply enabled on `router` and disabled on
+`router-backup`.
 
 If future consumer code still uses `activeOwner`, that should be treated as an
 explicit compatibility choice rather than the default HA mechanism.

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -1,7 +1,8 @@
 # Router Spare Cutover
 
-`router` and `router-backup` are separate management nodes that now participate
-in a shared VRRP-based router identity.
+`router` and `router-backup` are separate management nodes. The current
+production shape is intentionally non-HA: `router` is the only active router,
+and `router-backup` is a cold/manual spare.
 
 ## Management
 
@@ -12,12 +13,9 @@ in a shared VRRP-based router identity.
 
 ## Production Identity
 
-- the shared LAN VIP is `10.10.10.1/16`
-- `router` and `router-backup` each also keep their own stable node address on
-  the LAN
-- VRRP/Keepalived decides which node currently owns the LAN VIP
-- both nodes can stay cabled to the production LAN when the HA pair is healthy;
-  the safety rule is that only one node should own the active role at a time
+- `router` owns the production LAN identity `10.10.10.1/16`
+- `router-backup` keeps its own local standby LAN address for lab work, but it
+  does not claim the production router identity automatically
 - public WAN/public-ingress failover is currently disabled in HA config. WAN
   stays locally managed on `router` until `router-backup` has a real WAN NIC
   and the failover path is validated separately
@@ -28,40 +26,35 @@ To recover with `router-backup` after a failure or bad rebuild:
 
 1. Confirm `router` is out of service or should no longer be the active node.
 2. Verify `router-backup` still has management reachability.
-3. Confirm VRRP role, not just service state:
-   - `/run/router-ha/role`
-   - `systemctl status keepalived`
-4. Verify the production identity is present on the promoted node:
-   - the LAN VIP answers
-   - expect LAN recovery only; WAN/public-ingress failover is intentionally out
-     of scope in the current stage
-5. Verify client-facing services that are supposed to move or remain shared.
+3. Promote it manually only after checking which client-path services you intend
+   to bring up there.
+4. Verify the production LAN identity is present on the replacement node before
+   expecting clients to recover.
+5. Expect LAN recovery only; WAN/public-ingress failover is intentionally out
+   of scope in the current stage.
 
 ### Current config note
 
 - `router.failover.activeOwner` is now only a legacy static hint for the
   preferred node, not the live service-promotion switch.
-- DDNS execution no longer hangs off `activeOwner` directly. The current
-  consumer tree hands `inadyn.service` to
-  `services.router-ha.singleActiveUnits`, so DDNS follows VRRP promotion via
-  the active node without depending on a separate systemd timer unit.
-- The same runtime HA boundary now owns:
+- The current production tree does not use VRRP-owned runtime LAN services.
+- `router` owns:
+  - `inadyn.service`
   - `kea-dhcp4-server.service`
   - `kea-dhcp-ddns-server.service`
   - `miniupnpd.service`
-  - `router-ipv6-ra-owner.service`
-  so the promoted node answers LAN DHCP, advertises UPnP/NAT-PMP mappings, and
-  emits IPv6 RAs without needing a separate static owner flag.
+  - IPv6 RA emission on the production LAN
+- `router-backup` keeps those services disabled until a deliberate recovery or
+  later HA redesign reintroduces them safely.
 - `services.router-ntp.enable = true` on both nodes. Chrony is intentionally
   shared rather than single-owner in the current deployment.
 - WAN HA is currently disabled on both nodes. `router-backup` has no attached
   standby WAN device, and the current router-ha WAN hooks are too disruptive on
   the primary because they restart `systemd-networkd` during promotion.
-- This means the current failover split is:
-  - LAN VIP/DDNS/DHCP/UPnP/IPv6 RA: promotion-aware
-  - public WAN/public ingress: primary-owned but not HA-promoted until the
-    backup regains a real WAN NIC
+- This means the current split is:
+  - client-path LAN services and public ingress: primary-owned
   - Chrony and some observability: shared on both nodes
+  - backup promotion: manual, not automatic
 
 ## Technitium
 
@@ -101,13 +94,13 @@ After enabling clustering, still verify the standby router manually:
 - Technitium on `router-backup` shows healthy cluster sync
 - the `LAN` DHCP scope exists on `router-backup`
 - the dynamic pool matches the intended standby settings
-- only the active router is connected to production WAN/LAN
+- only the active router is expected to own production client-path services
 
 ## Standby / Dev Router Behavior
 
 When a router is used as a spare or dev box:
 
 - the management IP on the virtio interface stays reachable even with WAN/LAN unplugged
-- the shared production identity is the VRRP VIP plus per-node LAN addresses,
-  not two identical static host addresses
+- the production LAN identity stays on `router` unless you deliberately
+  reassign it during a manual recovery
 - LAN/WAN-dependent checks are expected to show degraded or failed until cables are reattached

--- a/hosts/nixos/router-backup/configuration.nix
+++ b/hosts/nixos/router-backup/configuration.nix
@@ -17,6 +17,8 @@ in
     (import ../router/role.nix {
       inherit inputs;
       sshTarget = "ssh router-backup";
+      enableHa = false;
+      ownLanServices = false;
       wanDevice = "ens27";
       enableWanHa = false;
       requireWanOnline = false;

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -21,6 +21,11 @@ in
       inherit inputs;
       sshTarget = "ssh router";
       wanDevice = "enp6s17";
+      # Active HA is disabled for now. The primary should boot as a plain
+      # router until the spare path is revalidated with real standby WAN
+      # hardware and a simpler promotion story.
+      enableHa = false;
+      ownLanServices = true;
       # Keep WAN locally managed until router-backup regains a real WAN NIC.
       # The current router-ha WAN hooks restart systemd-networkd on promotion,
       # which is too disruptive on the live primary.

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -10,6 +10,8 @@
   prometheusBindMountPath,
   enableExtraRoutedNetworks ? false,
   enableLogStorage ? true,
+  enableHa ? true,
+  ownLanServices ? true,
   enableWanHa ? true,
   requireWanOnline ? enableWanHa,
   inputs,
@@ -230,27 +232,38 @@ in
     };
   };
 
-  services.router-ha = {
-    # Both router nodes participate in VRRP so LAN VIP and WAN ownership can
-    # move together during failover.
-    enable = true;
-    role = if isPrimaryRouter then "master" else "backup";
-    virtualIp = "10.10.10.1/16";
-    vrrpInterface = lanDevice;
-    singleActiveUnits = singleActiveLanUnits;
-    keaSync.enable = isPrimaryRouter;
-    keaSync.peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
-    wan = {
-      # Public ingress failover requires WAN ownership to follow VRRP
-      # promotion, not just the LAN VIP.
-      enable = enableWanHa;
-      interface = wanDevice;
-      clonedMac = "02:76:c6:01:2a:b0";
-    };
-  };
+  services.router-ha =
+    lib.mkIf enableHa
+      {
+        # Both router nodes participate in VRRP so LAN VIP and WAN ownership can
+        # move together during failover.
+        enable = true;
+        role = if isPrimaryRouter then "master" else "backup";
+        virtualIp = "10.10.10.1/16";
+        vrrpInterface = lanDevice;
+        singleActiveUnits = singleActiveLanUnits;
+        keaSync.enable = isPrimaryRouter;
+        keaSync.peerAddress = if isPrimaryRouter then "10.10.11.213" else "10.10.11.1"; # Using management IPs for control plane sync
+        wan = {
+          # Public ingress failover requires WAN ownership to follow VRRP
+          # promotion, not just the LAN VIP.
+          enable = enableWanHa;
+          interface = wanDevice;
+          clonedMac = "02:76:c6:01:2a:b0";
+        };
+      };
+
+  services.router-dns-service.serviceListenAddresses = lib.mkIf (!enableHa) (
+    lib.mkForce [
+      "127.0.0.1"
+      lanListenAddress
+    ]
+  );
 
   services.router-ddns = {
-    enable = true;
+    enable = lib.mkForce ownLanServices;
+  }
+  // lib.optionalAttrs ownLanServices {
     cloudflare = {
       zoneName = topology.domain;
       labels = topology.routerHost.ddnsServices;
@@ -259,13 +272,16 @@ in
   };
 
   services.router-kea = {
-    # Keep Kea defined on both nodes so the unit, user/group, and secret wiring
-    # remain coherent, but gate actual DHCP ownership at service start.
-    enable = true;
+    # In non-HA mode, the primary router owns DHCP directly. The backup keeps
+    # Kea disabled so it remains a cold/manual spare instead of racing the
+    # production router during boot or recovery.
+    enable = lib.mkForce ownLanServices;
+  }
+  // lib.optionalAttrs ownLanServices {
     dhcp4 = {
       interfaces = [ lanDevice ];
       subnet = lanNetwork.cidr;
-      gatewayAddress = "10.10.10.1"; # Use the VIP
+      gatewayAddress = "10.10.10.1";
       dnsServers = [ "10.10.10.1" ];
       poolRanges = [
         {
@@ -309,10 +325,9 @@ in
   };
 
   services.router-upnp = {
-    # Bind miniupnpd to explicit interface names so the generated config does
-    # not fall back to invalid address-based guesses. router-ha owns the
-    # active runtime instance so only the promoted node advertises mappings.
-    enable = true;
+    # In HA mode the promoted node owns miniupnpd at runtime. In the current
+    # simplified consumer mode, only the primary router exposes UPnP/NAT-PMP.
+    enable = lib.mkForce ownLanServices;
     externalInterface = wanDevice;
     internalIPs = [ lanDevice ];
   };
@@ -322,13 +337,31 @@ in
   # continuity rather than a single-owner Chrony model.
   services.router-ntp.enable = true;
 
-  systemd.services.kea-dhcp4-server.serviceConfig.ExecStartPre = lib.mkBefore [
-    "+${ensureKeaLeaseState}"
-    "+${waitForKeaLanReady}"
+  systemd.services.kea-dhcp4-server = lib.mkMerge [
+    (lib.mkIf ownLanServices {
+      serviceConfig.ExecStartPre = lib.mkBefore [
+        "+${ensureKeaLeaseState}"
+        "+${waitForKeaLanReady}"
+      ];
+    })
+    (lib.mkIf enableHa {
+      wantedBy = lib.mkForce [ ];
+      serviceConfig.ExecCondition = lib.mkBefore [
+        masterExecCondition
+      ];
+      after = [ "router-ha-initial-role-state.service" ];
+      requires = [ "router-ha-initial-role-state.service" ];
+    })
   ];
-  systemd.services.kea-dhcp4-server.wantedBy = lib.mkForce [ ];
-  systemd.services.kea-dhcp-ddns-server.wantedBy = lib.mkForce [ ];
-  systemd.services.inadyn = {
+  systemd.services.kea-dhcp-ddns-server = lib.mkIf enableHa {
+    wantedBy = lib.mkForce [ ];
+    serviceConfig.ExecCondition = lib.mkBefore [
+      masterExecCondition
+    ];
+    after = [ "router-ha-initial-role-state.service" ];
+    requires = [ "router-ha-initial-role-state.service" ];
+  };
+  systemd.services.inadyn = lib.mkIf enableHa {
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];
     wantedBy = lib.mkForce [ ];
@@ -336,8 +369,8 @@ in
       masterExecCondition
     ];
   };
-  systemd.timers.inadyn.wantedBy = lib.mkForce [ ];
-  systemd.services.miniupnpd = {
+  systemd.timers.inadyn.wantedBy = lib.mkIf enableHa (lib.mkForce [ ]);
+  systemd.services.miniupnpd = lib.mkIf enableHa {
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];
     wantedBy = lib.mkForce [ ];
@@ -345,7 +378,7 @@ in
       masterExecCondition
     ];
   };
-  systemd.services.router-ipv6-ra-owner = {
+  systemd.services.router-ipv6-ra-owner = lib.mkIf enableHa {
     description = "Apply IPv6 RA ownership to the active router";
     after = [ "router-ha-initial-role-state.service" ];
     requires = [ "router-ha-initial-role-state.service" ];
@@ -357,16 +390,6 @@ in
       ExecStop = [ "+${disableIpv6RaOwner}" ];
     };
   };
-  systemd.services.kea-dhcp4-server.serviceConfig.ExecCondition = lib.mkBefore [
-    masterExecCondition
-  ];
-  systemd.services.kea-dhcp-ddns-server.serviceConfig.ExecCondition = lib.mkBefore [
-    masterExecCondition
-  ];
-  systemd.services.kea-dhcp4-server.after = [ "router-ha-initial-role-state.service" ];
-  systemd.services.kea-dhcp4-server.requires = [ "router-ha-initial-role-state.service" ];
-  systemd.services.kea-dhcp-ddns-server.after = [ "router-ha-initial-role-state.service" ];
-  systemd.services.kea-dhcp-ddns-server.requires = [ "router-ha-initial-role-state.service" ];
 
   services.router-networking = {
     enable = true;
@@ -546,7 +569,7 @@ in
     listenAddresses = [
       "127.0.0.1"
       managementListenAddress
-    ] ++ lib.optionals isPrimaryRouter [ "10.10.10.1" ];
+    ] ++ lib.optionals ownLanServices [ "10.10.10.1" ];
   };
 
   services.router-homelab.sshTarget = sshTarget;
@@ -944,7 +967,7 @@ in
       DNS = [ "127.0.0.1" ];
       Domains = [ topology.domain ];
       IPv6PrivacyExtensions = "no";
-      IPv6SendRA = false;
+      IPv6SendRA = !enableHa && ownLanServices;
     };
     linkConfig.RequiredForOnline = lib.mkForce "no";
     ipv6SendRAConfig = {

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -253,7 +253,7 @@ in
         };
       };
 
-  services.router-dns-service.serviceListenAddresses = lib.mkIf (!enableHa) (
+  services.router-dns-service.serviceListenAddresses = lib.mkIf (!enableHa && ownLanServices) (
     lib.mkForce [
       "127.0.0.1"
       lanListenAddress

--- a/hosts/nixos/router/service-capability.nix
+++ b/hosts/nixos/router/service-capability.nix
@@ -6,7 +6,11 @@
 let
   topology = config.router.topology;
   routerHost = topology.routerHost;
-  haVirtualIpAddress = builtins.head (lib.splitString "/" config.services.router-ha.virtualIp);
+  productionRouterAddress =
+    if config.services.router-ha.enable then
+      builtins.head (lib.splitString "/" config.services.router-ha.virtualIp)
+    else
+      routerHost.ip;
 in
 {
   services.router-dns-service = {
@@ -14,7 +18,7 @@ in
     provider = "technitium";
     serviceListenAddresses = [
       "127.0.0.1"
-      haVirtualIpAddress
+      productionRouterAddress
     ];
     searchDomains = [ topology.domain ];
     # Advertise the router's chrony instance to LAN clients via DHCP option 42.


### PR DESCRIPTION
## Summary
- disable active router HA on both nodes and run router as the sole production router again
- keep client-path LAN services enabled only on router while leaving router-backup as a cold/manual spare
- update consumer docs to describe the current non-HA recovery model

## Validation
- nix build --no-link /tmp/unified-nix-main-current#nixosConfigurations.router.config.system.build.toplevel
- nix build --no-link /tmp/unified-nix-main-current#nixosConfigurations.router-backup.config.system.build.toplevel
- nix eval /tmp/unified-nix-main-current#nixosConfigurations.router.config.services.router-ha.enable
- nix eval /tmp/unified-nix-main-current#nixosConfigurations.router-backup.config.services.router-ha.enable
- nix eval /tmp/unified-nix-main-current#nixosConfigurations.router.config.services.router-kea.enable
- nix eval /tmp/unified-nix-main-current#nixosConfigurations.router-backup.config.services.router-kea.enable

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Disabled active VRRP-based High Availability (HA) for the router pair, transitioning to a primary/cold-spare model.</li>
<li>Updated router configuration to explicitly set 'enableHa = false' and 'ownLanServices' flags for both primary and backup nodes.</li>
<li>Modified 'role.nix' to gate 'services.router-ha' behind the 'enableHa' flag and force-disable LAN services (DDNS, DHCP, UPnP, IPv6 RA) on the backup node.</li>
<li>Updated documentation to reflect the shift from automatic failover to manual recovery procedures.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the router HA/failover and recovery documentation to reflect the validated non-HA production posture and manual promotion approach.
  * Clarified the “cold/manual spare” behavior, including which node owns the production LAN identity and how router-backup should be treated.

* **New Features**
  * Added explicit HA and LAN-ownership controls that adjust router behavior in production vs spare/dev scenarios.

* **Bug Fixes**
  * Improved LAN-facing service ownership consistency (DDNS/DHCP/UPnP/IPv6 RA) and tightened DNS listen address selection for the active router.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->