### PR TITLE
fix(router): align non-HA LAN identity with boot readiness

### DIFF
--- a/docs/router-source-of-truth.md
+++ b/docs/router-source-of-truth.md
@@ -127,8 +127,12 @@ The currently validated consumer shape is intentionally simpler than active HA:
     race the production router during boot or recovery
 - **Shared on both nodes**
   - `services.router-ntp.enable = true` so Chrony stays available on the backup
-  - Suricata and EveBox, which remain useful on standby without claiming
-    single-owner semantics
+- **Temporarily disabled in the current simplified mode**
+  - `services.router-network-security`
+  - Suricata / EveBox
+  - These are intentionally out of the active boot path while the primary
+    reboot path is being stabilized. Reintroduce them later as a separate,
+    reboot-tested slice rather than bundling them with router ownership work.
 
 This is the working reference shape today. VRRP/Keepalived is no longer part of
 the live production path, because the current HA hooks are still too disruptive

--- a/docs/router-spare-cutover.md
+++ b/docs/router-spare-cutover.md
@@ -64,6 +64,9 @@ When you eventually return to HA work, keep this order:
   later HA redesign reintroduces them safely.
 - `services.router-ntp.enable = true` on both nodes. Chrony is intentionally
   shared rather than single-owner in the current deployment.
+- `services.router-network-security` is currently disabled on both nodes in the
+  simplified production shape. Suricata/EveBox were removed from the active
+  boot path while primary reboot stability was being restored.
 - WAN HA is currently disabled on both nodes. `router-backup` has no attached
   standby WAN device, and the current router-ha WAN hooks are too disruptive on
   the primary because they restart `systemd-networkd` during promotion.

--- a/hosts/nixos/router/configuration.nix
+++ b/hosts/nixos/router/configuration.nix
@@ -26,6 +26,7 @@ in
       # hardware and a simpler promotion story.
       enableHa = false;
       ownLanServices = true;
+      enableNetworkSecurity = false;
       # Keep WAN locally managed until router-backup regains a real WAN NIC.
       # The current router-ha WAN hooks restart systemd-networkd on promotion,
       # which is too disruptive on the live primary.

--- a/hosts/nixos/router/role.nix
+++ b/hosts/nixos/router/role.nix
@@ -12,6 +12,7 @@
   enableLogStorage ? true,
   enableHa ? true,
   ownLanServices ? true,
+  enableNetworkSecurity ? ownLanServices,
   enableWanHa ? true,
   requireWanOnline ? enableWanHa,
   inputs,
