### PR TITLE
docs(router): note stale DHCP init-reboot pattern

### DIFF
--- a/docs/router-reboot-validation.md
+++ b/docs/router-reboot-validation.md
@@ -122,6 +122,24 @@ If a client fails to get an address, inspect live Kea activity on `router`:
 journalctl -u kea-dhcp4-server --since "10 minutes ago" --no-pager -n 80
 ```
 
+If a specific device keeps failing while other clients are fine, look for a
+repeating `DHCP4_INIT_REBOOT` pattern for that device's MAC address:
+
+```bash
+journalctl -u kea-dhcp4-server --since "10 minutes ago" --no-pager \
+  | rg 'DHCP4_INIT_REBOOT|DHCP4_PACKET_RECEIVED|<mac-address>'
+```
+
+Interpretation:
+
+- repeated `INIT-REBOOT` for an old or wrong address usually means the client
+  is stuck on stale DHCP state
+- if the reservation in this repo and `/etc/kea/dhcp4-server.conf` is correct,
+  treat that as a client-side recovery problem first, not a reason to restart
+  the router again
+- typical recovery is to renew/release the client lease, or power-cycle the
+  affected device if it does not expose DHCP controls
+
 ## What Counts As Failure
 
 Treat the reboot as failed if any of these are true:

--- a/docs/router-reboot-validation.md
+++ b/docs/router-reboot-validation.md
@@ -127,7 +127,8 @@ repeating `DHCP4_INIT_REBOOT` pattern for that device's MAC address:
 
 ```bash
 journalctl -u kea-dhcp4-server --since "10 minutes ago" --no-pager \
-  | rg 'DHCP4_INIT_REBOOT|DHCP4_PACKET_RECEIVED|<mac-address>'
+  | rg -i 'DHCP4_INIT_REBOOT' \
+  | rg -i -- '<actual-mac-address>'
 ```
 
 Interpretation:


### PR DESCRIPTION
## Summary\n- document the stale DHCP INIT-REBOOT failure mode in the router reboot runbook\n- explain how to distinguish a client-side stale lease problem from a router-side DHCP outage\n- record the first recovery actions before restarting the router again\n\n## Testing\n- docs only\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added LAN-side DHCP troubleshooting guidance for clients that repeatedly fail to connect.
  * Included steps for identifying recurring DHCP reboot-init attempts and interpreting related logs for the affected device.
  * Documented client recovery actions to try (e.g., lease renew/release or power-cycle) before restarting the router.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->