### PR TITLE
fix(router): support cold-spare activation path

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -98,8 +98,8 @@ den/inventory/hosts.nix          ← entry point
 
 - **DNS / NTP shared capability**: `hosts/nixos/router/service-capability.nix`.
 - **Primary hostname / domain defaults**: `hosts/nixos/router/networking.nix`.
-- **Runtime single-owner LAN services**: `hosts/nixos/router/role.nix` via
-  `services.router-ha.singleActiveUnits` and `/run/router-ha/role`.
+- **Runtime LAN service ownership**: `hosts/nixos/router/role.nix` via
+  `enableHa` and `ownLanServices`.
 - **Firewall / NAT / observability / VPN**: tune options provided by
   `nix-router-optimized` modules; the entry point is `den/aspects/router-router.nix`.
 - **Caddy virtualHosts, ACME, DDNS**: `hosts/nixos/router/caddy.nix`.
@@ -143,6 +143,18 @@ The safest current interpretation of this pair is:
    failover peer.
 3. WAN/public-ingress failover should be re-enabled only after the backup has a
    real WAN NIC again and the whole promotion path is revalidated separately.
+
+## Deferred Follow-Up
+
+High availability is now an intentional future follow-up, not an active
+deployment goal. Before revisiting it, the next implementation should assume:
+
+1. the current supported production shape is `router` as the only active
+   router plus `router-backup` as a cold/manual spare
+2. any future HA retry must be validated on the backup first, then staged for
+   reboot-based primary testing instead of live `switch` cutovers
+3. WAN/public-ingress failover should remain out of scope until the backup has
+   real standby WAN hardware again
 
 ## Current `activeOwner` Consumers
 

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -4,6 +4,10 @@
 production shape is intentionally non-HA: `router` is the only active router,
 and `router-backup` is a cold/manual spare.
 
+High availability is intentionally deferred for now. Treat the active HA design
+as future work to revisit only after more pressing router needs are settled and
+the backup has real standby WAN hardware again.
+
 ## Management
 
 - `router` SSHes to the dedicated management interface at `192.168.100.100`
@@ -32,6 +36,18 @@ To recover with `router-backup` after a failure or bad rebuild:
    expecting clients to recover.
 5. Expect LAN recovery only; WAN/public-ingress failover is intentionally out
    of scope in the current stage.
+
+## Deferred HA TODO
+
+When you eventually return to HA work, keep this order:
+
+1. preserve the current single-active-router production model until the new HA
+   slice is fully validated
+2. test any new HA ownership or VRRP logic on `router-backup` first
+3. prefer reboot-based primary validation over live `nixos-rebuild switch`
+   cutovers
+4. do not re-enable WAN/public failover until `router-backup` has a real WAN
+   path again
 
 ### Current config note
 

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -92,11 +92,14 @@ let
       file = ../../../secrets-agenix/technitium-admin-password.age;
       mode = "0400";
     };
-    kea-ddns-tsig-key = {
-      file = ../../../secrets-agenix/kea-ddns-tsig-key.age;
-      mode = "0440";
-      group = "kea";
-    };
+    kea-ddns-tsig-key =
+      {
+        file = ../../../secrets-agenix/kea-ddns-tsig-key.age;
+        mode = "0440";
+      }
+      // lib.optionalAttrs ownLanServices {
+        group = "kea";
+      };
     tailscale-auth-key = {
       file = ../../../secrets-agenix/tailscale-auth-key.age;
     };


### PR DESCRIPTION
## Summary
- allow the backup cold-spare role to activate without requiring the Kea group for the TSIG secret
- remove stale HA ownership wording from the router docs
- explicitly record active HA as a deferred follow-up rather than a live production target

## Validation
- nix build --no-link --print-out-paths /tmp/unified-nix-main-current#nixosConfigurations.router-backup.config.system.build.toplevel
- backup-only manual test activation succeeded on router-backup
- backup-only manual switch succeeded on router-backup
- router-backup now has matching run/profile on /nix/store/8w6zg3bv9pv4ffcsb5zrf47c3rrsw2la-nixos-system-router-backup-26.05.20260611.a037402
- router-backup service state after switch: caddy/technitium/suricata/chronyd active; kea/miniupnpd/inadyn/keepalived inactive; no failed units

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Documented that high availability (HA) is deferred and the current production model is single-router with a cold spare.</li>
<li>Updated documentation to clarify that WAN/public-ingress failover is out of scope until the backup router has dedicated WAN hardware.</li>
<li>Refactored `kea-ddns-tsig-key` secret configuration in `role.nix` to conditionally set the group based on `ownLanServices`.</li>
<li>Updated documentation references for runtime LAN service ownership from `singleActiveUnits` to `enableHa` and `ownLanServices`.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated router guidance to reflect the current recommended place for LAN service ownership and to clarify the latest validation assumptions.
  * Added follow-up notes explaining that high-availability work remains deferred for now.

* **Bug Fixes**
  * Adjusted secret ownership handling so it only applies the expected group when LAN services are enabled, avoiding unnecessary permission changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->