@@ -404,7 +405,13 @@ in
       {
         lan = {
           device = lanDevice;
-          ipv4Address = if config.networking.hostName == "router" then "10.10.10.2/16" else "10.10.10.3/16";
+          ipv4Address =
+            if !enableHa then
+              lanIpv4Address
+            else if config.networking.hostName == "router" then
+              "10.10.10.2/16"
+            else
+              "10.10.10.3/16";
           dns = [ "127.0.0.1" ];
           domains = [ topology.domain ];
           requiredForOnline = "no";
@@ -556,14 +563,11 @@ in
   services.router-observability.enable = true;
 
   services.router-network-security = {
-    enable = true;
-    interfaces = [
-      lanDevice
-      wanDevice
-    ];
+    enable = enableNetworkSecurity;
+    interfaces = [ lanDevice ];
     suricata = {
-      enable = true;
-      evebox.enable = true;
+      enable = enableNetworkSecurity;
+      evebox.enable = enableNetworkSecurity;
     };
   };
 
@@ -606,95 +610,102 @@ in
       "health-wan-ip"
       "ulogd"
       "vector"
+    ] ++ lib.optionals enableNetworkSecurity [
       "suricata"
       "router-evebox"
     ];
-    links = lib.mkForce [
-      {
-        label = "Dashboard";
-        url = "https://${mkFqdn "dashboard"}";
-        icon = "🧭";
-      }
-      {
-        label = "Grafana";
-        url = "https://${mkFqdn "grafana"}";
-        icon = "📈";
-      }
-      {
-        label = "EveBox";
-        url = "https://${mkFqdn "evebox"}";
-        icon = "🔎";
-      }
-      {
-        label = "DNS Admin Mgmt";
-        url = "http://${managementListenAddress}:5380/";
-        icon = "🌍";
-      }
-      {
-        label = "Prometheus Mgmt";
-        url = "http://${managementListenAddress}:9090/";
-        icon = "🎯";
-      }
-      {
-        label = "Netdata Mgmt";
-        url = "http://${managementListenAddress}:19999/";
-        icon = "📊";
-      }
-      {
-        label = "Dashboard Mgmt";
-        url = "http://${managementListenAddress}:8888/";
-        icon = "🧭";
-      }
-      {
-        label = "DNS Admin LAN";
-        url = "http://${lanListenAddress}:5380/";
-        icon = "🌍";
-      }
-      {
-        label = "Prometheus LAN";
-        url = "http://${lanListenAddress}:9090/";
-        icon = "🎯";
-      }
-      {
-        label = "Netdata LAN";
-        url = "http://${lanListenAddress}:19999/";
-        icon = "📊";
-      }
-      {
-        label = "Router SSH";
-        kind = "copy";
-        copyText = "ssh router";
-        icon = "🖥️";
-      }
-      {
-        label = "Backup SSH";
-        kind = "copy";
-        copyText = "ssh router-backup";
-        icon = "🛟";
-      }
-      {
-        label = "Router Mgmt";
-        kind = "copy";
-        copyText = topology.routerHost.sshHostname;
-        icon = "🔧";
-      }
-      {
-        label = "Backup Mgmt";
-        kind = "copy";
-        copyText = topology.backupHost.sshHostname;
-        icon = "🧰";
-      }
-      {
-        label = "Tech Logs";
-        url = "/logs/technitium.html";
-        icon = "📜";
-      }
-      {
-        label = "Fail2ban";
-        url = "/status/fail2ban.html";
-        icon = "🛡️";
-      }
-    ];
+    links = lib.mkForce (
+      [
+        {
+          label = "Dashboard";
+          url = "https://${mkFqdn "dashboard"}";
+          icon = "🧭";
+        }
+        {
+          label = "Grafana";
+          url = "https://${mkFqdn "grafana"}";
+          icon = "📈";
+        }
+      ]
+      ++ lib.optionals enableNetworkSecurity [
+        {
+          label = "EveBox";
+          url = "https://${mkFqdn "evebox"}";
+          icon = "🔎";
+        }
+      ]
+      ++ [
+        {
+          label = "DNS Admin Mgmt";
+          url = "http://${managementListenAddress}:5380/";
+          icon = "🌍";
+        }
+        {
+          label = "Prometheus Mgmt";
+          url = "http://${managementListenAddress}:9090/";
+          icon = "🎯";
+        }
+        {
+          label = "Netdata Mgmt";
+          url = "http://${managementListenAddress}:19999/";
+          icon = "📊";
+        }
+        {
+          label = "Dashboard Mgmt";
+          url = "http://${managementListenAddress}:8888/";
+          icon = "🧭";
+        }
+        {
+          label = "DNS Admin LAN";
+          url = "http://${lanListenAddress}:5380/";
+          icon = "🌍";
+        }
+        {
+          label = "Prometheus LAN";
+          url = "http://${lanListenAddress}:9090/";
+          icon = "🎯";
+        }
+        {
+          label = "Netdata LAN";
+          url = "http://${lanListenAddress}:19999/";
+          icon = "📊";
+        }
+        {
+          label = "Router SSH";
+          kind = "copy";
+          copyText = "ssh router";
+          icon = "🖥️";
+        }
+        {
+          label = "Backup SSH";
+          kind = "copy";
+          copyText = "ssh router-backup";
+          icon = "🛟";
+        }
+        {
+          label = "Router Mgmt";
+          kind = "copy";
+          copyText = topology.routerHost.sshHostname;
+          icon = "🔧";
+        }
+        {
+          label = "Backup Mgmt";
+          kind = "copy";
+          copyText = topology.backupHost.sshHostname;
+          icon = "🧰";
+        }
+        {
+          label = "Tech Logs";
+          url = "/logs/technitium.html";
+          icon = "📜";
+        }
+        {
+          label = "Fail2ban";
+          url = "/status/fail2ban.html";
+          icon = "🛡️";
+        }
+      ]
+    );
   };
 
   services.router-tailscale = {


### PR DESCRIPTION
## Summary
- align the non-HA primary LAN address with the production .1 identity
- disable Suricata/EveBox in the current simplified primary/cold-spare router mode
- keep the dashboard aligned with the simplified router service set

## Validation
- nix build --no-link .#nixosConfigurations.router.config.system.build.toplevel
- nix build --no-link .#nixosConfigurations.router-backup.config.system.build.toplevel
- tested and persisted on router-backup
- staged on router and verified successful reboot into the new closure
- verified DHCP listener, DNS listener, and WAN default route after reboot

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added a configurable 'enableNetworkSecurity' option to the router role, defaulting to the value of 'ownLanServices'.</li>
<li>Refactored LAN IPv4 address assignment to support non-HA configurations using a configurable 'lanIpv4Address'.</li>
<li>Updated 'router-network-security' service to use the new 'enableNetworkSecurity' flag and restricted its interface scope to 'lanDevice'.</li>
<li>Conditionally included 'suricata' and 'router-evebox' services in the system based on the 'enableNetworkSecurity' setting.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable router network-security toggle (defaulted to existing LAN service behavior), controlling whether monitoring/dashboard integrations appear.
  * Updated HA router WAN IP selection for primary vs. backup nodes.

* **Bug Fixes**
  * Restricted network-security monitoring to the LAN interface only.
  * Adjusted dashboard service listings and links to reflect network security being disabled when applicable.

* **Documentation**
  * Updated router documentation to clarify that network security (Suricata/EveBox) is temporarily disabled and should be reintroduced later via a separate, reboot-tested change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->